### PR TITLE
Load ROTATE teammates for meliba

### DIFF
--- a/ego_agent_training/configs/algorithm/meliba_ego/lbf/lbf_7x7_nolevels.yaml
+++ b/ego_agent_training/configs/algorithm/meliba_ego/lbf/lbf_7x7_nolevels.yaml
@@ -4,3 +4,14 @@ defaults:
 
 TOTAL_TIMESTEPS: 3e6
 UPDATE_EPOCHS: 5
+
+partner_agent:
+  ippo: null
+  rotate:
+    path: partner_teammates/lbf_7x7_nolevels/rotate/2026-04-29_21-35-47/saved_train_run
+    actor_type: actor_with_double_critic
+    custom_loader:
+      name: open_ended
+      type: ego
+    ckpt_key: final_buffer
+    idx_list: [[0, -1]]

--- a/ego_agent_training/meliba_ego.py
+++ b/ego_agent_training/meliba_ego.py
@@ -541,7 +541,7 @@ def run_ego_training(config, wandb_logger):
     rng, init_partner_rng, init_ego_rng, train_rng = jax.random.split(rng, 4)
 
 
-    partner_agent_config = dict(algorithm_config["partner_agent"])
+    partner_agent_config = {k: v for k, v in dict(algorithm_config["partner_agent"]).items() if v is not None}
     assert len(partner_agent_config) == 1, "Only supports training against one type of partner agent."
 
     partner0_name = list(partner_agent_config.keys())[0]


### PR DESCRIPTION
Issue of loading more than one teammate since we by default load an IPPO teammate.

Setting ippo: null doesn't work directly, and we need to ignore it while parsing (this is the change in the .py file)