### PR TITLE
Align heldout BR paths with Hugging Face

### DIFF
--- a/evaluation/configs/global_heldout_br.yaml
+++ b/evaluation/configs/global_heldout_br.yaml
@@ -170,119 +170,119 @@ best_response_set:
 
   overcooked-v1/cramped_room:
     br_for_ippo_mlp_0:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_ippo_mlp_0_serious/2026-03-16_11-08-25/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_ippo_mlp_0_serious/2026-03-16_11-08-25/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_1:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_ippo_mlp_1_serious/2026-03-16_11-08-25/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_ippo_mlp_1_serious/2026-03-16_11-08-25/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_2:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_ippo_mlp_2_serious/2026-03-16_11-31-44/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_ippo_mlp_2_serious/2026-03-16_11-31-44/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf_0:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_brdiv_conf_0_serious/2026-03-16_11-31-44/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_brdiv_conf_0_serious/2026-03-16_11-31-44/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf_1:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_brdiv_conf_1_serious/2026-03-16_11-55-04/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_brdiv_conf_1_serious/2026-03-16_11-55-04/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_independent_agent_0_4:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_independent_agent_0_4_serious/2026-03-16_11-55-04/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_independent_agent_0_4_serious/2026-03-16_11-55-04/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_independent_agent_0:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_independent_agent_0_serious/2026-03-16_12-18-02/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_independent_agent_0_serious/2026-03-16_12-18-02/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_onion_agent_0_1:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_onion_agent_0_1_serious/2026-03-16_12-20-27/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_onion_agent_0_1_serious/2026-03-16_12-20-27/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_plate_agent_0_1:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_plate_agent_0_1_serious/2026-03-16_12-43-21/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_plate_agent_0_1_serious/2026-03-16_12-43-21/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_0:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_lbrdiv_conf_1_0_serious/2026-03-31_19-47-45/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_lbrdiv_conf_1_0_serious/2026-03-31_19-47-45/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_1:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_lbrdiv_conf_1_1_serious/2026-03-31_19-47-45/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_lbrdiv_conf_1_1_serious/2026-03-31_19-47-45/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_2:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_lbrdiv_conf_1_2_serious/2026-03-31_20-11-22/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_lbrdiv_conf_1_2_serious/2026-03-31_20-11-22/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_0:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_comedi_1_0_serious/2026-03-31_20-11-22/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_comedi_1_0_serious/2026-03-31_20-11-22/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_1:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_comedi_1_1_serious/2026-03-31_20-34-43/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_comedi_1_1_serious/2026-03-31_20-34-43/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_2:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_comedi_1_2_serious/2026-03-31_20-34-44/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_comedi_1_2_serious/2026-03-31_20-34-44/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_3:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_comedi_1_3_serious/2026-03-31_20-58-12/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_comedi_1_3_serious/2026-03-31_20-58-12/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_4:
