### PR TITLE
Populate BR metrics for lbf-12x12

### DIFF
--- a/evaluation/configs/global_heldout_settings.yaml
+++ b/evaluation/configs/global_heldout_settings.yaml
@@ -105,24 +105,24 @@ heldout_set:
     entitled_agent:
       actor_type: entitled_agent
       performance_bounds:
-        percent_eaten: [0.0, 100.0]
-        returned_episode_returns: [0.0, 0.5]
+        percent_eaten: [0.0, 98.77]
+        returned_episode_returns: [0.0, 0.49]
     greedy_closest_teammate:
       actor_type: greedy_agent
       heuristic: closest_teammate
       performance_bounds:
         percent_eaten: [0.0, 100.0]
         returned_episode_returns: [0.0, 0.5]
-  lbf/lbf_12x12: # TODO - update performance bounds when available
-    ippo_mlp: 
+  lbf/lbf_12x12:
+    ippo_mlp:
       path: "eval_teammates/lbf/ippo/ippo-lbf-12-levels/saved_train_run"
       actor_type: mlp
       ckpt_key: final_params
       idx_list: [0] # load in seed 0 only
       test_mode: false
-      performance_bounds: # TODO: placeholder bounds
-        percent_eaten: [[0.0, 100.0]]
-        returned_episode_returns: [[0.0, 0.5]]
+      performance_bounds:
+        percent_eaten: [[0.0, 96.53]]
+        returned_episode_returns: [[0.0, 0.48]]
     ippo_mlp_s2c1:
       path: "eval_teammates/lbf/ippo/ippo-lbf-12-levels/saved_train_run"
       actor_type: mlp
@@ -138,9 +138,9 @@ heldout_set:
       ckpt_key: final_params_conf
       POP_SIZE: 10
       test_mode: false
-      performance_bounds: # TODO: placeholder bounds
-        percent_eaten: [[0.0, 100.00], [0.0, 100.0], [0.0, 100.00], [0.0, 100.00], [0.0, 99.48]]
-        returned_episode_returns: [[0.0, 0.50], [0.0, 0.50], [0.0, 0.50], [0.0, 0.50], [0.0, 0.50]]
+      performance_bounds:
+        percent_eaten: [[0.0, 76.39], [0.0, 86.11], [0.0, 81.94], [0.0, 83.00], [0.0, 80.00]]
+        returned_episode_returns: [[0.0, 0.36], [0.0, 0.43], [0.0, 0.41], [0.0, 0.42], [0.0, 0.39]]
     seq_agent_lexi:
       actor_type: seq_agent
       ordering_strategy: lexicographic

--- a/evaluation/configs/global_heldout_settings.yaml
+++ b/evaluation/configs/global_heldout_settings.yaml
@@ -104,9 +104,9 @@ heldout_set:
         returned_episode_returns: [[0.0, 0.50], [0.0, 0.32], [0.0, 0.50], [0.0, 0.50], [0.0, 0.50]]
     entitled_agent:
       actor_type: entitled_agent
-      performance_bounds:
-        percent_eaten: [0.0, 98.77]
-        returned_episode_returns: [0.0, 0.49]
+      performance_bounds: # in practice, PPO BR gets ~98% 
+        percent_eaten: [0.0, 100.0]
+        returned_episode_returns: [0.0, 0.5]
     greedy_closest_teammate:
       actor_type: greedy_agent
       heuristic: closest_teammate


### PR DESCRIPTION
  | Teammate | Run |
  |----------|-----|
  | ippo_mlp s0c6 10M (12x12) | [kind-haze-348](https://wandb.ai/aht-project/aht-benchmark/runs/yeb9d3oq) (not using this)|
  | ippo_mlp s0c6 20M (12x12) | [fluent-glade-351](https://wandb.ai/aht-project/aht-benchmark/runs/3uee1dvg)|
  | comedi t0 | [different-brook-360](https://wandb.ai/aht-project/aht-benchmark/runs/4137fh2o) |
  | comedi t1 | [tough-butterfly-385](https://wandb.ai/aht-project/aht-benchmark/runs/k0992cr3) |
  | comedi t2 | [dainty-monkey-384](https://wandb.ai/aht-project/aht-benchmark/runs/djd6ne42) |
  | comedi t3 | [clear-dew-385](https://wandb.ai/aht-project/aht-benchmark/runs/e5ftbzdw) |
  | comedi t4 | [fearless-aardvark-389](https://wandb.ai/aht-project/aht-benchmark/runs/6czd9vd2) |
  | comedi t5 | [graceful-smoke-390](https://wandb.ai/aht-project/aht-benchmark/runs/srw2s80v) |
  | comedi t6 | [young-puddle-391](https://wandb.ai/aht-project/aht-benchmark/runs/610nii21) (partial — artifact upload failed) |
  | comedi t7 | [zesty-spaceship-392](https://wandb.ai/aht-project/aht-benchmark/runs/4e8hvybs) (partial — artifact upload failed) |
  | comedi t8 | N/A (wandb upload failed) |
  | comedi t9 | N/A (wandb upload failed) |
  | entitled_agent (7x7) | [astral-violet-347](https://wandb.ai/aht-project/aht-benchmark/runs/hd30m9t9) (not using this)|
