### PR TITLE
fixes to reduce LBRDiv memory usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ results*/
 eval_teammates/
 val_teammates/
 wandb/
-.vscode/
 
 # Human data raw
 human_data_collecting/collected_data_prolific/
@@ -23,3 +22,8 @@ __pycache__/
 *.pyc
 dist/
 build/
+
+# Coding editor things
+CLAUDE.md
+.claude/
+.vscode/

--- a/teammate_generation/LBRDiv.py
+++ b/teammate_generation/LBRDiv.py
@@ -464,250 +464,11 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     (minibatches_conf, minibatches_br, repeated_lms_vertical, repeated_lms_horizontal)
                 )
 
-                def compute_lagrange_grads_same(params_br, batch, target_value, ids):
-                    '''
-                    conf_id: int
-                    br_id: int
-                    batch: a pytree where all leaves have shape (rollout_len, num_envs, -1)
-                    target_value: (rollout_len, num_envs)
-                    '''
-                    conf_id, br_id = ids
-
-                    all_target_value = jnp.reshape(
-                        target_value, (-1, 1)
-                    )
-
-                    repeated_value_sp = jnp.repeat(
-                        jnp.reshape(all_target_value, (1, -1)),
-                        config["PARTNER_POP_SIZE"],
-                        axis=0
-                    )
-
-                    ##### Compute grad_sp_vary_conf
-                    relevant_conf_params = gather_params(params_br, jnp.reshape(conf_id, (1,)))
-                    relevant_conf_params = jax.tree.map(lambda x: jnp.squeeze(x, 0), relevant_conf_params)
-                    def _get_value_xp_vary_conf(param, agent_onehot_id):
-                        ts, bs = batch.obs.shape[:2]
-                        agent_onehot_id = agent_onehot_id[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
-                        _, value_xp_vary_conf, _, _ = br_policy.get_action_value_policy(
-                            params=param,
-                            obs=batch.obs,
-                            done=batch.done,
-                            avail_actions=batch.avail_actions,
-                            hstate=init_br_hstate,
-                            rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                            aux_obs=agent_onehot_id
-                        )
-                        return value_xp_vary_conf.reshape(ts*bs)
-
-                    # For a given trajectory, identify the BR policy that generates that trajectory
-                    # For every state in the trajectory, estimate (using the value function) the ego agent's returns
-                    # when they follow the identified BR policy. Do this assuming various possible partner
-                    # confederate policies (thus, why we basically "vary" the conf policy).
-                    all_possible_value_xp_vary_conf = jax.vmap(
-                        lambda agent_id: _get_value_xp_vary_conf(relevant_conf_params, agent_id)
-                    )(jnp.eye(config["PARTNER_POP_SIZE"]))
-
-                    all_possible_value_xp_vary_conf = all_possible_value_xp_vary_conf.at[conf_id].set(
-                        repeated_value_sp[conf_id]
-                    )
-
-                    offsetting_thresholds = jnp.zeros_like(repeated_value_sp)
-                    offsetting_thresholds = offsetting_thresholds.at[conf_id].set(
-                        config["TOLERANCE_FACTOR"] * jnp.ones_like(offsetting_thresholds[conf_id])
-                    )
-                    grad_sp_vary_conf = repeated_value_sp + offsetting_thresholds  - (
-                        all_possible_value_xp_vary_conf + config["TOLERANCE_FACTOR"] * jnp.ones_like(offsetting_thresholds)
-                    )
-
-                    ##### Compute grad_sp_vary_br
-                    # This code tries to measure the expected returns of the ego agent had the BR policy been
-                    # substituted by another BR policy
-
-                    # Lets say that R_{i,-j} is the ego agent's returns when following the BR policy of the i^th pair
-                    # againts the confederate policy of the j^th pair.
-
-                    # Then grad_sp_vary_conf computes R_{i,-i} - R_{i,-j} - tolerance factor
-                    # for all possible j (note for j=i, we sub in <repeated_value_sp + offsetting_thresholds above>
-                    # R_{i,-i} with the target returns + tolerance factor so that R_{i,-i} - R_{i,-j} = 0)
-
-                    # Meanwhile grad_sp_vary_br below computes R_{i,-i} - R_{j,-i} - tolerance factor
-                    # for all possible j.
-
-                    # Vary the BR policy parameters (j) used in value computation
-                    # Use the experience generating pop id (batch.self_onehot_id) <i> as the conf ID.
-
-                    relevant_params = gather_params(params_br, jnp.arange(config["PARTNER_POP_SIZE"]))
-                    def _get_value_xp_vary_br(param):
-                        ts, bs = batch.obs.shape[:2]
-                        conf_one_hot = jnp.eye(config["PARTNER_POP_SIZE"])[conf_id]
-                        conf_one_hot = conf_one_hot[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
-                        _, value_xp_vary_br, _, _ = br_policy.get_action_value_policy(
-                            params=param,
-                            obs=batch.obs,
-                            done=batch.done,
-                            avail_actions=batch.avail_actions,
-                            hstate=init_br_hstate,
-                            rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                            aux_obs=conf_one_hot
-                        )
-                        return value_xp_vary_br.reshape(ts*bs)
-
-                    all_possible_value_xp_vary_br = jax.vmap(
-                        lambda param: _get_value_xp_vary_br(param)
-                    )(relevant_params)
-
-                    all_possible_value_xp_vary_br = jnp.reshape(
-                        all_possible_value_xp_vary_br, (config["PARTNER_POP_SIZE"], -1)
-                    )
-                    all_possible_value_xp_vary_br = all_possible_value_xp_vary_br.at[conf_id].set(
-                        repeated_value_sp[conf_id]
-                    )
-
-                    grad_sp_vary_br = repeated_value_sp + offsetting_thresholds - (
-                        all_possible_value_xp_vary_br + config["TOLERANCE_FACTOR"] * jnp.ones_like(offsetting_thresholds)
-                    )
-
-                    #### Compute loss weights
-                    all_self_id_int = jnp.reshape(
-                        batch.self_onehot_id, (-1, jnp.shape(batch.self_onehot_id)[-1])
-                    ).argmax(axis=-1)
-
-                    all_oppo_id_int = jnp.reshape(
-                        batch.oppo_onehot_id, (-1, jnp.shape(batch.oppo_onehot_id)[-1])
-                    ).argmax(axis=-1)
-
-                    # check if self and oppo ids both correspond to the confederate for the self-play update
-                    self_is_conf = jnp.equal(all_self_id_int, conf_id).astype(jnp.float32)
-                    oppo_is_conf = jnp.equal(all_oppo_id_int, conf_id).astype(jnp.float32)
-                    loss_weights = self_is_conf * oppo_is_conf
-                    repeated_loss_weights = jnp.repeat(
-                        jnp.expand_dims(loss_weights, axis=0),
-                        config["PARTNER_POP_SIZE"],
-                        axis=0
-                    )
-
-                    # Compute vertical and horizontal gradients
-                    vertical_grads = jnp.sum(grad_sp_vary_conf * repeated_loss_weights, axis=-1)/(jnp.sum(loss_weights) + 1e-8)
-                    horizontal_grads = jnp.sum(grad_sp_vary_br * repeated_loss_weights, axis=-1)/(jnp.sum(loss_weights) + 1e-8)
-
-                    output_grad_matrix_vertical = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
-                    output_grad_matrix_horizontal = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
-
-                    output_grad_matrix_vertical = output_grad_matrix_vertical.at[conf_id].set(vertical_grads)
-                    output_grad_matrix_horizontal = output_grad_matrix_horizontal.at[conf_id].set(horizontal_grads)
-
-                    return output_grad_matrix_vertical, output_grad_matrix_horizontal
-
-                def compute_lagrange_grads_diff(params_br, batch, target_returns, ids):
-                    conf_id, br_id = ids
-                    param_conf_id = gather_params(params_br, jnp.reshape(conf_id, (1,)))
-                    param_br_id = gather_params(params_br, jnp.reshape(br_id, (1,)))
-
-                    param_br_id = jax.tree.map(lambda x: jnp.squeeze(x, 0), param_br_id)
-                    param_conf_id = jax.tree.map(lambda x: jnp.squeeze(x, 0), param_conf_id)
-
-                    all_self_id_int = jnp.reshape(
-                        batch.self_onehot_id, (-1, jnp.shape(batch.self_onehot_id)[-1])
-                    ).argmax(axis=-1)
-
-                    all_oppo_id_int = jnp.reshape(
-                        batch.oppo_onehot_id, (-1, jnp.shape(batch.oppo_onehot_id)[-1])
-                    ).argmax(axis=-1)
-
-                    all_target_returns = jnp.reshape(
-                        target_returns, (-1)
-                    )
-
-                    # Compute data weights based on whether selected ID
-                    # is relevant for the gradient computation process
-                    oppo_is_conf = jnp.equal(all_oppo_id_int, conf_id).astype(jnp.float32)
-                    self_is_br = jnp.equal(all_self_id_int, br_id).astype(jnp.float32)
-                    loss_weights = oppo_is_conf * self_is_br
-
-                    ts, bs = batch.obs.shape[:2]
-
-                    conf_one_hot = jnp.eye(config["PARTNER_POP_SIZE"])[conf_id]
-                    conf_one_hot = conf_one_hot[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
-                    br_one_hot = jnp.eye(config["PARTNER_POP_SIZE"])[br_id]
-                    br_one_hot = br_one_hot[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
-
-                    _, value_sp_pop_is_br, _, _ = br_policy.get_action_value_policy(
-                        params=param_br_id,
-                        obs=batch.obs,
-                        done=batch.done,
-                        avail_actions=batch.avail_actions,
-                        hstate=init_br_hstate,
-                        rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                        aux_obs=br_one_hot
-                    )
-                    value_sp_pop_is_br = value_sp_pop_is_br.reshape(bs*ts)
-
-                    _, value_sp_pop_is_not_br, _, _ = br_policy.get_action_value_policy(
-                        params=param_conf_id,
-                        obs=batch.obs,
-                        done=batch.done,
-                        avail_actions=batch.avail_actions,
-                        hstate=init_br_hstate,
-                        rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                        aux_obs=conf_one_hot
-                    )
-                    value_sp_pop_is_not_br = value_sp_pop_is_not_br.reshape(bs*ts)
-                     # Compute V_{b_id, b_id} - V_{c_id, br_id} - tolerance_factor
-                     # which will be the gradient for lm_vertical[b_id][c_id] in the Lagrange dual objective
-                    vertical_diff = value_sp_pop_is_br - all_target_returns - config["TOLERANCE_FACTOR"]
-
-                    # Compute V_{c_id, c_id} - V_{c_id, br_id} - tolerance_factor
-                    # which will be the gradient for lm_horizontal[b_id][c_id] in the Lagrange dual objective
-                    horizontal_diff = value_sp_pop_is_not_br - all_target_returns - config["TOLERANCE_FACTOR"]
-
-                    total_grad_vertical = (loss_weights * vertical_diff).sum()/(loss_weights.sum() + 1e-8)
-                    total_grad_horizontal = (loss_weights * horizontal_diff).sum()/(loss_weights.sum() + 1e-8)
-
-                    output_grad_matrix_vertical = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
-                    output_grad_matrix_horizontal = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
-
-                    output_grad_matrix_vertical = output_grad_matrix_vertical.at[br_id, conf_id].set(total_grad_vertical)
-                    output_grad_matrix_horizontal = output_grad_matrix_horizontal.at[conf_id, br_id].set(total_grad_horizontal)
-
-                    return output_grad_matrix_vertical, output_grad_matrix_horizontal
-
-                def _compute_indiv_lagrange_grads(conf_id, br_id):
-                    return jax.lax.cond(
-                    conf_id == br_id,
-                    lambda ids: compute_lagrange_grads_same(train_state_br.params, traj_batch_br, targets_br, ids),
-                    lambda ids: compute_lagrange_grads_diff(train_state_br.params, traj_batch_br, targets_br, ids),
-                    (conf_id, br_id)
-                )
-
-                all_conf_ids, all_br_ids = _get_all_ids(config["PARTNER_POP_SIZE"])
-                all_lagrange_grads = jax.vmap(_compute_indiv_lagrange_grads)(all_conf_ids, all_br_ids)
-                averaged_grad_vertical = jnp.sum(all_lagrange_grads[0], axis=0)
-                averaged_grad_horizontal = jnp.sum(all_lagrange_grads[1], axis=0)
-
-                lms_vertical_new = jnp.maximum(
-                    lms_vertical - config["LAGRANGE_LR"] * averaged_grad_vertical,
-                    0.5 * jnp.eye(config["PARTNER_POP_SIZE"])
-                )
-                lms_vertical_new = jnp.fill_diagonal(
-                    lms_vertical_new, 0.5 * jnp.ones((config["PARTNER_POP_SIZE"]), dtype=jnp.float32),
-                    inplace=False
-                )
-
-                lms_horizontal_new = jnp.maximum(
-                    lms_horizontal - config["LAGRANGE_LR"] * averaged_grad_horizontal,
-                    0.5 * jnp.eye(config["PARTNER_POP_SIZE"]),
-                )
-                lms_horizontal_new = jnp.fill_diagonal(
-                    lms_horizontal_new, 0.5 * jnp.ones((config["PARTNER_POP_SIZE"]), dtype=jnp.float32),
-                    inplace=False
-                )
-
                 update_state = (train_state_conf, train_state_br,
                     traj_batch_conf, traj_batch_br,
                     advantages_conf, advantages_br,
                     targets_conf, targets_br,
-                    rng, lms_vertical_new, lms_horizontal_new
+                    rng, lms_vertical, lms_horizontal
                 )
                 return update_state, all_losses
 
@@ -789,6 +550,210 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
                 all_train_state_conf, all_train_state_br = update_state[:2]
                 lms_vertical, lms_horizontal = update_state[-2:]
+
+                # Compute Lagrange gradient updates once per update step (after all PPO epochs).
+                # Diagonal and off-diagonal pairs use separate vmaps to avoid evaluating both
+                # branches of lax.cond for all pop_size^2 elements under vmap.
+                def compute_lagrange_grads_same(params_br, batch, target_value, ids):
+                    conf_id, br_id = ids
+
+                    all_target_value = jnp.reshape(target_value, (-1, 1))
+                    repeated_value_sp = jnp.repeat(
+                        jnp.reshape(all_target_value, (1, -1)),
+                        config["PARTNER_POP_SIZE"],
+                        axis=0
+                    )
+
+                    relevant_conf_params = gather_params(params_br, jnp.reshape(conf_id, (1,)))
+                    relevant_conf_params = jax.tree.map(lambda x: jnp.squeeze(x, 0), relevant_conf_params)
+                    def _get_value_xp_vary_conf(param, agent_onehot_id):
+                        ts, bs = batch.obs.shape[:2]
+                        agent_onehot_id = agent_onehot_id[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
+                        _, value_xp_vary_conf, _, _ = br_policy.get_action_value_policy(
+                            params=param,
+                            obs=batch.obs,
+                            done=batch.done,
+                            avail_actions=batch.avail_actions,
+                            hstate=init_br_hstate,
+                            rng=jax.random.PRNGKey(0),
+                            aux_obs=agent_onehot_id
+                        )
+                        return value_xp_vary_conf.reshape(ts*bs)
+
+                    all_possible_value_xp_vary_conf = jax.vmap(
+                        lambda agent_id: _get_value_xp_vary_conf(relevant_conf_params, agent_id)
+                    )(jnp.eye(config["PARTNER_POP_SIZE"]))
+                    all_possible_value_xp_vary_conf = all_possible_value_xp_vary_conf.at[conf_id].set(
+                        repeated_value_sp[conf_id]
+                    )
+
+                    offsetting_thresholds = jnp.zeros_like(repeated_value_sp)
+                    offsetting_thresholds = offsetting_thresholds.at[conf_id].set(
+                        config["TOLERANCE_FACTOR"] * jnp.ones_like(offsetting_thresholds[conf_id])
+                    )
+                    grad_sp_vary_conf = repeated_value_sp + offsetting_thresholds - (
+                        all_possible_value_xp_vary_conf + config["TOLERANCE_FACTOR"] * jnp.ones_like(offsetting_thresholds)
+                    )
+
+                    relevant_params = gather_params(params_br, jnp.arange(config["PARTNER_POP_SIZE"]))
+                    def _get_value_xp_vary_br(param):
+                        ts, bs = batch.obs.shape[:2]
+                        conf_one_hot = jnp.eye(config["PARTNER_POP_SIZE"])[conf_id]
+                        conf_one_hot = conf_one_hot[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
+                        _, value_xp_vary_br, _, _ = br_policy.get_action_value_policy(
+                            params=param,
+                            obs=batch.obs,
+                            done=batch.done,
+                            avail_actions=batch.avail_actions,
+                            hstate=init_br_hstate,
+                            rng=jax.random.PRNGKey(0),
+                            aux_obs=conf_one_hot
+                        )
+                        return value_xp_vary_br.reshape(ts*bs)
+
+                    all_possible_value_xp_vary_br = jax.vmap(
+                        lambda param: _get_value_xp_vary_br(param)
+                    )(relevant_params)
+                    all_possible_value_xp_vary_br = jnp.reshape(
+                        all_possible_value_xp_vary_br, (config["PARTNER_POP_SIZE"], -1)
+                    )
+                    all_possible_value_xp_vary_br = all_possible_value_xp_vary_br.at[conf_id].set(
+                        repeated_value_sp[conf_id]
+                    )
+
+                    grad_sp_vary_br = repeated_value_sp + offsetting_thresholds - (
+                        all_possible_value_xp_vary_br + config["TOLERANCE_FACTOR"] * jnp.ones_like(offsetting_thresholds)
+                    )
+
+                    all_self_id_int = jnp.reshape(
+                        batch.self_onehot_id, (-1, jnp.shape(batch.self_onehot_id)[-1])
+                    ).argmax(axis=-1)
+                    all_oppo_id_int = jnp.reshape(
+                        batch.oppo_onehot_id, (-1, jnp.shape(batch.oppo_onehot_id)[-1])
+                    ).argmax(axis=-1)
+
+                    self_is_conf = jnp.equal(all_self_id_int, conf_id).astype(jnp.float32)
+                    oppo_is_conf = jnp.equal(all_oppo_id_int, conf_id).astype(jnp.float32)
+                    loss_weights = self_is_conf * oppo_is_conf
+                    repeated_loss_weights = jnp.repeat(
+                        jnp.expand_dims(loss_weights, axis=0),
+                        config["PARTNER_POP_SIZE"],
+                        axis=0
+                    )
+
+                    vertical_grads = jnp.sum(grad_sp_vary_conf * repeated_loss_weights, axis=-1) / (jnp.sum(loss_weights) + 1e-8)
+                    horizontal_grads = jnp.sum(grad_sp_vary_br * repeated_loss_weights, axis=-1) / (jnp.sum(loss_weights) + 1e-8)
+
+                    output_grad_matrix_vertical = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
+                    output_grad_matrix_horizontal = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
+                    output_grad_matrix_vertical = output_grad_matrix_vertical.at[conf_id].set(vertical_grads)
+                    output_grad_matrix_horizontal = output_grad_matrix_horizontal.at[conf_id].set(horizontal_grads)
+                    return output_grad_matrix_vertical, output_grad_matrix_horizontal
+
+                def compute_lagrange_grads_diff(params_br, batch, target_returns, ids):
+                    conf_id, br_id = ids
+                    param_conf_id = gather_params(params_br, jnp.reshape(conf_id, (1,)))
+                    param_br_id = gather_params(params_br, jnp.reshape(br_id, (1,)))
+                    param_br_id = jax.tree.map(lambda x: jnp.squeeze(x, 0), param_br_id)
+                    param_conf_id = jax.tree.map(lambda x: jnp.squeeze(x, 0), param_conf_id)
+
+                    all_self_id_int = jnp.reshape(
+                        batch.self_onehot_id, (-1, jnp.shape(batch.self_onehot_id)[-1])
+                    ).argmax(axis=-1)
+                    all_oppo_id_int = jnp.reshape(
+                        batch.oppo_onehot_id, (-1, jnp.shape(batch.oppo_onehot_id)[-1])
+                    ).argmax(axis=-1)
+                    all_target_returns = jnp.reshape(target_returns, (-1))
+
+                    oppo_is_conf = jnp.equal(all_oppo_id_int, conf_id).astype(jnp.float32)
+                    self_is_br = jnp.equal(all_self_id_int, br_id).astype(jnp.float32)
+                    loss_weights = oppo_is_conf * self_is_br
+
+                    ts, bs = batch.obs.shape[:2]
+                    conf_one_hot = jnp.eye(config["PARTNER_POP_SIZE"])[conf_id]
+                    conf_one_hot = conf_one_hot[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
+                    br_one_hot = jnp.eye(config["PARTNER_POP_SIZE"])[br_id]
+                    br_one_hot = br_one_hot[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
+
+                    _, value_sp_pop_is_br, _, _ = br_policy.get_action_value_policy(
+                        params=param_br_id,
+                        obs=batch.obs,
+                        done=batch.done,
+                        avail_actions=batch.avail_actions,
+                        hstate=init_br_hstate,
+                        rng=jax.random.PRNGKey(0),
+                        aux_obs=br_one_hot
+                    )
+                    value_sp_pop_is_br = value_sp_pop_is_br.reshape(bs*ts)
+
+                    _, value_sp_pop_is_not_br, _, _ = br_policy.get_action_value_policy(
+                        params=param_conf_id,
+                        obs=batch.obs,
+                        done=batch.done,
+                        avail_actions=batch.avail_actions,
+                        hstate=init_br_hstate,
+                        rng=jax.random.PRNGKey(0),
+                        aux_obs=conf_one_hot
+                    )
+                    value_sp_pop_is_not_br = value_sp_pop_is_not_br.reshape(bs*ts)
+
+                    vertical_diff = value_sp_pop_is_br - all_target_returns - config["TOLERANCE_FACTOR"]
+                    horizontal_diff = value_sp_pop_is_not_br - all_target_returns - config["TOLERANCE_FACTOR"]
+
+                    total_grad_vertical = (loss_weights * vertical_diff).sum() / (loss_weights.sum() + 1e-8)
+                    total_grad_horizontal = (loss_weights * horizontal_diff).sum() / (loss_weights.sum() + 1e-8)
+
+                    output_grad_matrix_vertical = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
+                    output_grad_matrix_horizontal = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
+                    output_grad_matrix_vertical = output_grad_matrix_vertical.at[br_id, conf_id].set(total_grad_vertical)
+                    output_grad_matrix_horizontal = output_grad_matrix_horizontal.at[conf_id, br_id].set(total_grad_horizontal)
+                    return output_grad_matrix_vertical, output_grad_matrix_horizontal
+
+                # Diagonal pairs (conf_id == br_id): vmap over pop_size elements only
+                diag_ids = np.arange(config["PARTNER_POP_SIZE"])
+                diag_lagrange_grads = jax.vmap(
+                    lambda conf_id, br_id: compute_lagrange_grads_same(
+                        all_train_state_br.params, traj_batch_br, targets_br, (conf_id, br_id)
+                    )
+                )(diag_ids, diag_ids)
+
+                # Off-diagonal pairs (conf_id != br_id): vmap over pop_size*(pop_size-1) elements only
+                all_conf_ids_np, all_br_ids_np = _get_all_ids(config["PARTNER_POP_SIZE"])
+                off_diag_mask = all_conf_ids_np != all_br_ids_np
+                off_diag_conf_ids = all_conf_ids_np[off_diag_mask]
+                off_diag_br_ids = all_br_ids_np[off_diag_mask]
+                off_diag_lagrange_grads = jax.vmap(
+                    lambda conf_id, br_id: compute_lagrange_grads_diff(
+                        all_train_state_br.params, traj_batch_br, targets_br, (conf_id, br_id)
+                    )
+                )(off_diag_conf_ids, off_diag_br_ids)
+
+                averaged_grad_vertical = (
+                    jnp.sum(diag_lagrange_grads[0], axis=0) +
+                    jnp.sum(off_diag_lagrange_grads[0], axis=0)
+                )
+                averaged_grad_horizontal = (
+                    jnp.sum(diag_lagrange_grads[1], axis=0) +
+                    jnp.sum(off_diag_lagrange_grads[1], axis=0)
+                )
+
+                lms_vertical = jnp.maximum(
+                    lms_vertical - config["LAGRANGE_LR"] * averaged_grad_vertical,
+                    0.5 * jnp.eye(config["PARTNER_POP_SIZE"])
+                )
+                lms_vertical = jnp.fill_diagonal(
+                    lms_vertical, 0.5 * jnp.ones((config["PARTNER_POP_SIZE"]), dtype=jnp.float32),
+                    inplace=False
+                )
+                lms_horizontal = jnp.maximum(
+                    lms_horizontal - config["LAGRANGE_LR"] * averaged_grad_horizontal,
+                    0.5 * jnp.eye(config["PARTNER_POP_SIZE"]),
+                )
+                lms_horizontal = jnp.fill_diagonal(
+                    lms_horizontal, 0.5 * jnp.ones((config["PARTNER_POP_SIZE"]), dtype=jnp.float32),
+                    inplace=False
+                )
+
                 (_, (value_loss_conf, pg_loss_conf, entropy_conf)), (_, (value_loss_br, pg_loss_br, entropy_br)) = all_losses
 
                 # Metrics

--- a/teammate_generation/LBRDiv.py
+++ b/teammate_generation/LBRDiv.py
@@ -476,7 +476,8 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 """
                 1. Collect rollouts
                 2. Compute advantage
-                3. PPO updates
+                3. PPO updates (UPDATE_EPOCHS epochs)
+                4. Lagrange multiplier update (once, after all PPO epochs)
                 """
                 (
                     all_train_state_conf, all_train_state_br,
@@ -595,6 +596,23 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         all_possible_value_xp_vary_conf + config["TOLERANCE_FACTOR"] * jnp.ones_like(offsetting_thresholds)
                     )
 
+                    ##### Compute grad_sp_vary_br
+                    # This code tries to measure the expected returns of the ego agent had the BR policy been
+                    # substituted by another BR policy
+
+                    # Lets say that R_{i,-j} is the ego agent's returns when following the BR policy of the i^th pair
+                    # againts the confederate policy of the j^th pair.
+
+                    # Then grad_sp_vary_conf computes R_{i,-i} - R_{i,-j} - tolerance factor
+                    # for all possible j (note for j=i, we sub in <repeated_value_sp + offsetting_thresholds above>
+                    # R_{i,-i} with the target returns + tolerance factor so that R_{i,-i} - R_{i,-j} = 0)
+
+                    # Meanwhile grad_sp_vary_br below computes R_{i,-i} - R_{j,-i} - tolerance factor
+                    # for all possible j.
+
+                    # Vary the BR policy parameters (j) used in value computation
+                    # Use the experience generating pop id (batch.self_onehot_id) <i> as the conf ID.
+
                     relevant_params = gather_params(params_br, jnp.arange(config["PARTNER_POP_SIZE"]))
                     def _get_value_xp_vary_br(param):
                         ts, bs = batch.obs.shape[:2]
@@ -606,7 +624,7 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                             done=batch.done,
                             avail_actions=batch.avail_actions,
                             hstate=init_br_hstate,
-                            rng=jax.random.PRNGKey(0),
+                            rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
                             aux_obs=conf_one_hot
                         )
                         return value_xp_vary_br.reshape(ts*bs)
@@ -641,6 +659,7 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         axis=0
                     )
 
+                    # Compute vertical and horizontal gradient
                     vertical_grads = jnp.sum(grad_sp_vary_conf * repeated_loss_weights, axis=-1) / (jnp.sum(loss_weights) + 1e-8)
                     horizontal_grads = jnp.sum(grad_sp_vary_br * repeated_loss_weights, axis=-1) / (jnp.sum(loss_weights) + 1e-8)
 
@@ -665,6 +684,8 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     ).argmax(axis=-1)
                     all_target_returns = jnp.reshape(target_returns, (-1))
 
+                    # Compute data weights based on whether selected ID
+                    # is relevant for the gradient computation process
                     oppo_is_conf = jnp.equal(all_oppo_id_int, conf_id).astype(jnp.float32)
                     self_is_br = jnp.equal(all_self_id_int, br_id).astype(jnp.float32)
                     loss_weights = oppo_is_conf * self_is_br


### PR DESCRIPTION
LBRDiv ran significantly slower and OOM'd far more frequently than BRDiv under the same hyperparameters, despite having the same overall training structure.

### Testing on LBF

W/o issue 2 fix: https://wandb.ai/aht-project/aht-benchmark/runs/f32ws8fq
W/ issue 2 fix: https://wandb.ai/aht-project/aht-benchmark/runs/k7rhfggs

Smoke-tested with the standard debug config (TOTAL_TIMESTEPS=2e5, PARTNER_POP_SIZE=2, NUM_SEEDS=1). Ran end-to-end without errors. 

### Issues
1. jax.vmap over jax.lax.cond → O(pop_size³) forward passes

The Lagrange gradient computation used jax.vmap(_compute_indiv_lagrange_grads)(all_conf_ids, all_br_ids), where _compute_indiv_lagrange_grads contained a jax.lax.cond branch. Under JAX semantics, vmap over lax.cond evaluates both branches for all pop_size² elements and selects results afterward — it does not short-circuit. Since compute_lagrange_grads_same itself contains two nested vmaps over pop_size, this caused ~2×pop_size³ value function calls per Lagrange update instead of the intended ~2×pop_size².

2. Lagrange updates ran UPDATE_EPOCHS times per update step

The full Lagrange gradient computation lived inside _update_epoch, which is scanned UPDATE_EPOCHS times per update step. This multiplied the already expensive O(pop_size³) computation by UPDATE_EPOCHS unnecessarily. BRDiv's _update_epoch only does the PPO minibatch scan.

### Fixes
Issue 1: Replaced the vmap+lax.cond pattern with two separate vmaps — one over the pop_size diagonal pairs (calling compute_lagrange_grads_same) and one over the pop_size*(pop_size-1) off-diagonal pairs (calling compute_lagrange_grads_diff). Their gradient matrices are summed to produce the same result, reducing Lagrange forward passes from O(pop_size³) to O(pop_size²).

Issue 2: Moved the Lagrange gradient computation out of _update_epoch and into _update_step, so it executes once per update step after all PPO epochs complete. The epoch scan is now pure PPO. The fixed LM values from the start of each update step are used for actor weight computation during PPO (consistent with standard Lagrangian dual gradient ascent practice).