-      path: "results/overcooked-v1/cramped_room/ppo_br_s5/cramped_room_comedi_1_4_serious/2026-03-31_20-58-12/ego_train_run"
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_comedi_1_4_serious/2026-03-31_20-58-12/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
@@ -290,119 +290,119 @@ best_response_set:
 
   overcooked-v1/asymm_advantages:
     br_for_ippo_mlp_0:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_ippo_mlp_0_serious/2026-03-16_12-44-48/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_ippo_mlp_0_serious/2026-03-16_12-44-48/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_1:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_ippo_mlp_1_serious/2026-03-16_13-08-19/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_ippo_mlp_1_serious/2026-03-16_13-08-19/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_2:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_ippo_mlp_2_serious/2026-03-16_13-12-02/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_ippo_mlp_2_serious/2026-03-16_13-12-02/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf_0:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_brdiv_conf_0_serious/2026-03-16_13-35-34/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_brdiv_conf_0_serious/2026-03-16_13-35-34/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf_1:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_brdiv_conf_1_serious/2026-03-16_13-39-19/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_brdiv_conf_1_serious/2026-03-16_13-39-19/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf_2:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_brdiv_conf_2_serious/2026-03-16_14-41-26/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_brdiv_conf_2_serious/2026-03-16_14-41-26/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_independent_agent_0:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_independent_agent_0_serious/2026-03-16_14-41-26/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_independent_agent_0_serious/2026-03-16_14-41-26/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_onion_agent_0:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_onion_agent_0_serious/2026-03-16_15-08-51/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_onion_agent_0_serious/2026-03-16_15-08-51/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_plate_agent_0:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_plate_agent_0_serious/2026-03-16_15-11-58/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_plate_agent_0_serious/2026-03-16_15-11-58/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_0:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_lbrdiv_conf_1_0_serious/2026-03-31_21-21-36/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_lbrdiv_conf_1_0_serious/2026-03-31_21-21-36/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_1:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_lbrdiv_conf_1_1_serious/2026-03-31_21-21-36/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_lbrdiv_conf_1_1_serious/2026-03-31_21-21-36/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_2:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_lbrdiv_conf_1_2_serious/2026-03-31_21-49-29/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_lbrdiv_conf_1_2_serious/2026-03-31_21-49-29/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_0:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_comedi_1_0_serious/2026-03-31_21-49-29/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_comedi_1_0_serious/2026-03-31_21-49-29/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_1:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_comedi_1_1_serious/2026-03-31_22-17-28/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_comedi_1_1_serious/2026-03-31_22-17-28/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_2:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_comedi_1_2_serious/2026-03-31_22-17-28/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_comedi_1_2_serious/2026-03-31_22-17-28/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_3:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_comedi_1_3_serious/2026-03-31_22-45-22/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_comedi_1_3_serious/2026-03-31_22-45-22/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_4:
-      path: "results/overcooked-v1/asymm_advantages/ppo_br_s5/asymm_advantages_comedi_1_4_serious/2026-03-31_22-45-22/ego_train_run"
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_comedi_1_4_serious/2026-03-31_22-45-22/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
@@ -410,133 +410,133 @@ best_response_set:
 
   overcooked-v1/counter_circuit:
     br_for_ippo_mlp_cc_0:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_ippo_mlp_cc_0_serious/2026-03-16_15-37-34/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_cc_0_serious/2026-03-16_15-37-34/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_cc_1:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_ippo_mlp_cc_1_serious/2026-03-16_15-40-58/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_cc_1_serious/2026-03-16_15-40-58/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_cc_2:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_ippo_mlp_cc_2_serious/2026-03-16_16-01-42/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_cc_2_serious/2026-03-16_16-01-42/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_pass_0:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_ippo_mlp_pass_0_serious/2026-03-16_16-04-58/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_pass_0_serious/2026-03-16_16-04-58/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_pass_1:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_ippo_mlp_pass_1_serious/2026-03-16_16-25-49/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_pass_1_serious/2026-03-16_16-25-49/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_pass_2:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_ippo_mlp_pass_2_serious/2026-03-16_16-29-00/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_pass_2_serious/2026-03-16_16-29-00/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_independent_agent_0:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_independent_agent_0_serious/2026-03-16_16-49-59/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_independent_agent_0_serious/2026-03-16_16-49-59/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_onion_agent_0:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_onion_agent_0_serious/2026-03-16_19-56-09/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_onion_agent_0_serious/2026-03-16_19-56-09/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_plate_agent_0:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_plate_agent_0_serious/2026-03-16_19-56-09/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_plate_agent_0_serious/2026-03-16_19-56-09/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_onion_agent_0_9:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_onion_agent_0_9_serious/2026-03-16_20-22-17/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_onion_agent_0_9_serious/2026-03-16_20-22-17/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_plate_agent_0_9:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_plate_agent_0_9_serious/2026-03-16_20-22-27/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_plate_agent_0_9_serious/2026-03-16_20-22-27/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_0:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_lbrdiv_conf_1_0_serious/2026-03-31_23-13-25/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_lbrdiv_conf_1_0_serious/2026-03-31_23-13-25/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_1:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_lbrdiv_conf_1_1_serious/2026-03-31_23-13-25/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_lbrdiv_conf_1_1_serious/2026-03-31_23-13-25/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_2:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_lbrdiv_conf_1_2_serious/2026-04-01_08-46-15/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_lbrdiv_conf_1_2_serious/2026-04-01_08-46-15/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_0:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_comedi_1_0_serious/2026-04-01_08-46-15/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_comedi_1_0_serious/2026-04-01_08-46-15/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_1:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_comedi_1_1_serious/2026-04-01_09-11-00/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_comedi_1_1_serious/2026-04-01_09-11-00/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_2:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_comedi_1_2_serious/2026-04-01_09-11-00/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_comedi_1_2_serious/2026-04-01_09-11-00/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_3:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_comedi_1_3_serious/2026-04-01_09-35-44/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_comedi_1_3_serious/2026-04-01_09-35-44/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_4:
