### PR TITLE
added test script to run all algorithms; reduced metrics to scalars

### DIFF
--- a/common/plot_utils.py
+++ b/common/plot_utils.py
@@ -25,23 +25,30 @@ def get_stats(metrics, stats: tuple):
     stats is a tuple of strings, each corresponding to a metric of interest in metrics
     '''
     # Get mask for final steps of episodes
-    mask = metrics["returned_episode"]
+    mask = metrics.get("returned_episode", None)
     
     # Initialize output dictionary
     all_stats = {}
     stats = list(stats) # convert to list to correctly iterate if the tuple only has a single element
     for stat_name in stats:
         # Get the metric array
-        metric_data = metrics[stat_name]  # Shape: (..., rollout_length, num_envs)
+        metric_data = metrics[stat_name]  # Shape: (..., rollout_length, num_envs) or (num_seeds, num_updates)
 
-        # Compute means and stds for each seed and update
-        # Use masked operations to only consider final episode steps
-        means = jnp.where(mask, metric_data, 0).sum(axis=(-2, -1)) / mask.sum(axis=(-2, -1))
-        # For std, first compute masked values
-        masked_vals = jnp.where(mask, metric_data, 0)
-        squared_diff = (masked_vals - means[..., None, None]) ** 2
-        variance = jnp.where(mask, squared_diff, 0).sum(axis=(-2, -1)) / mask.sum(axis=(-2, -1))
-        stds = jnp.sqrt(variance)
+        if metric_data.ndim == 2:
+            # Data is already pre-averaged over rollout and envs
+            means = metric_data
+            stds = jnp.zeros_like(metric_data)
+        else:
+            # Compute means and stds for each seed and update
+            # Use masked operations to only consider final episode steps
+            mask_sum = jnp.maximum(1, mask.sum(axis=(-2, -1)))
+            means = jnp.where(mask, metric_data, 0).sum(axis=(-2, -1)) / mask_sum
+            # For std, first compute masked values
+            masked_vals = jnp.where(mask, metric_data, 0)
+            squared_diff = (masked_vals - means[..., None, None]) ** 2
+            variance = jnp.where(mask, squared_diff, 0).sum(axis=(-2, -1)) / mask_sum
+            stds = jnp.sqrt(variance)
+            
         # Stack means and stds
         all_stats[stat_name] = jnp.stack([means, stds], axis=-1)
     

--- a/ego_agent_training/liam_ego.py
+++ b/ego_agent_training/liam_ego.py
@@ -377,15 +377,19 @@ def train_liam_ego_agent(config, env, train_rng,
                 encoder_decoder_train_state = update_state[1]
                 _, loss_terms, avg_grad_norm, encoder_avg_grad_norm, decoder_avg_grad_norm = losses_and_grads
 
-                metric = traj_batch.info
+                def mask_and_mean(x, mask):
+                    return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+                
+                mask = traj_batch.info.get("returned_episode", jnp.ones_like(traj_batch.reward))
+                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch.info)
                 metric["update_steps"] = update_steps
-                metric["actor_loss"] = loss_terms[1]
-                metric["value_loss"] = loss_terms[0]
-                metric["entropy_loss"] = loss_terms[2]
-                metric["reconstruction_loss"] = loss_terms[3]
-                metric["avg_grad_norm"] = avg_grad_norm
-                metric["encoder_avg_grad_norm"] = encoder_avg_grad_norm
-                metric["decoder_avg_grad_norm"] = decoder_avg_grad_norm
+                metric["actor_loss"] = loss_terms[1].mean()
+                metric["value_loss"] = loss_terms[0].mean()
+                metric["entropy_loss"] = loss_terms[2].mean()
+                metric["reconstruction_loss"] = loss_terms[3].mean()
+                metric["avg_grad_norm"] = avg_grad_norm.mean()
+                metric["encoder_avg_grad_norm"] = encoder_avg_grad_norm.mean()
+                metric["decoder_avg_grad_norm"] = decoder_avg_grad_norm.mean()
                 new_runner_state = (train_state, encoder_decoder_train_state, rng, update_steps + 1)
                 return (new_runner_state, metric)
 
@@ -596,14 +600,14 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
     average_ego_rets_per_iter = np.mean(all_ego_returns, axis=(0, 2, 3, 4))
 
     # Process loss metrics - average across ego seeds, partners and minibatches dims
-    # Loss metrics shape should be (n_ego_train_seeds, num_updates, ...)
-    average_ego_value_losses = np.mean(all_ego_value_losses, axis=(0, 2, 3))
-    average_ego_actor_losses = np.mean(all_ego_actor_losses, axis=(0, 2, 3))
-    average_ego_entropy_losses = np.mean(all_ego_entropy_losses, axis=(0, 2, 3))
-    average_ego_reconstruction_losses = np.mean(all_ego_reconstruction_losses, axis=(0, 2, 3))
-    average_ego_grad_norms = np.mean(all_ego_grad_norms, axis=(0, 2, 3))
-    average_ego_encoder_grad_norms = np.mean(all_ego_encoder_grad_norms, axis=(0, 2, 3))
-    average_ego_decoder_grad_norms = np.mean(all_ego_decoder_grad_norms, axis=(0, 2, 3))
+    # Loss metrics shape should be (n_ego_train_seeds, num_updates)
+    average_ego_value_losses = np.mean(all_ego_value_losses, axis=0)
+    average_ego_actor_losses = np.mean(all_ego_actor_losses, axis=0)
+    average_ego_entropy_losses = np.mean(all_ego_entropy_losses, axis=0)
+    average_ego_reconstruction_losses = np.mean(all_ego_reconstruction_losses, axis=0)
+    average_ego_grad_norms = np.mean(all_ego_grad_norms, axis=0)
+    average_ego_encoder_grad_norms = np.mean(all_ego_encoder_grad_norms, axis=0)
+    average_ego_decoder_grad_norms = np.mean(all_ego_decoder_grad_norms, axis=0)
 
     # Log metrics for each update step
     num_updates = len(average_ego_value_losses)

--- a/ego_agent_training/meliba_ego.py
+++ b/ego_agent_training/meliba_ego.py
@@ -388,17 +388,21 @@ def train_meliba_ego_agent(config, env, train_rng,
                 encoder_decoder_train_state = update_state[1]
                 _, loss_terms, avg_grad_norm, encoder_avg_grad_norm, decoder_avg_grad_norm = losses_and_grads
 
-                metric = traj_batch.info
+                def mask_and_mean(x, mask):
+                    return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+                
+                mask = traj_batch.info.get("returned_episode", jnp.ones_like(traj_batch.reward))
+                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch.info)
                 metric["update_steps"] = update_steps
-                metric["actor_loss"] = loss_terms[1]
-                metric["value_loss"] = loss_terms[0]
-                metric["entropy_loss"] = loss_terms[2]
-                metric["kl_divergence_loss"] = loss_terms[3]
-                metric["reconstruction_loss"] = loss_terms[4]
-                metric["elbo_loss"] = loss_terms[5]
-                metric["avg_grad_norm"] = avg_grad_norm
-                metric["encoder_avg_grad_norm"] = encoder_avg_grad_norm
-                metric["decoder_avg_grad_norm"] = decoder_avg_grad_norm
+                metric["actor_loss"] = loss_terms[1].mean()
+                metric["value_loss"] = loss_terms[0].mean()
+                metric["entropy_loss"] = loss_terms[2].mean()
+                metric["kl_divergence_loss"] = loss_terms[3].mean()
+                metric["reconstruction_loss"] = loss_terms[4].mean()
+                metric["elbo_loss"] = loss_terms[5].mean()
+                metric["avg_grad_norm"] = avg_grad_norm.mean()
+                metric["encoder_avg_grad_norm"] = encoder_avg_grad_norm.mean()
+                metric["decoder_avg_grad_norm"] = decoder_avg_grad_norm.mean()
                 new_runner_state = (train_state, encoder_decoder_train_state, rng, update_steps + 1)
                 return (new_runner_state, metric)
 
@@ -611,16 +615,16 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
     average_ego_rets_per_iter = np.mean(all_ego_returns, axis=(0, 2, 3, 4))
 
     # Process loss metrics - average across ego seeds, partners and minibatches dims
-    # Loss metrics shape should be (n_ego_train_seeds, num_updates, ...)
-    average_ego_value_losses = np.mean(all_ego_value_losses, axis=(0, 2, 3))
-    average_ego_actor_losses = np.mean(all_ego_actor_losses, axis=(0, 2, 3))
-    average_ego_entropy_losses = np.mean(all_ego_entropy_losses, axis=(0, 2, 3))
-    average_ego_kl_divergence_losses = np.mean(all_ego_kl_divergence_losses, axis=(0, 2, 3))
-    average_ego_reconstruction_losses = np.mean(all_ego_reconstruction_losses, axis=(0, 2, 3))
-    average_ego_elbo_losses = np.mean(all_ego_elbo_losses, axis=(0, 2, 3))
-    average_ego_grad_norms = np.mean(all_ego_grad_norms, axis=(0, 2, 3))
-    average_ego_encoder_grad_norms = np.mean(all_ego_encoder_grad_norms, axis=(0, 2, 3))
-    average_ego_decoder_grad_norms = np.mean(all_ego_decoder_grad_norms, axis=(0, 2, 3))
+    # Loss metrics shape should be (n_ego_train_seeds, num_updates)
+    average_ego_value_losses = np.mean(all_ego_value_losses, axis=0)
+    average_ego_actor_losses = np.mean(all_ego_actor_losses, axis=0)
+    average_ego_entropy_losses = np.mean(all_ego_entropy_losses, axis=0)
+    average_ego_kl_divergence_losses = np.mean(all_ego_kl_divergence_losses, axis=0)
+    average_ego_reconstruction_losses = np.mean(all_ego_reconstruction_losses, axis=0)
+    average_ego_elbo_losses = np.mean(all_ego_elbo_losses, axis=0)
+    average_ego_grad_norms = np.mean(all_ego_grad_norms, axis=0)
+    average_ego_encoder_grad_norms = np.mean(all_ego_encoder_grad_norms, axis=0)
+    average_ego_decoder_grad_norms = np.mean(all_ego_decoder_grad_norms, axis=0)
 
     # Log metrics for each update step
     num_updates = len(average_ego_value_losses)

--- a/ego_agent_training/ppo_ego.py
+++ b/ego_agent_training/ppo_ego.py
@@ -326,12 +326,16 @@ def train_ppo_ego_agent(config, env, train_rng,
                 train_state = update_state[0]
                 _, loss_terms, avg_grad_norm = losses_and_grads
                 
-                metric = traj_batch.info
+                def mask_and_mean(x, mask):
+                    return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+                
+                mask = traj_batch.info.get("returned_episode", jnp.ones_like(traj_batch.reward))
+                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch.info)
                 metric["update_steps"] = update_steps
-                metric["actor_loss"] = loss_terms[1]
-                metric["value_loss"] = loss_terms[0]
-                metric["entropy_loss"] = loss_terms[2]
-                metric["avg_grad_norm"] = avg_grad_norm
+                metric["actor_loss"] = loss_terms[1].mean()
+                metric["value_loss"] = loss_terms[0].mean()
+                metric["entropy_loss"] = loss_terms[2].mean()
+                metric["avg_grad_norm"] = avg_grad_norm.mean()
                 new_runner_state = (train_state, rng, update_steps + 1)
                 return (new_runner_state, metric)
 
@@ -520,11 +524,11 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
     average_ego_rets_per_iter = np.mean(all_ego_returns, axis=(0, 2, 3, 4))
 
     # Process loss metrics - average across ego seeds, partners and minibatches dims
-    # Loss metrics shape should be (n_ego_train_seeds, num_updates, ...)
-    average_ego_value_losses = np.mean(all_ego_value_losses, axis=(0, 2, 3))
-    average_ego_actor_losses = np.mean(all_ego_actor_losses, axis=(0, 2, 3))
-    average_ego_entropy_losses = np.mean(all_ego_entropy_losses, axis=(0, 2, 3))
-    average_ego_grad_norms = np.mean(all_ego_grad_norms, axis=(0, 2, 3))
+    # Loss metrics shape should be (n_ego_train_seeds, num_updates)
+    average_ego_value_losses = np.mean(all_ego_value_losses, axis=0)
+    average_ego_actor_losses = np.mean(all_ego_actor_losses, axis=0)
+    average_ego_entropy_losses = np.mean(all_ego_entropy_losses, axis=0)
+    average_ego_grad_norms = np.mean(all_ego_grad_norms, axis=0)
 
     # Log metrics for each update step
     num_updates = len(average_ego_value_losses)

--- a/marl/ippo.py
+++ b/marl/ippo.py
@@ -252,7 +252,11 @@ def make_train(config, env, logger, progress_callback=None):
                 _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
             )
             train_state = update_state[0]
-            metric = traj_batch.info
+            def mask_and_mean(x, mask):
+                return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+            
+            mask = traj_batch.info.get("returned_episode", jnp.ones_like(traj_batch.reward))
+            metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch.info)
             metric["update_steps"] = update_steps
             
             def callback(metrics):
@@ -260,7 +264,7 @@ def make_train(config, env, logger, progress_callback=None):
                 if progress_callback is not None:
                     progress_callback()
 
-            # metrics: (ROLLOUT_LENGTH, NUM_ACTORS)
+            # metrics: scalars
             jax.experimental.io_callback(callback, None, metric)
 
             rng = update_state[-1]
@@ -375,19 +379,11 @@ def run_ippo(config, logger):
 def log_metrics_intermediate(train_stats, logger):
     # Log metrics for one update step
     step = int(np.array(train_stats.pop("update_steps")))
-    # remaining values have shape (ROLLOUT_LENGTH, NUM_ACTORS)
-    mask = np.array(train_stats.pop("returned_episode"))  # boolean mask for episode-ending steps
-    num_trajectories = mask.sum()
     
     metric_names = [k for k in train_stats if k != "returned_episode"]
     for stat_name in metric_names:        
-        if num_trajectories > 0:
-            # Only average over timesteps where an episode actually ended, matching get_stats logic
-            metric_sum = np.where(mask, np.array(train_stats[stat_name]), 0).sum()
-            stat_mean = metric_sum / num_trajectories
-        else:
-            stat_mean = 0.0
-        logger.log_item(f"Train/{stat_name}", float(stat_mean), train_step=step, commit=True)
+        stat_mean = float(np.array(train_stats[stat_name]))
+        logger.log_item(f"Train/{stat_name}", stat_mean, train_step=step, commit=True)
     logger.commit()
 
 def log_artifacts(config, out, logger):

--- a/open_ended_training/cole.py
+++ b/open_ended_training/cole.py
@@ -4,18 +4,18 @@ Paper: https://proceedings.mlr.press/v202/li23au.html
 Code: https://github.com/liyang619/COLE-Platform/tree/COLE_training
 
 Suggested debug command:
-python open_ended_training/run.py
-    algorithm=cole/lbf 
-    task=lbf
-    label=test_cole
-    run_heldout_eval=false
-    algorithm.TOTAL_TIMESTEPS_PER_ITERATION=2e5
-    algorithm.PARTNER_POP_SIZE=2
-    algorithm.NUM_SEEDS=1
-    logger.mode=offline
-    logger.log_train_out=false
-    logger.log_eval_out=false
-    local_logger.save_train_out=false
+python open_ended_training/run.py /
+    algorithm=cole/lbf /
+    task=lbf /
+    label=test_cole /
+    run_heldout_eval=false /
+    algorithm.TOTAL_TIMESTEPS_PER_ITERATION=2e5 /
+    algorithm.PARTNER_POP_SIZE=2 /
+    algorithm.NUM_SEEDS=1 /
+    logger.mode=offline /
+    logger.log_train_out=false /
+    logger.log_eval_out=false /
+    local_logger.save_train_out=false /
     local_logger.save_eval_out=false
 """
 from functools import partial
@@ -30,6 +30,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
+
+
 
 from agents.initialize_agents import (
     initialize_s5_agent,
@@ -736,16 +738,20 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                     )
 
                     # Metrics
-                    metric = traj_batch_xp.info
+                    def mask_and_mean(x, mask):
+                        return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+
+                    mask = traj_batch_xp.info.get("returned_episode", jnp.ones_like(traj_batch_xp.reward))
+                    metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_xp.info)
                     metric["update_steps"] = update_steps
-                    metric["value_loss_xp"] = value_loss_xp
-                    metric["value_loss_sp"] = value_loss_sp
+                    metric["value_loss_xp"] = value_loss_xp.mean()
+                    metric["value_loss_sp"] = value_loss_sp.mean()
 
-                    metric["pg_loss_xp"] = pg_loss_xp
-                    metric["pg_loss_sp"] = pg_loss_sp
+                    metric["pg_loss_xp"] = pg_loss_xp.mean()
+                    metric["pg_loss_sp"] = pg_loss_sp.mean()
 
-                    metric["entropy_xp"] = entropy_xp
-                    metric["entropy_sp"] = entropy_sp
+                    metric["entropy_xp"] = entropy_xp.mean()
+                    metric["entropy_sp"] = entropy_sp.mean()
 
                     metric["average_rewards_xp"] = jnp.mean(traj_batch_xp.reward)
                     metric["average_rewards_sp"] = jnp.mean(traj_batch_sp1.reward)
@@ -1088,11 +1094,11 @@ def log_metrics_intermediate(metric, logger):
 
     Metric keys and their shapes (before vmap over seeds collapses them):
       update_steps            : scalar int
-      value_loss_xp/sp        : (UPDATE_EPOCHS, NUM_MINIBATCHES)
-      pg_loss_xp/sp           : (UPDATE_EPOCHS, NUM_MINIBATCHES)
-      entropy_xp/sp           : (UPDATE_EPOCHS, NUM_MINIBATCHES)
-      average_rewards_xp/sp  : scalar float
-      returned_episode_returns: (ROLLOUT_LENGTH, NUM_ENVS)  – from LogWrapper
+      value_loss_xp/sp        : scalar float
+      pg_loss_xp/sp           : scalar float
+      entropy_xp/sp           : scalar float
+      average_rewards_xp/sp   : scalar float
+      returned_episode_returns: scalar float  – masked mean over episode-terminal steps
     """
     metric = dict(metric)  # shallow copy – avoid mutating the original
     step = int(np.array(metric.pop("update_steps")))
@@ -1128,7 +1134,7 @@ def log_final_metrics(config, outs, logger, metric_names: tuple):
     """
     metrics = outs["metrics"]
     # trained_pop_size excludes the initial policy, so it's pop_size - 1
-    num_seeds, trained_pop_size, num_updates, _, _ = metrics["pg_loss_sp"].shape
+    num_seeds, trained_pop_size, num_updates = metrics["pg_loss_sp"].shape
 
     ### Log last XP matrix
     final_xp_matrix = np.asarray(outs["final_xp_matrix"]).mean(axis=0)  # shape (pop_size, pop_size)

--- a/open_ended_training/open_ended_minimax.py
+++ b/open_ended_training/open_ended_minimax.py
@@ -324,11 +324,15 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                 value_loss_ego, pg_loss_ego, entropy_ego = aux_vals
 
                 # Metrics
-                metric = traj_batch_ego.info
+                def mask_and_mean(x, mask):
+                    return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+
+                mask = traj_batch_ego.info.get("returned_episode", jnp.ones_like(traj_batch_ego.reward))
+                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_ego.info)
                 metric["update_steps"] = update_steps
-                metric["value_loss_conf_against_ego"] = value_loss_ego
-                metric["pg_loss_conf_against_ego"] = pg_loss_ego
-                metric["entropy_conf_against_ego"] = entropy_ego
+                metric["value_loss_conf_against_ego"] = value_loss_ego.mean()
+                metric["pg_loss_conf_against_ego"] = pg_loss_ego.mean()
+                metric["entropy_conf_against_ego"] = entropy_ego.mean()
                 metric["average_rewards_ego"] = jnp.mean(traj_batch_ego.reward)
 
                 new_runner_state = (
@@ -603,23 +607,30 @@ def log_metrics(config, logger, outs, metric_names: tuple):
     num_ego_updates = ego_metrics["returned_episode_returns"].shape[3]
 
     # Extract partner train stats
-    teammate_metrics = jax.tree.map(lambda x: x, teammate_metrics)
-    teammate_stats = get_stats(teammate_metrics, metric_names) # shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_partner_updates, 2)
-    teammate_stat_means = jax.tree.map(lambda x: np.mean(x, axis=(0, 2))[..., 0], teammate_stats) # shape (num_open_ended_iters, num_partner_updates)
+    # metrics pre-averaged to scalars per step; shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_partner_updates)
+    teammate_stat_means = {
+        stat_name: np.mean(np.asarray(teammate_metrics[stat_name]), axis=(0, 2))
+        for stat_name in metric_names
+        if stat_name in teammate_metrics
+    }  # shape (num_open_ended_iters, num_partner_updates)
 
     # Extract ego train stats
-    ego_stats = get_stats(ego_metrics, metric_names) # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_ego_updates, 2)
-    ego_stat_means = jax.tree.map(lambda x: np.mean(x, axis=(0, 2))[..., 0], ego_stats) # shape (num_open_ended_iters, num_ego_updates)
+    # metrics pre-averaged to scalars per step; shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_ego_updates)
+    ego_stat_means = {
+        stat_name: np.mean(np.asarray(ego_metrics[stat_name]), axis=(0, 2))
+        for stat_name in metric_names
+        if stat_name in ego_metrics
+    }  # shape (num_open_ended_iters, num_ego_updates)
 
     # Process/extract minimax-specific losses
     # shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_updates, num_eval_episodes, num_agents_per_env)
     avg_teammate_xp_returns = np.asarray(teammate_metrics["eval_ep_last_info_ego"]["returned_episode_returns"]).mean(axis=(0, 2, 4, 5))
 
     # Conf vs ego losses
-    #  shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_updates, update_epochs, num_minibatches)
-    avg_value_losses_teammate_against_ego = np.asarray(teammate_metrics["value_loss_conf_against_ego"]).mean(axis=(0, 2, 4, 5))
-    avg_actor_losses_teammate_against_ego = np.asarray(teammate_metrics["pg_loss_conf_against_ego"]).mean(axis=(0, 2, 4, 5))
-    avg_entropy_losses_teammate_against_ego = np.asarray(teammate_metrics["entropy_conf_against_ego"]).mean(axis=(0, 2, 4, 5))
+    #  shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_updates)
+    avg_value_losses_teammate_against_ego = np.asarray(teammate_metrics["value_loss_conf_against_ego"]).mean(axis=(0, 2))
+    avg_actor_losses_teammate_against_ego = np.asarray(teammate_metrics["pg_loss_conf_against_ego"]).mean(axis=(0, 2))
+    avg_entropy_losses_teammate_against_ego = np.asarray(teammate_metrics["entropy_conf_against_ego"]).mean(axis=(0, 2))
 
     # shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_updates)
     avg_rewards_teammate_against_ego = np.asarray(teammate_metrics["average_rewards_ego"]).mean(axis=(0, 2))
@@ -628,11 +639,11 @@ def log_metrics(config, logger, outs, metric_names: tuple):
     # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_updates, num_partners, num_eval_episodes, num_agents_per_env)
     avg_ego_returns = np.asarray(ego_metrics["eval_ep_last_info"]["returned_episode_returns"]).mean(axis=(0, 2, 4, 5, 6))
 
-    # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_updates, update_epochs, num_minibatches)
-    avg_ego_value_losses = np.asarray(ego_metrics["value_loss"]).mean(axis=(0, 2, 4, 5))
-    avg_ego_actor_losses = np.asarray(ego_metrics["actor_loss"]).mean(axis=(0, 2, 4, 5))
-    avg_ego_entropy_losses = np.asarray(ego_metrics["entropy_loss"]).mean(axis=(0, 2, 4, 5))
-    avg_ego_grad_norms = np.asarray(ego_metrics["avg_grad_norm"]).mean(axis=(0, 2, 4, 5))
+    # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_updates)
+    avg_ego_value_losses = np.asarray(ego_metrics["value_loss"]).mean(axis=(0, 2))
+    avg_ego_actor_losses = np.asarray(ego_metrics["actor_loss"]).mean(axis=(0, 2))
+    avg_ego_entropy_losses = np.asarray(ego_metrics["entropy_loss"]).mean(axis=(0, 2))
+    avg_ego_grad_norms = np.asarray(ego_metrics["avg_grad_norm"]).mean(axis=(0, 2))
     for iter_idx in range(num_open_ended_iters):
         # Log all partner metrics
         for step in range(num_partner_updates):

--- a/open_ended_training/paired.py
+++ b/open_ended_training/paired.py
@@ -657,26 +657,30 @@ def train_paired(config, env, partner_rng):
                 train_state_ego = update_state[2]
 
                 # Metrics
-                metric = traj_batch_ego.info
+                def mask_and_mean(x, mask):
+                    return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+
+                mask = traj_batch_ego.info.get("returned_episode", jnp.ones_like(traj_batch_ego.reward))
+                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_ego.info)
                 metric["update_steps"] = update_steps
 
                 # Conf agent losses: value_loss_ego, value_loss_br, pg_loss_ego, pg_loss_br, entropy_ego, entropy_br
-                metric["value_loss_conf_against_ego"] = all_losses_conf[1][0]
-                metric["value_loss_conf_against_br"] = all_losses_conf[1][1]
-                metric["pg_loss_conf_against_ego"] = all_losses_conf[1][2]
-                metric["pg_loss_conf_against_br"] = all_losses_conf[1][3]
-                metric["entropy_conf_against_ego"] = all_losses_conf[1][4]
-                metric["entropy_conf_against_br"] = all_losses_conf[1][5]
+                metric["value_loss_conf_against_ego"] = all_losses_conf[1][0].mean()
+                metric["value_loss_conf_against_br"] = all_losses_conf[1][1].mean()
+                metric["pg_loss_conf_against_ego"] = all_losses_conf[1][2].mean()
+                metric["pg_loss_conf_against_br"] = all_losses_conf[1][3].mean()
+                metric["entropy_conf_against_ego"] = all_losses_conf[1][4].mean()
+                metric["entropy_conf_against_br"] = all_losses_conf[1][5].mean()
 
                 # Ego agent losses
-                metric["value_loss_ego"] = all_losses_ego[1][0]
-                metric["pg_loss_ego"] = all_losses_ego[1][1]
-                metric["entropy_loss_ego"] = all_losses_ego[1][2]
+                metric["value_loss_ego"] = all_losses_ego[1][0].mean()
+                metric["pg_loss_ego"] = all_losses_ego[1][1].mean()
+                metric["entropy_loss_ego"] = all_losses_ego[1][2].mean()
 
                 # br agent losses
-                metric["value_loss_br"] = all_losses_br[1][0]
-                metric["pg_loss_br"] = all_losses_br[1][1]
-                metric["entropy_loss_br"] = all_losses_br[1][2]
+                metric["value_loss_br"] = all_losses_br[1][0].mean()
+                metric["pg_loss_br"] = all_losses_br[1][1].mean()
+                metric["entropy_loss_br"] = all_losses_br[1][2].mean()
 
                 metric["average_rewards_conf_against_ego"] = jnp.mean(traj_batch_conf_ego.reward)
                 metric["average_rewards_conf_against_br"] = jnp.mean(traj_batch_conf_br.reward) # redundant with br reward
@@ -879,25 +883,25 @@ def log_metrics(config, logger, outs, metric_names: tuple):
     avg_conf_returns_vs_br = np.asarray(metrics["eval_ep_last_info_br"]["returned_episode_returns"]).mean(axis=(0, 2, 3))
 
     # Value losses
-    # shape (num_seeds, num_updates, update_epochs, num_minibatches)
-    avg_value_losses_conf_vs_ego = np.asarray(metrics["value_loss_conf_against_ego"]).mean(axis=(0, 2, 3))
-    avg_value_losses_conf_vs_br = np.asarray(metrics["value_loss_conf_against_br"]).mean(axis=(0, 2, 3))
-    avg_value_losses_br = np.asarray(metrics["value_loss_br"]).mean(axis=(0, 2, 3))
-    avg_value_losses_ego = np.asarray(metrics["value_loss_ego"]).mean(axis=(0, 2, 3))
+    # shape (num_seeds, num_updates)
+    avg_value_losses_conf_vs_ego = np.asarray(metrics["value_loss_conf_against_ego"]).mean(axis=0)
+    avg_value_losses_conf_vs_br = np.asarray(metrics["value_loss_conf_against_br"]).mean(axis=0)
+    avg_value_losses_br = np.asarray(metrics["value_loss_br"]).mean(axis=0)
+    avg_value_losses_ego = np.asarray(metrics["value_loss_ego"]).mean(axis=0)
 
     # Actor losses
-    # shape (num_seeds, num_updates, update_epochs, num_minibatches)
-    avg_actor_losses_conf_vs_ego = np.asarray(metrics["pg_loss_conf_against_ego"]).mean(axis=(0, 2, 3))
-    avg_actor_losses_conf_vs_br = np.asarray(metrics["pg_loss_conf_against_br"]).mean(axis=(0, 2, 3))
-    avg_actor_losses_br = np.asarray(metrics["pg_loss_br"]).mean(axis=(0, 2, 3))
-    avg_actor_losses_ego = np.asarray(metrics["pg_loss_ego"]).mean(axis=(0, 2, 3))
+    # shape (num_seeds, num_updates)
+    avg_actor_losses_conf_vs_ego = np.asarray(metrics["pg_loss_conf_against_ego"]).mean(axis=0)
+    avg_actor_losses_conf_vs_br = np.asarray(metrics["pg_loss_conf_against_br"]).mean(axis=0)
+    avg_actor_losses_br = np.asarray(metrics["pg_loss_br"]).mean(axis=0)
+    avg_actor_losses_ego = np.asarray(metrics["pg_loss_ego"]).mean(axis=0)
 
     # Entropy losses
-    #  shape (num_seeds, num_updates, update_epochs, num_minibatches)
-    avg_entropy_losses_conf_vs_ego = np.asarray(metrics["entropy_conf_against_ego"]).mean(axis=(0, 2, 3))
-    avg_entropy_losses_conf_vs_br = np.asarray(metrics["entropy_conf_against_br"]).mean(axis=(0, 2, 3))
-    avg_entropy_losses_br = np.asarray(metrics["entropy_loss_br"]).mean(axis=(0, 2, 3))
-    avg_entropy_losses_ego = np.asarray(metrics["entropy_loss_ego"]).mean(axis=(0, 2, 3))
+    #  shape (num_seeds, num_updates)
+    avg_entropy_losses_conf_vs_ego = np.asarray(metrics["entropy_conf_against_ego"]).mean(axis=0)
+    avg_entropy_losses_conf_vs_br = np.asarray(metrics["entropy_conf_against_br"]).mean(axis=0)
+    avg_entropy_losses_br = np.asarray(metrics["entropy_loss_br"]).mean(axis=0)
+    avg_entropy_losses_ego = np.asarray(metrics["entropy_loss_ego"]).mean(axis=0)
 
     # Rewards
     # shape (num_seeds, num_updates)

--- a/open_ended_training/ppo_ego_with_buffer.py
+++ b/open_ended_training/ppo_ego_with_buffer.py
@@ -317,12 +317,16 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                 _, loss_terms, avg_grad_norm = losses_and_grads
 
                 # Metrics
-                metric = traj_batch.info
+                def mask_and_mean(x, mask):
+                    return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+
+                mask = traj_batch.info.get("returned_episode", jnp.ones_like(traj_batch.reward))
+                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch.info)
                 metric["update_steps"] = update_steps
-                metric["actor_loss"] = loss_terms[1]
-                metric["value_loss"] = loss_terms[0]
-                metric["entropy_loss"] = loss_terms[2]
-                metric["avg_grad_norm"] = avg_grad_norm
+                metric["actor_loss"] = loss_terms[1].mean()
+                metric["value_loss"] = loss_terms[0].mean()
+                metric["entropy_loss"] = loss_terms[2].mean()
+                metric["avg_grad_norm"] = avg_grad_norm.mean()
                 new_runner_state = (train_state, buffer, rng, update_steps + 1)
                 return (new_runner_state, metric)
 

--- a/open_ended_training/rotate.py
+++ b/open_ended_training/rotate.py
@@ -832,23 +832,27 @@ def train_regret_maximizing_partners(config, env,
                 (br_value_loss, br_pg_loss, br_entropy) = br_losses[1]
 
                 # Metrics
-                metric = traj_batch_xp.info
+                def mask_and_mean(x, mask):
+                    return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+
+                mask = traj_batch_xp.info.get("returned_episode", jnp.ones_like(traj_batch_xp.reward))
+                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_xp.info)
                 metric["update_steps"] = update_steps
-                metric["value_loss_conf_against_ego"] = conf_value_loss_xp
-                metric["value_loss_conf_against_br"] = conf_value_loss_sp
+                metric["value_loss_conf_against_ego"] = conf_value_loss_xp.mean()
+                metric["value_loss_conf_against_br"] = conf_value_loss_sp.mean()
 
-                metric["pg_loss_conf_against_ego"] = conf_pg_loss_xp
-                metric["pg_loss_conf_against_br"] = conf_pg_loss_sp
+                metric["pg_loss_conf_against_ego"] = conf_pg_loss_xp.mean()
+                metric["pg_loss_conf_against_br"] = conf_pg_loss_sp.mean()
 
-                metric["entropy_conf_against_ego"] = conf_entropy_xp
-                metric["entropy_conf_against_br"] = conf_entropy_sp
+                metric["entropy_conf_against_ego"] = conf_entropy_xp.mean()
+                metric["entropy_conf_against_br"] = conf_entropy_sp.mean()
 
                 metric["average_rewards_ego"] = conf_avg_reward_ego
                 metric["average_rewards_br"] = conf_avg_reward_br
 
-                metric["value_loss_br"] = br_value_loss
-                metric["pg_loss_br"] = br_pg_loss
-                metric["entropy_loss_br"] = br_entropy
+                metric["value_loss_br"] = br_value_loss.mean()
+                metric["pg_loss_br"] = br_pg_loss.mean()
+                metric["entropy_loss_br"] = br_entropy.mean()
 
                 new_update_runner_state = (
                     train_state_conf, train_state_br,
@@ -1252,43 +1256,52 @@ def log_metrics(config, logger, outs, metric_names: tuple):
     ### Process/extract ROTATE-specific losses
     # Conf vs ego, conf vs br, br losses
     # shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_updates, num_eval_episodes, num_agents_per_env)
-    teammate_mean_dims = (0, 2, 4, 5)
-    avg_teammate_sp_returns = np.asarray(teammate_metrics["eval_ep_last_info_br"]["returned_episode_returns"]).mean(axis=teammate_mean_dims)
-    avg_teammate_xp_returns = np.asarray(teammate_metrics["eval_ep_last_info_ego"]["returned_episode_returns"]).mean(axis=teammate_mean_dims)
-
-    #  shape (num_open_ended_iters, num_partner_seeds, num_partner_updates, update_epochs, num_minibatches)
-    avg_value_losses_teammate_against_ego = np.asarray(teammate_metrics["value_loss_conf_against_ego"]).mean(axis=teammate_mean_dims)
-    avg_value_losses_teammate_against_br = np.asarray(teammate_metrics["value_loss_conf_against_br"]).mean(axis=teammate_mean_dims)
-    avg_value_losses_br = np.asarray(teammate_metrics["value_loss_br"]).mean(axis=teammate_mean_dims)
-
-    avg_actor_losses_teammate_against_ego = np.asarray(teammate_metrics["pg_loss_conf_against_ego"]).mean(axis=teammate_mean_dims)
-    avg_actor_losses_teammate_against_br = np.asarray(teammate_metrics["pg_loss_conf_against_br"]).mean(axis=teammate_mean_dims)
-    avg_actor_losses_br = np.asarray(teammate_metrics["pg_loss_br"]).mean(axis=teammate_mean_dims)
-
-    avg_entropy_losses_teammate_against_ego = np.asarray(teammate_metrics["entropy_conf_against_ego"]).mean(axis=teammate_mean_dims)
-    avg_entropy_losses_teammate_against_br = np.asarray(teammate_metrics["entropy_conf_against_br"]).mean(axis=teammate_mean_dims)
-    avg_entropy_losses_br = np.asarray(teammate_metrics["entropy_loss_br"]).mean(axis=teammate_mean_dims)
+    eval_mean_dims = (0, 2, 4, 5)
+    avg_teammate_sp_returns = np.asarray(teammate_metrics["eval_ep_last_info_br"]["returned_episode_returns"]).mean(axis=eval_mean_dims)
+    avg_teammate_xp_returns = np.asarray(teammate_metrics["eval_ep_last_info_ego"]["returned_episode_returns"]).mean(axis=eval_mean_dims)
 
     # shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_partner_updates)
-    avg_rewards_teammate_against_br = np.asarray(teammate_metrics["average_rewards_br"]).mean(axis=(0, 2))
-    avg_rewards_teammate_against_ego = np.asarray(teammate_metrics["average_rewards_ego"]).mean(axis=(0, 2))
+    loss_mean_dims = (0, 2)
+    avg_value_losses_teammate_against_ego = np.asarray(teammate_metrics["value_loss_conf_against_ego"]).mean(axis=loss_mean_dims)
+    avg_value_losses_teammate_against_br = np.asarray(teammate_metrics["value_loss_conf_against_br"]).mean(axis=loss_mean_dims)
+    avg_value_losses_br = np.asarray(teammate_metrics["value_loss_br"]).mean(axis=loss_mean_dims)
+
+    avg_actor_losses_teammate_against_ego = np.asarray(teammate_metrics["pg_loss_conf_against_ego"]).mean(axis=loss_mean_dims)
+    avg_actor_losses_teammate_against_br = np.asarray(teammate_metrics["pg_loss_conf_against_br"]).mean(axis=loss_mean_dims)
+    avg_actor_losses_br = np.asarray(teammate_metrics["pg_loss_br"]).mean(axis=loss_mean_dims)
+
+    avg_entropy_losses_teammate_against_ego = np.asarray(teammate_metrics["entropy_conf_against_ego"]).mean(axis=loss_mean_dims)
+    avg_entropy_losses_teammate_against_br = np.asarray(teammate_metrics["entropy_conf_against_br"]).mean(axis=loss_mean_dims)
+    avg_entropy_losses_br = np.asarray(teammate_metrics["entropy_loss_br"]).mean(axis=loss_mean_dims)
+
+    # shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_partner_updates)
+    avg_rewards_teammate_against_br = np.asarray(teammate_metrics["average_rewards_br"]).mean(axis=loss_mean_dims)
+    avg_rewards_teammate_against_ego = np.asarray(teammate_metrics["average_rewards_ego"]).mean(axis=loss_mean_dims)
 
     # Process ego-specific metrics
     # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_ego_updates, num_partners, num_eval_episodes, num_agents_per_env)
     avg_ego_returns = np.asarray(ego_metrics["eval_ep_last_info"]["returned_episode_returns"]).mean(axis=(0, 2, 4, 5, 6))
-    # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_ego_updates, update_epochs, num_minibatches)
-    avg_ego_value_losses = np.asarray(ego_metrics["value_loss"]).mean(axis=(0, 2, 4, 5))
-    avg_ego_actor_losses = np.asarray(ego_metrics["actor_loss"]).mean(axis=(0, 2, 4, 5))
-    avg_ego_entropy_losses = np.asarray(ego_metrics["entropy_loss"]).mean(axis=(0, 2, 4, 5))
-    avg_ego_grad_norms = np.asarray(ego_metrics["avg_grad_norm"]).mean(axis=(0, 2, 4, 5))
+    # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_ego_updates)
+    avg_ego_value_losses = np.asarray(ego_metrics["value_loss"]).mean(axis=loss_mean_dims)
+    avg_ego_actor_losses = np.asarray(ego_metrics["actor_loss"]).mean(axis=loss_mean_dims)
+    avg_ego_entropy_losses = np.asarray(ego_metrics["entropy_loss"]).mean(axis=loss_mean_dims)
+    avg_ego_grad_norms = np.asarray(ego_metrics["avg_grad_norm"]).mean(axis=loss_mean_dims)
 
     # extract teammate-vs-ego stats
-    teammate_stats = get_stats(teammate_metrics, metric_names) # shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_partner_updates, 2)
-    teammate_stat_means = jax.tree.map(lambda x: np.mean(x, axis=(0, 2))[..., 0], teammate_stats) # shape (num_open_ended_iters, num_partner_updates)
+    # metrics pre-averaged to scalars per step; shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_partner_updates)
+    teammate_stat_means = {
+        stat_name: np.mean(np.asarray(teammate_metrics[stat_name]), axis=loss_mean_dims)
+        for stat_name in metric_names
+        if stat_name in teammate_metrics
+    }  # shape (num_open_ended_iters, num_partner_updates)
 
     # extract ego stats
-    ego_stats = get_stats(ego_metrics, metric_names) # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_ego_updates, 2)
-    ego_stat_means = jax.tree.map(lambda x: np.mean(x, axis=(0, 2))[..., 0], ego_stats) # shape (num_open_ended_iters, num_ego_updates)
+    # metrics pre-averaged to scalars per step; shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_ego_updates)
+    ego_stat_means = {
+        stat_name: np.mean(np.asarray(ego_metrics[stat_name]), axis=loss_mean_dims)
+        for stat_name in metric_names
+        if stat_name in ego_metrics
+    }  # shape (num_open_ended_iters, num_ego_updates)
 
     for iter_idx in range(num_open_ended_iters):
         # Log all partner metrics

--- a/open_ended_training/run.py
+++ b/open_ended_training/run.py
@@ -6,10 +6,10 @@ from evaluation.heldout_eval import run_heldout_evaluation, log_heldout_metrics
 from common.plot_utils import get_metric_names
 from common.wandb_visualizations import Logger
 from open_ended_training.rotate import run_rotate
+from open_ended_training.cole import run_cole
 from open_ended_minimax import run_minimax
-from paired import run_paired
-from trajedi import run_trajedi
-from cole import run_cole
+from open_ended_training.paired import run_paired
+from open_ended_training.trajedi import run_trajedi
 
 @hydra.main(version_base=None, config_path="configs", config_name="base_config_oel")
 def run_training(cfg):

--- a/open_ended_training/trajedi.py
+++ b/open_ended_training/trajedi.py
@@ -1253,25 +1253,29 @@ def train_trajedi_partners(config, env, partner_rng):
                 train_state_ego = update_state[1]
 
                 # Metrics
-                metric = traj_batch_conf_p0.info
+                def mask_and_mean(x, mask):
+                    return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+                
+                mask = traj_batch_conf_p0.info.get("returned_episode", jnp.ones_like(traj_batch_conf_p0.reward))
+                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_conf_p0.info)
                 metric["update_steps"] = update_steps
 
                 # Conf agent losses: value_loss_ego, value_loss_br, pg_loss_ego, pg_loss_br, entropy_ego, entropy_br
-                metric["value_loss_conf_against_br"] = all_losses_conf[1][0]
-                metric["value_loss_conf_self_play"] = all_losses_conf[1][1]
-                metric["pg_loss_conf_against_br"] = all_losses_conf[1][2]
-                metric["pg_loss_conf_self_play"] = all_losses_conf[1][3]
-                metric["entropy_conf_against_br"] = all_losses_conf[1][4]
-                metric["entropy_conf_self_play"] = all_losses_conf[1][5]
-                metric["trajedi_loss"] = all_losses_conf[1][6]
+                metric["value_loss_conf_against_br"] = all_losses_conf[1][0].mean()
+                metric["value_loss_conf_self_play"] = all_losses_conf[1][1].mean()
+                metric["pg_loss_conf_against_br"] = all_losses_conf[1][2].mean()
+                metric["pg_loss_conf_self_play"] = all_losses_conf[1][3].mean()
+                metric["entropy_conf_against_br"] = all_losses_conf[1][4].mean()
+                metric["entropy_conf_self_play"] = all_losses_conf[1][5].mean()
+                metric["trajedi_loss"] = all_losses_conf[1][6].mean()
 
                 # Ego agent losses
-                metric["value_loss_ego_against_conf"] = all_losses_ego[1][0]
-                metric["value_loss_ego_self_play"] = all_losses_ego[1][1]
-                metric["pg_loss_ego_against_conf"] = all_losses_ego[1][2]
-                metric["pg_loss_ego_self_play"] = all_losses_ego[1][3]
-                metric["entropy_loss_ego_against_conf"] = all_losses_ego[1][4]
-                metric["entropy_loss_ego_self_play"] = all_losses_ego[1][5]
+                metric["value_loss_ego_against_conf"] = all_losses_ego[1][0].mean()
+                metric["value_loss_ego_self_play"] = all_losses_ego[1][1].mean()
+                metric["pg_loss_ego_against_conf"] = all_losses_ego[1][2].mean()
+                metric["pg_loss_ego_self_play"] = all_losses_ego[1][3].mean()
+                metric["entropy_loss_ego_against_conf"] = all_losses_ego[1][4].mean()
+                metric["entropy_loss_ego_self_play"] = all_losses_ego[1][5].mean()
 
                 metric["average_rewards_conf_sp"] = (jnp.mean(traj_batch_conf_p0.reward) + jnp.mean(traj_batch_conf_p1.reward))/2.0
                 metric["average_rewards_conf_xp"] = jnp.mean(traj_batch_conf_xp.reward) 
@@ -1541,29 +1545,29 @@ def log_metrics(config, logger, outs, metric_names: tuple):
     avg_returns_confs_vs_br = np.asarray(metrics["eval_ep_last_info_ego"]["returned_episode_returns"]).mean(axis=(0, 2, 3))
     
     # Value losses
-    # shape (num_seeds, num_updates, update_epochs, num_minibatches)
-    avg_value_losses_conf_self_play = np.asarray(metrics["value_loss_conf_self_play"]).mean(axis=(0, 2, 3, 4))
-    avg_value_losses_conf_vs_br = np.asarray(metrics["value_loss_conf_against_br"]).mean(axis=(0, 2, 3, 4))
-    avg_value_losses_br_sp = np.asarray(metrics["value_loss_ego_self_play"]).mean(axis=(0, 2, 3))
-    avg_value_losses_br_xp = np.asarray(metrics["value_loss_ego_against_conf"]).mean(axis=(0, 2, 3))
+    # shape (num_seeds, num_updates)
+    avg_value_losses_conf_self_play = np.asarray(metrics["value_loss_conf_self_play"]).mean(axis=0)
+    avg_value_losses_conf_vs_br = np.asarray(metrics["value_loss_conf_against_br"]).mean(axis=0)
+    avg_value_losses_br_sp = np.asarray(metrics["value_loss_ego_self_play"]).mean(axis=0)
+    avg_value_losses_br_xp = np.asarray(metrics["value_loss_ego_against_conf"]).mean(axis=0)
 
     # Actor losses
-    # shape (num_seeds, num_updates, update_epochs, num_minibatches)
-    avg_actor_losses_conf_self_play = np.asarray(metrics["pg_loss_conf_self_play"]).mean(axis=(0, 2, 3, 4))
-    avg_actor_losses_conf_vs_br = np.asarray(metrics["pg_loss_conf_against_br"]).mean(axis=(0, 2, 3, 4))
-    avg_actor_losses_ego_sp = np.asarray(metrics["pg_loss_ego_self_play"]).mean(axis=(0, 2, 3))
-    avg_actor_losses_ego_xp = np.asarray(metrics["pg_loss_ego_against_conf"]).mean(axis=(0, 2, 3))
+    # shape (num_seeds, num_updates)
+    avg_actor_losses_conf_self_play = np.asarray(metrics["pg_loss_conf_self_play"]).mean(axis=0)
+    avg_actor_losses_conf_vs_br = np.asarray(metrics["pg_loss_conf_against_br"]).mean(axis=0)
+    avg_actor_losses_ego_sp = np.asarray(metrics["pg_loss_ego_self_play"]).mean(axis=0)
+    avg_actor_losses_ego_xp = np.asarray(metrics["pg_loss_ego_against_conf"]).mean(axis=0)
 
     # Entropy losses
-    #  shape (num_seeds, num_updates, update_epochs, num_minibatches)
-    avg_entropy_losses_conf_self_play = np.asarray(metrics["entropy_conf_self_play"]).mean(axis=(0, 2, 3, 4))
-    avg_entropy_losses_conf_vs_br = np.asarray(metrics["entropy_conf_against_br"]).mean(axis=(0, 2, 3, 4))
-    avg_entropy_losses_ego_sp = np.asarray(metrics["entropy_loss_ego_self_play"]).mean(axis=(0, 2, 3))
-    avg_entropy_losses_ego_xp = np.asarray(metrics["entropy_loss_ego_against_conf"]).mean(axis=(0, 2, 3))
+    #  shape (num_seeds, num_updates)
+    avg_entropy_losses_conf_self_play = np.asarray(metrics["entropy_conf_self_play"]).mean(axis=0)
+    avg_entropy_losses_conf_vs_br = np.asarray(metrics["entropy_conf_against_br"]).mean(axis=0)
+    avg_entropy_losses_ego_sp = np.asarray(metrics["entropy_loss_ego_self_play"]).mean(axis=0)
+    avg_entropy_losses_ego_xp = np.asarray(metrics["entropy_loss_ego_against_conf"]).mean(axis=0)
 
     # Entropy losses
-    #  shape (num_seeds, num_updates, update_epochs, num_minibatches)
-    avg_sp_trajedi_loss = np.asarray(metrics["trajedi_loss"]).mean(axis=(0, 2, 3, 4))
+    #  shape (num_seeds, num_updates)
+    avg_sp_trajedi_loss = np.asarray(metrics["trajedi_loss"]).mean(axis=0)
 
     # Rewards
     # shape (num_seeds, num_updates)

--- a/scripts/test_algos.sh
+++ b/scripts/test_algos.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test_algos.sh — Smoke-test all algorithms in parallel across GPUs.
+#
+# PURPOSE
+#   Runs a short training pass for every algorithm to verify that the code
+#   executes end-to-end without errors.  All runs use tiny timestep budgets,
+#   offline logging, and skip artifact saving so they finish quickly.
+#
+# USAGE
+#   bash scripts/test_algos.sh
+#   Run from anywhere; the script locates the repo root automatically.
+#
+# OUTPUT
+#   Each job's stdout/stderr is written to:
+#     results/test_algos_<timestamp>/<job_name>.log
+#   A running status log and final summary are written to:
+#     results/test_algos_<timestamp>/summary.log
+#   The script exits 0 if all jobs passed, 1 if any failed.
+#
+# GPU REQUIREMENTS
+#   Any GPU reported by nvidia-smi with >= 20 GB of free memory is used.
+#   Jobs are distributed across available GPUs; up to N jobs run in parallel
+#   where N = number of qualifying GPUs.  The script aborts if none qualify.
+#
+# SELECTING WHICH ALGORITHMS TO RUN
+#   Edit the RUN_JOBS array (just below the job definitions).
+#   List the job names you want to run, e.g.:
+#     RUN_JOBS=(ippo brdiv liam_ego)
+#   Leave it empty to run every defined job:
+#     RUN_JOBS=()
+#
+# ADDING A NEW TEST
+#   1. Append a name to JOB_NAMES and the matching command to JOB_CMDS in the
+#      "Job definitions" section below.  The two arrays must stay in sync.
+#   2. Add the name to RUN_JOBS (or leave RUN_JOBS empty to run all).
+#   3. Each JOB_CMDS entry is a plain shell command string (no special quoting
+#      needed; use backslash-newline for readability as shown below).
+#   4. Use the shared COMMON_FLAGS variable for the standard set of flags that
+#      disable logging and artifact saving.
+#
+# PREREQUISITES
+#   nvidia-smi must be on PATH (standard on any machine with an Nvidia driver).
+#   The conda/venv environment that can run the project must be active.
+# =============================================================================
+set -uo pipefail
+
+# ─── Paths ───────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+RESULTS_DIR="$REPO_ROOT/results/test_algos_$(date +%Y-%m-%d_%H-%M-%S)"
+mkdir -p "$RESULTS_DIR"
+LOG="$RESULTS_DIR/summary.log"
+
+# ─── Shared flags ─────────────────────────────────────────────────────────────
+# Appended to every command: disables W&B uploads and local artifact saving.
+COMMON_FLAGS="logger.mode=offline logger.log_train_out=false logger.log_eval_out=false local_logger.save_train_out=false local_logger.save_eval_out=false"
+
+# Path to a pre-trained IPPO partner checkpoint (required by ego-training algos).
+PARTNER_PATH="eval_teammates/lbf/ippo/ippo-lbf-7-levels/saved_train_run/"
+
+# =============================================================================
+# ─── Job definitions ──────────────────────────────────────────────────────────
+# To add a new test:
+#   JOB_NAMES+=("my_algo_name")
+#   JOB_CMDS+=("python my_module/run.py algorithm=my_algo/lbf ... $COMMON_FLAGS")
+#
+# The two arrays are parallel: JOB_NAMES[i] is the label for JOB_CMDS[i].
+# Use backslash-newline for multi-line readability (bash strips them).
+# =============================================================================
+JOB_NAMES=()
+JOB_CMDS=()
+
+# ── MARL ──────────────────────────────────────────────────────────────────────
+JOB_NAMES+=("ippo")
+JOB_CMDS+=("python marl/run.py \
+    algorithm=ippo/lbf task=lbf label=test_ippo \
+    algorithm.NUM_SEEDS=1 \
+    $COMMON_FLAGS")
+
+# ── Teammate generation ───────────────────────────────────────────────────────
+JOB_NAMES+=("brdiv")
+JOB_CMDS+=("python teammate_generation/run.py \
+    algorithm=brdiv/lbf task=lbf label=test_brdiv \
+    algorithm.TOTAL_TIMESTEPS=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
+    $COMMON_FLAGS")
+
+JOB_NAMES+=("lbrdiv")
+JOB_CMDS+=("python teammate_generation/run.py \
+    algorithm=lbrdiv/lbf task=lbf label=test_lbrdiv \
+    run_heldout_eval=false train_ego=false \
+    algorithm.TOTAL_TIMESTEPS=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
+    $COMMON_FLAGS")
+
+JOB_NAMES+=("comedi")
+JOB_CMDS+=("python teammate_generation/run.py \
+    algorithm=comedi/lbf task=lbf label=test_comedi \
+    run_heldout_eval=false train_ego=false \
+    algorithm.TOTAL_TIMESTEPS_PER_ITERATION=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
+    $COMMON_FLAGS")
+
+# ── Ego training ──────────────────────────────────────────────────────────────
+JOB_NAMES+=("liam_ego")
+JOB_CMDS+=("python ego_agent_training/run.py \
+    algorithm=liam_ego/lbf task=lbf label=test_liam_ego \
+    algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_EGO_TRAIN_SEEDS=1 \
+    algorithm.partner_agent.ippo.path=$PARTNER_PATH \
+    run_heldout_eval=false \
+    $COMMON_FLAGS")
+
+JOB_NAMES+=("meliba_ego")
+JOB_CMDS+=("python ego_agent_training/run.py \
+    algorithm=meliba_ego/lbf task=lbf label=test_meliba_ego \
+    algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_EGO_TRAIN_SEEDS=1 \
+    algorithm.partner_agent.ippo.path=$PARTNER_PATH \
+    run_heldout_eval=false \
+    $COMMON_FLAGS")
+
+JOB_NAMES+=("ppo_ego")
+JOB_CMDS+=("python ego_agent_training/run.py \
+    algorithm=ppo_ego/lbf task=lbf label=test_ppo_ego \
+    algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_EGO_TRAIN_SEEDS=1 \
+    algorithm.partner_agent.ippo.path=$PARTNER_PATH \
+    run_heldout_eval=false \
+    $COMMON_FLAGS")
+
+# ── Open-ended / unified training ─────────────────────────────────────────────
+JOB_NAMES+=("rotate")
+JOB_CMDS+=("python open_ended_training/run.py \
+    algorithm=rotate/lbf task=lbf label=test_rotate \
+    algorithm.NUM_OPEN_ENDED_ITERS=1 \
+    algorithm.TIMESTEPS_PER_ITER_PARTNER=1e5 algorithm.TIMESTEPS_PER_ITER_EGO=1e5 \
+    algorithm.NUM_SEEDS=1 \
+    run_heldout_eval=false \
+    $COMMON_FLAGS")
+
+JOB_NAMES+=("cole")
+JOB_CMDS+=("python open_ended_training/run.py \
+    algorithm=cole/lbf task=lbf label=test_cole \
+    algorithm.TOTAL_TIMESTEPS_PER_ITERATION=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
+    run_heldout_eval=false \
+    $COMMON_FLAGS")
+
+JOB_NAMES+=("trajedi")
+JOB_CMDS+=("python open_ended_training/run.py \
+    algorithm=trajedi/lbf task=lbf label=test_trajedi \
+    algorithm.TOTAL_TIMESTEPS=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
+    run_heldout_eval=false \
+    $COMMON_FLAGS")
+
+# =============================================================================
+# ─── Selection — which jobs to run ────────────────────────────────────────────
+# List the job names you want to run.  Empty = run all defined jobs.
+# Example (run a subset):
+#   RUN_JOBS=(ippo brdiv liam_ego)
+# =============================================================================
+RUN_JOBS=(
+    ippo
+    brdiv
+    lbrdiv
+    comedi
+    liam_ego
+    meliba_ego
+    ppo_ego
+    rotate
+    cole
+    trajedi
+)
+
+# =============================================================================
+# ─── Implementation — no edits needed below this line ─────────────────────────
+# =============================================================================
+
+echo "Logs → $RESULTS_DIR" | tee "$LOG"
+
+# ─── GPU detection ────────────────────────────────────────────────────────────
+mapfile -t GPUS < <(
+    nvidia-smi --query-gpu=index,memory.free --format=csv,noheader,nounits 2>/dev/null \
+    | awk -F',' '{ gsub(/ /,"",$1); gsub(/ /,"",$2); if ($2+0 >= 20000) print $1 }'
+)
+
+if [[ ${#GPUS[@]} -eq 0 ]]; then
+    echo "ERROR: no GPUs with >= 20 GB free memory found. Aborting." | tee -a "$LOG" >&2
+    exit 1
+fi
+echo "GPUs with >= 20 GB free: ${GPUS[*]}" | tee -a "$LOG"
+
+# ─── Parallel job manager ─────────────────────────────────────────────────────
+declare -a FREE_GPUS=("${GPUS[@]}")
+declare -A PID_GPU    # pid -> gpu index
+declare -A PID_NAME   # pid -> job name
+SUCCEEDED=()
+FAILED=()
+
+# Reap any finished jobs and return their GPUs to the pool.
+reap() {
+    local -a done_pids=()
+    for pid in "${!PID_GPU[@]}"; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            done_pids+=("$pid")
+        fi
+    done
+    for pid in "${done_pids[@]}"; do
+        local name="${PID_NAME[$pid]}"
+        local gpu="${PID_GPU[$pid]}"
+        if wait "$pid"; then
+            SUCCEEDED+=("$name")
+            echo "[$(date '+%H:%M:%S')] [OK]   $name  (GPU $gpu)" | tee -a "$LOG"
+        else
+            FAILED+=("$name")
+            echo "[$(date '+%H:%M:%S')] [FAIL] $name  (GPU $gpu) — see ${name}.log" | tee -a "$LOG"
+        fi
+        FREE_GPUS+=("$gpu")
+        unset 'PID_GPU[$pid]'
+        unset 'PID_NAME[$pid]'
+    done
+}
+
+# Block until a GPU slot is free; sets FREE_GPU to the acquired GPU index.
+acquire_gpu() {
+    while [[ ${#FREE_GPUS[@]} -eq 0 ]]; do
+        reap
+        [[ ${#FREE_GPUS[@]} -eq 0 ]] && sleep 2
+    done
+    FREE_GPU="${FREE_GPUS[0]}"
+    FREE_GPUS=("${FREE_GPUS[@]:1}")
+}
+
+# Launch a job: launch <name> <cmd...>
+launch() {
+    local name="$1"; shift
+    acquire_gpu
+    local gpu="$FREE_GPU"
+    local logfile="$RESULTS_DIR/${name}.log"
+    echo "[$(date '+%H:%M:%S')] [START] $name  (GPU $gpu)" | tee -a "$LOG"
+    CUDA_VISIBLE_DEVICES="$gpu" "$@" >"$logfile" 2>&1 &
+    local pid=$!
+    PID_GPU[$pid]="$gpu"
+    PID_NAME[$pid]="$name"
+}
+
+# Wait for all running jobs to finish.
+wait_all() {
+    while [[ ${#PID_GPU[@]} -gt 0 ]]; do
+        reap
+        [[ ${#PID_GPU[@]} -gt 0 ]] && sleep 2
+    done
+}
+
+# ─── Dispatch selected jobs ───────────────────────────────────────────────────
+cd "$REPO_ROOT"
+
+# Build a lookup set from RUN_JOBS (empty RUN_JOBS = run everything).
+declare -A _RUN_SET
+if [[ ${#RUN_JOBS[@]} -gt 0 ]]; then
+    for name in "${RUN_JOBS[@]}"; do _RUN_SET["$name"]=1; done
+fi
+
+for i in "${!JOB_NAMES[@]}"; do
+    name="${JOB_NAMES[$i]}"
+    if [[ ${#RUN_JOBS[@]} -eq 0 || -n "${_RUN_SET[$name]+x}" ]]; then
+        launch "$name" bash -c "${JOB_CMDS[$i]}"
+    else
+        echo "[SKIP]  $name" | tee -a "$LOG"
+    fi
+done
+
+wait_all
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+{
+echo ""
+echo "══════════════════════════════════════════════════════"
+echo "  RESULTS"
+echo "══════════════════════════════════════════════════════"
+printf "  PASSED (%d):" "${#SUCCEEDED[@]}"; printf " %s" "${SUCCEEDED[@]:-}"; echo ""
+printf "  FAILED (%d):" "${#FAILED[@]}";   printf " %s" "${FAILED[@]:-}";   echo ""
+echo "══════════════════════════════════════════════════════"
+echo "  Full logs: $RESULTS_DIR"
+} | tee -a "$LOG"
+
+[[ ${#FAILED[@]} -eq 0 ]] && exit 0 || exit 1

--- a/scripts/test_algos.sh
+++ b/scripts/test_algos.sh
@@ -100,6 +100,13 @@ JOB_CMDS+=("python teammate_generation/run.py \
     algorithm.TOTAL_TIMESTEPS_PER_ITERATION=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
     $COMMON_FLAGS")
 
+JOB_NAMES+=("fcp")
+JOB_CMDS+=("python teammate_generation/run.py \
+    algorithm=fcp/lbf task=lbf label=test_fcp \
+    run_heldout_eval=false train_ego=false \
+    algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_CHECKPOINTS=2 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
+    $COMMON_FLAGS")
+
 # ── Ego training ──────────────────────────────────────────────────────────────
 # Run heldout eval for ppo ego only
 JOB_NAMES+=("ppo_ego")
@@ -161,6 +168,7 @@ RUN_JOBS=(
     brdiv
     lbrdiv
     comedi
+    fcp
     liam_ego
     meliba_ego
     ppo_ego

--- a/scripts/test_algos.sh
+++ b/scripts/test_algos.sh
@@ -82,6 +82,7 @@ JOB_CMDS+=("python marl/run.py \
 JOB_NAMES+=("brdiv")
 JOB_CMDS+=("python teammate_generation/run.py \
     algorithm=brdiv/lbf task=lbf label=test_brdiv \
+    run_heldout_eval=false train_ego=false \
     algorithm.TOTAL_TIMESTEPS=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
     $COMMON_FLAGS")
 
@@ -100,6 +101,15 @@ JOB_CMDS+=("python teammate_generation/run.py \
     $COMMON_FLAGS")
 
 # ── Ego training ──────────────────────────────────────────────────────────────
+# Run heldout eval for ppo ego only
+JOB_NAMES+=("ppo_ego")
+JOB_CMDS+=("python ego_agent_training/run.py \
+    algorithm=ppo_ego/lbf task=lbf label=test_ppo_ego \
+    algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_EGO_TRAIN_SEEDS=1 \
+    algorithm.partner_agent.ippo.path=$PARTNER_PATH \
+    run_heldout_eval=true \
+    $COMMON_FLAGS")
+
 JOB_NAMES+=("liam_ego")
 JOB_CMDS+=("python ego_agent_training/run.py \
     algorithm=liam_ego/lbf task=lbf label=test_liam_ego \
@@ -111,14 +121,6 @@ JOB_CMDS+=("python ego_agent_training/run.py \
 JOB_NAMES+=("meliba_ego")
 JOB_CMDS+=("python ego_agent_training/run.py \
     algorithm=meliba_ego/lbf task=lbf label=test_meliba_ego \
-    algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_EGO_TRAIN_SEEDS=1 \
-    algorithm.partner_agent.ippo.path=$PARTNER_PATH \
-    run_heldout_eval=false \
-    $COMMON_FLAGS")
-
-JOB_NAMES+=("ppo_ego")
-JOB_CMDS+=("python ego_agent_training/run.py \
-    algorithm=ppo_ego/lbf task=lbf label=test_ppo_ego \
     algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_EGO_TRAIN_SEEDS=1 \
     algorithm.partner_agent.ippo.path=$PARTNER_PATH \
     run_heldout_eval=false \

--- a/teammate_generation/BRDiv.py
+++ b/teammate_generation/BRDiv.py
@@ -551,16 +551,20 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 (_, (value_loss_conf, pg_loss_conf, entropy_conf)), (_, (value_loss_br, pg_loss_br, entropy_br)) = all_losses
 
                 # Metrics
-                metric = traj_batch_conf.info
+                def mask_and_mean(x, mask):
+                    return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+                
+                mask = traj_batch_conf.info.get("returned_episode", jnp.ones_like(traj_batch_conf.reward))
+                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_conf.info)
                 metric["update_steps"] = update_steps
-                metric["value_loss_conf_agent"] = value_loss_conf
-                metric["value_loss_br_agent"] = value_loss_br
+                metric["value_loss_conf_agent"] = value_loss_conf.mean(axis=(0, 1))
+                metric["value_loss_br_agent"] = value_loss_br.mean(axis=(0, 1))
 
-                metric["pg_loss_conf_agent"] = pg_loss_conf
-                metric["pg_loss_br_agent"] = pg_loss_br
+                metric["pg_loss_conf_agent"] = pg_loss_conf.mean(axis=(0, 1))
+                metric["pg_loss_br_agent"] = pg_loss_br.mean(axis=(0, 1))
 
-                metric["entropy_conf"] = entropy_conf
-                metric["entropy_br"] = entropy_br
+                metric["entropy_conf"] = entropy_conf.mean(axis=(0, 1))
+                metric["entropy_br"] = entropy_br.mean(axis=(0, 1))
 
                 new_runner_state = (
                     all_train_state_conf, all_train_state_br,
@@ -764,8 +768,8 @@ def run_brdiv(config, wandb_logger):
 
 def log_metrics(config, outs, logger, metric_names: tuple):
     metrics = outs["metrics"]
-    # metrics now has shape (num_seeds, num_updates, _, _, pop_size)
-    num_seeds, num_updates, _, _, pop_size = metrics["pg_loss_conf_agent"].shape # number of trained pairs
+    # metrics now has shape (num_seeds, num_updates, pop_size)
+    num_seeds, num_updates, pop_size = metrics["pg_loss_conf_agent"].shape # number of trained pairs
 
     ### Log evaluation metrics
     # we plot XP return curves separately from SP return curves
@@ -796,12 +800,12 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     # shape (num_seeds, num_updates, update_epochs, num_minibatches, pop_size)
     # Average over seeds
     processed_losses = {
-        "ConfPGLoss": np.asarray(metrics["pg_loss_conf_agent"]).mean(axis=(0, 2, 3)).transpose(),
-        "BRPGLoss": np.asarray(metrics["pg_loss_br_agent"]).mean(axis=(0, 2, 3)).transpose(),
-        "ConfValLoss": np.asarray(metrics["value_loss_conf_agent"]).mean(axis=(0, 2, 3)).transpose(),
-        "BRValLoss": np.asarray(metrics["value_loss_br_agent"]).mean(axis=(0, 2, 3)).transpose(),
-        "ConfEntropy": np.asarray(metrics["entropy_conf"]).mean(axis=(0, 2, 3)).transpose(),
-        "BREntropy": np.asarray(metrics["entropy_br"]).mean(axis=(0, 2, 3)).transpose(),
+        "ConfPGLoss": np.asarray(metrics["pg_loss_conf_agent"]).mean(axis=0).transpose(),
+        "BRPGLoss": np.asarray(metrics["pg_loss_br_agent"]).mean(axis=0).transpose(),
+        "ConfValLoss": np.asarray(metrics["value_loss_conf_agent"]).mean(axis=0).transpose(),
+        "BRValLoss": np.asarray(metrics["value_loss_br_agent"]).mean(axis=0).transpose(),
+        "ConfEntropy": np.asarray(metrics["entropy_conf"]).mean(axis=0).transpose(),
+        "BREntropy": np.asarray(metrics["entropy_br"]).mean(axis=0).transpose(),
     }
 
     xs = list(range(num_updates))

--- a/teammate_generation/CoMeDi.py
+++ b/teammate_generation/CoMeDi.py
@@ -870,19 +870,23 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                     )
 
                     # Metrics
-                    metric = traj_batch_xp.info
+                    def mask_and_mean(x, mask):
+                        return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+                    
+                    mask = traj_batch_xp.info.get("returned_episode", jnp.ones_like(traj_batch_xp.reward))
+                    metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_xp.info)
                     metric["update_steps"] = update_steps
-                    metric["value_loss_conf_xp"] = conf_value_loss_xp
-                    metric["value_loss_conf_sp"] = conf_value_loss_sp
-                    metric["value_loss_conf_mp"] = conf_value_loss_mp
+                    metric["value_loss_conf_xp"] = conf_value_loss_xp.mean()
+                    metric["value_loss_conf_sp"] = conf_value_loss_sp.mean()
+                    metric["value_loss_conf_mp"] = conf_value_loss_mp.mean()
 
-                    metric["pg_loss_conf_xp"] = conf_pg_loss_xp
-                    metric["pg_loss_conf_sp"] = conf_pg_loss_sp
-                    metric["pg_loss_conf_mp"] = conf_pg_loss_mp
+                    metric["pg_loss_conf_xp"] = conf_pg_loss_xp.mean()
+                    metric["pg_loss_conf_sp"] = conf_pg_loss_sp.mean()
+                    metric["pg_loss_conf_mp"] = conf_pg_loss_mp.mean()
 
-                    metric["entropy_conf_xp"] = conf_entropy_xp
-                    metric["entropy_conf_sp"] = conf_entropy_sp
-                    metric["entropy_conf_mp"] = conf_entropy_mp
+                    metric["entropy_conf_xp"] = conf_entropy_xp.mean()
+                    metric["entropy_conf_sp"] = conf_entropy_sp.mean()
+                    metric["entropy_conf_mp"] = conf_entropy_mp.mean()
 
                     metric["average_rewards_ego"] = jnp.mean(traj_batch_xp.reward)
                     metric["average_rewards_br_sp"] = jnp.mean(traj_batch_sp_agent1.reward)
@@ -1087,7 +1091,7 @@ def compute_sp_mask_and_ids(pop_size):
 def log_metrics(config, outs, logger, metric_names: tuple):
     metrics = outs["metrics"]
     # trained_pop_size excludes the initial policy
-    num_seeds, pop_size, num_updates, _, _ = metrics["pg_loss_conf_sp"].shape
+    num_seeds, pop_size, num_updates = metrics["pg_loss_conf_sp"].shape
     # TODO: add the eval_ep_last_info metrics
 
     ### Log evaluation metrics
@@ -1119,15 +1123,15 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     # both xp and xp metrics has shape (num_seeds, pop_size - 1, num_updates, update_epochs, num_minibatches)
     # Average over seeds
     processed_losses = {
-        "ConfPGLossSP": np.asarray(metrics["pg_loss_conf_sp"]).mean(axis=(0, 3, 4)), # desired shape (pop_size - 1, num_updates)
-        "ConfPGLossXP": np.asarray(metrics["pg_loss_conf_xp"]).mean(axis=(0, 3, 4)),
-        "ConfPGLossMP": np.asarray(metrics["pg_loss_conf_mp"]).mean(axis=(0, 3, 4)),
-        "ConfValLossSP": np.asarray(metrics["value_loss_conf_sp"]).mean(axis=(0, 3, 4)),
-        "ConfValLossXP": np.asarray(metrics["value_loss_conf_xp"]).mean(axis=(0, 3, 4)),
-        "ConfValLossMP": np.asarray(metrics["value_loss_conf_mp"]).mean(axis=(0, 3, 4)),
-        "EntropySP": np.asarray(metrics["entropy_conf_sp"]).mean(axis=(0, 3, 4)),
-        "EntropyXP": np.asarray(metrics["entropy_conf_xp"]).mean(axis=(0, 3, 4)),
-        "EntropyMP": np.asarray(metrics["entropy_conf_mp"]).mean(axis=(0, 3, 4)),
+        "ConfPGLossSP": np.asarray(metrics["pg_loss_conf_sp"]).mean(axis=0), # desired shape (pop_size - 1, num_updates)
+        "ConfPGLossXP": np.asarray(metrics["pg_loss_conf_xp"]).mean(axis=0),
+        "ConfPGLossMP": np.asarray(metrics["pg_loss_conf_mp"]).mean(axis=0),
+        "ConfValLossSP": np.asarray(metrics["value_loss_conf_sp"]).mean(axis=0),
+        "ConfValLossXP": np.asarray(metrics["value_loss_conf_xp"]).mean(axis=0),
+        "ConfValLossMP": np.asarray(metrics["value_loss_conf_mp"]).mean(axis=0),
+        "EntropySP": np.asarray(metrics["entropy_conf_sp"]).mean(axis=0),
+        "EntropyXP": np.asarray(metrics["entropy_conf_xp"]).mean(axis=0),
+        "EntropyMP": np.asarray(metrics["entropy_conf_mp"]).mean(axis=0),
     }
 
     xs = list(range(num_updates))

--- a/teammate_generation/LBRDiv.py
+++ b/teammate_generation/LBRDiv.py
@@ -792,18 +792,22 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 (_, (value_loss_conf, pg_loss_conf, entropy_conf)), (_, (value_loss_br, pg_loss_br, entropy_br)) = all_losses
 
                 # Metrics
-                metric = traj_batch_conf.info
+                def mask_and_mean(x, mask):
+                    return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
+                
+                mask = traj_batch_conf.info.get("returned_episode", jnp.ones_like(traj_batch_conf.reward))
+                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_conf.info)
                 metric["lms_vertical"] = lms_vertical
                 metric["lms_horizontal"] = lms_horizontal
                 metric["update_steps"] = update_steps
-                metric["value_loss_conf_agent"] = value_loss_conf
-                metric["value_loss_br_agent"] = value_loss_br
+                metric["value_loss_conf_agent"] = value_loss_conf.mean(axis=(0, 1))
+                metric["value_loss_br_agent"] = value_loss_br.mean(axis=(0, 1))
 
-                metric["pg_loss_conf_agent"] = pg_loss_conf
-                metric["pg_loss_br_agent"] = pg_loss_br
+                metric["pg_loss_conf_agent"] = pg_loss_conf.mean(axis=(0, 1))
+                metric["pg_loss_br_agent"] = pg_loss_br.mean(axis=(0, 1))
 
-                metric["entropy_conf"] = entropy_conf
-                metric["entropy_br"] = entropy_br
+                metric["entropy_conf"] = entropy_conf.mean(axis=(0, 1))
+                metric["entropy_br"] = entropy_br.mean(axis=(0, 1))
 
                 new_runner_state = (
                     all_train_state_conf, all_train_state_br,
@@ -1026,8 +1030,8 @@ def run_lbrdiv(config, wandb_logger):
 
 def log_metrics(config, outs, logger, metric_names: tuple):
     metrics = outs["metrics"]
-    # metrics now has shape (num_seeds, num_updates, _, _, pop_size)
-    num_seeds, num_updates, _, _, pop_size = metrics["pg_loss_conf_agent"].shape # number of trained pairs
+    # metrics now has shape (num_seeds, num_updates, pop_size)
+    num_seeds, num_updates, pop_size = metrics["pg_loss_conf_agent"].shape # number of trained pairs
 
     ### Log evaluation metrics
     all_returns = np.asarray(metrics["eval_ep_last_info"]["returned_episode_returns"])
@@ -1056,12 +1060,12 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     # shape (num_seeds, num_updates, update_epochs, num_minibatches, pop_size)
     # Average over seeds
     processed_losses = {
-        "ConfPGLoss": np.asarray(metrics["pg_loss_conf_agent"]).mean(axis=(0, 2, 3)).transpose(),
-        "BRPGLoss": np.asarray(metrics["pg_loss_br_agent"]).mean(axis=(0, 2, 3)).transpose(),
-        "ConfValLoss": np.asarray(metrics["value_loss_conf_agent"]).mean(axis=(0, 2, 3)).transpose(),
-        "BRValLoss": np.asarray(metrics["value_loss_br_agent"]).mean(axis=(0, 2, 3)).transpose(),
-        "ConfEntropy": np.asarray(metrics["entropy_conf"]).mean(axis=(0, 2, 3)).transpose(),
-        "BREntropy": np.asarray(metrics["entropy_br"]).mean(axis=(0, 2, 3)).transpose(),
+        "ConfPGLoss": np.asarray(metrics["pg_loss_conf_agent"]).mean(axis=0).transpose(),
+        "BRPGLoss": np.asarray(metrics["pg_loss_br_agent"]).mean(axis=0).transpose(),
+        "ConfValLoss": np.asarray(metrics["value_loss_conf_agent"]).mean(axis=0).transpose(),
+        "BRValLoss": np.asarray(metrics["value_loss_br_agent"]).mean(axis=0).transpose(),
+        "ConfEntropy": np.asarray(metrics["entropy_conf"]).mean(axis=0).transpose(),
+        "BREntropy": np.asarray(metrics["entropy_br"]).mean(axis=0).transpose(),
     }
 
     xs = list(range(num_updates))

--- a/teammate_generation/fcp.py
+++ b/teammate_generation/fcp.py
@@ -14,7 +14,7 @@ from agents.population_interface import AgentPopulation
 from envs import make_env
 from envs.log_wrapper import LogWrapper
 from marl.ippo import make_train as make_ppo_train
-from common.plot_utils import get_metric_names, get_stats
+from common.plot_utils import get_metric_names
 from common.save_load_utils import save_train_run
 
 log = logging.getLogger(__name__)
@@ -88,15 +88,17 @@ def run_fcp(config, wandb_logger):
 def log_metrics(config, out, logger):
     '''Log statistics, save train run output and log to wandb as artifact.'''
     metric_names = get_metric_names(config["ENV_NAME"])
-    # metrics is a pytree where each leaf has shape
-    # (num_seeds, partner_pop_size, num_partner_updates, rollout_length, agents_per_env * num_envs)
+    # After mask_and_mean in ippo, metrics have shape
+    # (num_seeds, partner_pop_size, num_partner_updates)
     partner_metrics = out["metrics"]
     num_partner_updates = partner_metrics["returned_episode_returns"].shape[2]
-    # Extract partner train stats
-    num_controlled_actors = config["algorithm"]["NUM_ENVS"]
-    partner_metrics = jax.tree.map(lambda x: x[..., :num_controlled_actors], partner_metrics)
-    partner_stats = get_stats(partner_metrics, metric_names) # shape (num_seeds, partner_pop_size, num_partner_updates, 2)
-    partner_stat_means = jax.tree.map(lambda x: np.mean(x, axis=(0, 1))[..., 0], partner_stats) # shape (num_partner_updates)
+
+    # Average over seeds and pop members → (num_partner_updates,)
+    partner_stat_means = {
+        stat_name: np.mean(np.asarray(partner_metrics[stat_name]), axis=(0, 1))
+        for stat_name in metric_names
+        if stat_name in partner_metrics
+    }
 
     for step in range(num_partner_updates):
         for stat_name, stat_data in partner_stat_means.items():


### PR DESCRIPTION
This PR reduces OOM issues resulting from the large number of metrics maintained over JAX scan iterations. The fix is to take the mean over metric values within each iteration. 

Testing:
- Full run of ippo [here](https://wandb.ai/aht-project/aht-benchmark/runs/5uv5t72u), confirming no performance regression due to logging changes. 
- I also added a test script to perform short debug runs of all algorithms, confirming that all methods still run. 

Further details: 

**Problem**: jax.lax.scan was accumulating the full traj_batch.info dict (shape ROLLOUT_LENGTH × NUM_ENVS per step) across all update steps, causing memory usage to scale as O(NUM_UPDATES × ROLLOUT_LENGTH × NUM_ENVS) — large enough to OOM under multi-seed runs with long horizons.

**Fix**: Inside each algorithm's _update_step, reduce every info metric to a scalar before returning it from the scan body using a mask_and_mean helper. This correctly averages only over episode-terminal steps (avoiding the length-weighted bias that a naive .mean() would introduce). Loss terms are similarly reduced with .mean().

The downstream log_metrics functions is updated throughout to expect the new (num_seeds, num_updates[, ...]) shapes instead of the old shapes that included UPDATE_EPOCHS and NUM_MINIBATCHES axes. plot_utils.get_stats updated to handle pre-averaged scalar metrics.

Test script: scripts/test_algos.sh added — runs smoke tests for all 10 algorithms in parallel across available GPUs (≥20 GB free), with per-job logs, pass/fail summary.
