### PR TITLE
Fix diversity pipeline for Overcooked

### DIFF
--- a/scripts/eval_teammate_diversity/run_overcooked_coord_ring_pipeline.sh
+++ b/scripts/eval_teammate_diversity/run_overcooked_coord_ring_pipeline.sh
@@ -74,7 +74,7 @@ MODEL_DIR="results/${TASK_NAME}/models"
 OUTPUT_FILE="results/${TASK_NAME}/tsne_trajectory_visualization.png"
 
 # Default parameters for the scripts
-NUM_POINTS_PER_PAIR=100  # Episodes collected per specific-BR pair for the validation / t-SNE set
+NUM_POINTS_PER_PAIR=20  # Episodes collected per specific-BR pair for the validation / t-SNE set
 NUM_ENVS=48  # Number of parallel environments (keeps trajectory pkl under 15 GB: 48 envs × 289 pairs × 400 steps × 650 floats × 4 bytes ≈ 14.4 GB)
 HIDDEN_DIM=64  # Autoencoder hidden dimension
 LATENT_DIM=16  # Autoencoder latent dimension

--- a/scripts/eval_teammate_diversity/trajectory_collection.py
+++ b/scripts/eval_teammate_diversity/trajectory_collection.py
@@ -336,6 +336,10 @@ def collect_heldout_pairwise_trajectories(
         actor_type = agent_cfg.get("actor_type", "")
         if actor_type in HEURISTIC_ACTOR_TYPES:
             policy = initialize_heuristic_agent_from_config(agent_cfg, agent_name, task_name, env_kwargs)
+            # Trajectory collection doesn't use a log wrapper (env state is WrappedEnvState,
+            # not LogWrapper(WrappedEnvState)), so base_agent does the single unwrap itself.
+            if hasattr(policy, 'using_log_wrapper'):
+                policy.using_log_wrapper = False
             return policy, {}, {}
         policy, params, init_params, _ = initialize_rl_agent_from_config(agent_cfg, agent_name, env, rng)
         params = jax.tree_map(jnp.squeeze, params)


### PR DESCRIPTION
There was a small bug in the overcooked diversity pipeline having to do with running heuristic agents such as the independent agent. This has now been fixed. In addition, the number of trajectories collected during the validation process has been reduced to prevent OOM.