-      path: "results/overcooked-v1/counter_circuit/ppo_br_s5/counter_circuit_comedi_1_4_serious/2026-04-01_09-35-44/ego_train_run"
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_comedi_1_4_serious/2026-04-01_09-35-44/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
@@ -671,119 +671,119 @@ best_response_set:
 
   overcooked-v1/forced_coord:
     br_for_ippo_mlp_0:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_ippo_mlp_0_serious/2026-03-16_22-27-05/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_ippo_mlp_0_serious/2026-03-16_22-27-05/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_1:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_ippo_mlp_1_serious/2026-03-17_08-04-53/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_ippo_mlp_1_serious/2026-03-17_08-04-53/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_2:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_ippo_mlp_2_serious/2026-03-17_08-04-53/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_ippo_mlp_2_serious/2026-03-17_08-04-53/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf1_0:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_brdiv_conf1_0_serious/2026-03-17_08-24-58/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_brdiv_conf1_0_serious/2026-03-17_08-24-58/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf1_2:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_brdiv_conf1_2_serious/2026-03-17_08-25-00/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_brdiv_conf1_2_serious/2026-03-17_08-25-00/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf2_1:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_brdiv_conf2_1_serious/2026-03-17_08-44-38/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_brdiv_conf2_1_serious/2026-03-17_08-44-38/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf3_0:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_brdiv_conf3_0_serious/2026-03-17_08-44-42/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_brdiv_conf3_0_serious/2026-03-17_08-44-42/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf3_2:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_brdiv_conf3_2_serious/2026-03-17_09-04-28/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_brdiv_conf3_2_serious/2026-03-17_09-04-28/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_independent_agent_0_6:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_independent_agent_0_6_serious/2026-03-17_09-04-28/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_independent_agent_0_6_serious/2026-03-17_09-04-28/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_0:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_lbrdiv_conf_1_0_serious/2026-04-01_11-36-25/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_lbrdiv_conf_1_0_serious/2026-04-01_11-36-25/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_1:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_lbrdiv_conf_1_1_serious/2026-04-01_11-36-29/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_lbrdiv_conf_1_1_serious/2026-04-01_11-36-29/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_2:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_lbrdiv_conf_1_2_serious/2026-04-01_11-56-23/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_lbrdiv_conf_1_2_serious/2026-04-01_11-56-23/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_0:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_comedi_1_0_serious/2026-04-01_11-56-22/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_comedi_1_0_serious/2026-04-01_11-56-22/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_1:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_comedi_1_1_serious/2026-04-01_12-16-04/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_comedi_1_1_serious/2026-04-01_12-16-04/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_2:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_comedi_1_2_serious/2026-04-01_12-17-45/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_comedi_1_2_serious/2026-04-01_12-17-45/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_3:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_comedi_1_3_serious/2026-04-01_12-35-44/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_comedi_1_3_serious/2026-04-01_12-35-44/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_4:
-      path: "results/overcooked-v1/forced_coord/ppo_br_s5/forced_coord_comedi_1_4_serious/2026-04-01_12-42-01/ego_train_run"
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_comedi_1_4_serious/2026-04-01_12-42-01/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]

--- a/evaluation/configs/global_heldout_br.yaml
+++ b/evaluation/configs/global_heldout_br.yaml
@@ -4,14 +4,14 @@
 best_response_set:
   lbf/lbf_7x7_nolevels:
     br_for_ippo_mlp_0:
-      path: "results/lbf/ppo_br_s5/ippo_mlp_0_serious/2026-03-09_14-37-49/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/ippo_mlp_0_serious/2026-03-09_14-37-49/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_s2c0_2_0:
-      path: "results/lbf/ppo_br_s5/ippo_mlp_s2c0_serious/2026-03-09_21-11-30/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/ippo_mlp_s2c0_serious/2026-03-09_21-11-30/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
@@ -58,28 +58,28 @@ best_response_set:
       test_mode: false
 
     br_for_seq_agent_lexi:
-      path: "results/lbf/ppo_br_s5/seq_agent_lexi_serious/2026-03-09_22-00-17/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_lexi_serious/2026-03-09_22-00-17/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_seq_agent_rlexi:
-      path: "results/lbf/ppo_br_s5/seq_agent_rlexi_serious/2026-03-09_22-04-11/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_rlexi_serious/2026-03-09_22-04-11/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_seq_agent_col:
-      path: "results/lbf/ppo_br_s5/seq_agent_col_serious/2026-03-10_11-34-55/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_col_serious/2026-03-10_11-34-55/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_seq_agent_rcol:
-      path: "results/lbf/ppo_br_s5/seq_agent_rcol_serious/2026-03-10_11-35-07/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_rcol_serious/2026-03-10_11-35-07/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
@@ -88,77 +88,77 @@ best_response_set:
     # retrained the nearest/farthest seq-agent BRs longer (6e7)
     # see file log to get back 1e7 versions if needed
     br_for_seq_agent_nearest:
-      path: "results/lbf/ppo_br_s5/seq_agent_nearest_long_6e7/2026-03-17_15-29-35/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_nearest_long_6e7/2026-03-17_15-29-35/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_seq_agent_farthest:
-      path: "results/lbf/ppo_br_s5/seq_agent_farthest_long_6e7/2026-03-17_15-30-02/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_farthest_long_6e7/2026-03-17_15-30-02/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_0:
-      path: "results/lbf/ppo_br_s5/lbrdiv_conf_1_0_serious/2026-03-26_14-39-54/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/lbrdiv_conf_1_0_serious/2026-03-26_14-39-54/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_1:
-      path: "results/lbf/ppo_br_s5/lbrdiv_conf_1_1_serious/2026-03-27_08-00-13/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/lbrdiv_conf_1_1_serious/2026-03-27_08-00-13/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_2:
-      path: "results/lbf/ppo_br_s5/lbrdiv_conf_1_2_serious/2026-03-26_15-26-40/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/lbrdiv_conf_1_2_serious/2026-03-26_15-26-40/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_0:
-      path: "results/lbf/ppo_br_s5/comedi_1_0_serious/2026-03-29_14-57-30/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/comedi_1_0_serious/2026-03-29_14-57-30/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_1:
-      path: "results/lbf/ppo_br_s5/comedi_1_1_serious/2026-03-29_15-35-46/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/comedi_1_1_serious/2026-03-29_15-35-46/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_2:
-      path: "results/lbf/ppo_br_s5/comedi_1_2_serious/2026-03-29_16-14-12/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/comedi_1_2_serious/2026-03-29_16-14-12/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_3:
-      path: "results/lbf/ppo_br_s5/comedi_1_3_serious/2026-03-29_16-52-38/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/comedi_1_3_serious/2026-03-29_16-52-38/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_4:
-      path: "results/lbf/ppo_br_s5/comedi_1_4_serious/2026-03-29_17-30-53/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/comedi_1_4_serious/2026-03-29_17-30-53/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_entitled_agent:
-      path: "results/lbf/ppo_br_s5/entitled_agent_serious/2026-05-05_10-30-43/ego_train_run"
+      path: "eval_teammates/lbf_7x7_nolevels/entitled_agent_serious/2026-05-05_10-30-43/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
@@ -544,126 +544,126 @@ best_response_set:
 
   overcooked-v1/coord_ring:
     br_for_ippo_mlp_1:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_ippo_mlp_1_serious/2026-03-16_20-48-58/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_ippo_mlp_1_serious/2026-03-16_20-48-58/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_2:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_ippo_mlp_2_serious/2026-03-16_20-49-15/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_ippo_mlp_2_serious/2026-03-16_20-49-15/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_ippo_mlp_3:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_ippo_mlp_3_serious/2026-03-16_21-12-48/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_ippo_mlp_3_serious/2026-03-16_21-12-48/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf1_1:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_brdiv_conf1_1_serious/2026-03-16_21-13-18/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_brdiv_conf1_1_serious/2026-03-16_21-13-18/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf1_2:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_brdiv_conf1_2_serious/2026-03-16_21-36-51/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_brdiv_conf1_2_serious/2026-03-16_21-36-51/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_brdiv_conf2_0:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_brdiv_conf2_0_serious/2026-03-16_21-37-32/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_brdiv_conf2_0_serious/2026-03-16_21-37-32/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_independent_agent_0:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_independent_agent_0_serious/2026-03-16_22-00-43/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_independent_agent_0_serious/2026-03-16_22-00-43/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_onion_agent_0:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_onion_agent_0_serious/2026-03-16_22-01-32/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_onion_agent_0_serious/2026-03-16_22-01-32/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_plate_agent_0:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_plate_agent_0_serious/2026-03-16_22-26-32/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_plate_agent_0_serious/2026-03-16_22-26-32/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_0:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_lbrdiv_conf_1_0_serious/2026-04-01_10-00-27/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_lbrdiv_conf_1_0_serious/2026-04-01_10-00-27/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_1:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_lbrdiv_conf_1_1_serious/2026-04-01_10-00-27/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_lbrdiv_conf_1_1_serious/2026-04-01_10-00-27/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_lbrdiv_conf_1_2:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_lbrdiv_conf_1_2_serious/2026-04-01_10-24-20/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_lbrdiv_conf_1_2_serious/2026-04-01_10-24-20/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_0:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_comedi_1_0_serious/2026-04-01_10-24-22/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_comedi_1_0_serious/2026-04-01_10-24-22/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_1:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_comedi_1_1_serious/2026-04-01_10-48-16/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_comedi_1_1_serious/2026-04-01_10-48-16/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_2:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_comedi_1_2_serious/2026-04-01_10-48-16/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_comedi_1_2_serious/2026-04-01_10-48-16/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_3:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_comedi_1_3_serious/2026-04-01_11-12-21/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_comedi_1_3_serious/2026-04-01_11-12-21/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_comedi_1_4:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_comedi_1_4_serious/2026-04-01_11-12-21/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_comedi_1_4_serious/2026-04-01_11-12-21/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
 
     br_for_human_proxy:
-      path: "results/overcooked-v1/coord_ring/ppo_br_s5/coord_ring_br_for_bc_run0_1e8/2026-05-05_20-08-22/ego_train_run"
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_BC_0/2026-05-05_20-08-22/ego_train_run"
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]

--- a/scripts/download_from_hf.py
+++ b/scripts/download_from_hf.py
@@ -8,7 +8,7 @@ Example:
     python download_from_hf.py \
         --dataset jaxaht/eval-teammates-br \
         --path_in_dataset overcooked_v1_coord_ring \
-        --dest_dir results/overcooked-v1/coord_ring/ppo_br_s5
+        --dest_dir eval_teammates/overcooked_v1_coord_ring
 """
 
 import argparse
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--dest_dir", required=True,
-        help="Local directory to download into (e.g. results/overcooked-v1/coord_ring/ppo_br_s5)",
+        help="Local directory to download into (e.g. eval_teammates/overcooked_v1_coord_ring)",
     )
     parser.add_argument(
         "--api_key", default=None,


### PR DESCRIPTION
## Summary
- align all heldout BR checkpoint paths with `jaxaht/eval-teammates-br`
- add the previously missing Overcooked BR checkpoints for cramped room, asymmetric advantages, counter circuit, and forced coordination
- update the download helper example so BR files land under the configured `eval_teammates` layout

## Verification
- verified all 105 BR checkpoint paths against Hugging Face
- verified the five nested LBF teammate references against `jaxaht/eval-teammates`
- parsed `global_heldout_br.yaml`
- checked `scripts/download_from_hf.py` syntax
- ran `git diff --check`