### PR TITLE
Fix heldout eval routing for bc_proxy agents

### DIFF
--- a/agents/lbf/agent_policy_wrappers.py
+++ b/agents/lbf/agent_policy_wrappers.py
@@ -91,3 +91,55 @@ class LBFGreedyHeuristicPolicyWrapper(AgentPolicy):
 
     def init_hstate(self, batch_size: int, aux_info):
         return self.policy.init_agent_state(aux_info["agent_id"])
+
+class LBFBCLSTMPolicyWrapper(AgentPolicy):
+    """BC-LSTM human proxy for LBF, loaded from a safetensors weight file with a
+    sibling .yaml describing the architecture (see agents/bc)."""
+
+    def __init__(self, weight_file: str, using_log_wrapper: bool = False,
+                 greedy: bool = True):
+        import os, yaml
+        from common.save_load_utils import REPO_PATH
+        from agents.bc import BCLSTMAgent, BCLSTMConfig
+
+        yaml_path = weight_file.rsplit('.', 1)[0] + '.yaml'
+        abs_yaml = yaml_path if os.path.isabs(yaml_path) else os.path.join(REPO_PATH, yaml_path)
+        with open(abs_yaml) as f:
+            cfg = yaml.safe_load(f)
+
+        config = BCLSTMConfig(
+            obs_dim=cfg['obs_dim'], action_dim=cfg['action_dim'],
+            preprocess_dim=cfg.get('preprocess_dim', 1024),
+            lstm_dim=cfg.get('lstm_dim', 512),
+            postprocess_dim=cfg.get('postprocess_dim', 256),
+            dropout_rate=cfg.get('dropout_rate', 0.0),
+        )
+        self.agent = BCLSTMAgent(config, weight_path=weight_file)
+        self.action_dim = cfg['action_dim']
+        self.using_log_wrapper = using_log_wrapper
+        self.greedy = greedy
+
+    def get_action(self, params, obs, done, avail_actions, hstate, rng,
+                   env_state, aux_obs=None, test_mode=False):
+        import jax.numpy as jnp
+        obs_flat = obs.reshape(-1)
+
+        if avail_actions is not None and avail_actions.ndim >= 1:
+            legal_mask = avail_actions.reshape(-1).astype(jnp.float32)
+        else:
+            legal_mask = jnp.ones(self.action_dim, dtype=jnp.float32)
+
+        if self.greedy or test_mode:
+            carry, action = self.agent.greedy_act(hstate, obs_flat, legal_mask)
+        else:
+            carry, action = self.agent.sample_act(hstate, obs_flat, legal_mask, rng)
+
+        carry = jax.lax.cond(
+            done.squeeze().astype(bool),
+            lambda: self.agent.init_carry(),
+            lambda: carry,
+        )
+        return action, carry
+
+    def init_hstate(self, batch_size: int, aux_info=None):
+        return self.agent.init_carry()

--- a/agents/overcooked/bc_agent.py
+++ b/agents/overcooked/bc_agent.py
@@ -27,27 +27,21 @@ ACTION_DIM = len(Actions)
 STATE_HISTORY_LEN = 3
 
 
-# Layout name to base directory mapping
 # Get path to repo root
 REPO_ROOT = Path(__file__).parent.parent.parent
-LAYOUT_TO_BASE_DIR = {
-    "cramped_room": REPO_ROOT / "eval_teammates/overcooked-v1/cramped_room/human_proxy/models",
-    "asymm_advantages": REPO_ROOT / "eval_teammates/overcooked-v1/asymm_advantages/human_proxy/models",
-    "counter_circuit": REPO_ROOT / "eval_teammates/overcooked-v1/counter_circuit/human_proxy/models",
-    "coord_ring": REPO_ROOT / "eval_teammates/overcooked-v1/coord_ring/human_proxy/models",
-    "forced_coord": REPO_ROOT / "eval_teammates/overcooked-v1/forced_coord/human_proxy/models",
-}
 
 
 class BCPolicy(AgentPolicy):
     """Behavior Cloning policy that directly implements the AgentPolicy interface."""
-    def __init__(self, layout_name, using_log_wrapper=True, run_id=0):
+    def __init__(self, layout_name, model_base_dir, using_log_wrapper=True, run_id=0):
         """
         Initialize BC policy with layout name.
         The agent_id must be provided through init_hstate via aux_info.
 
         Args:
             layout_name: Name of the layout (e.g., "cramped_room")
+            model_base_dir: Directory containing the BC checkpoints, one subdirectory
+                per run_id. Relative paths are resolved against the repo root.
             using_log_wrapper: If True, assume that the agent is interacting with the wrapped Overcooked-v1
                 environment. If False, assume that the agent is interacting with the original Overcooked-v1
                 environment.
@@ -56,6 +50,8 @@ class BCPolicy(AgentPolicy):
         super().__init__(action_dim=ACTION_DIM, obs_dim=None)
         self.network = BCModel(action_dim=ACTION_DIM, hidden_dims=(64, 64))
         self.layout_name = layout_name
+        base_dir = Path(model_base_dir)
+        self.model_base_dir = base_dir if base_dir.is_absolute() else REPO_ROOT / base_dir
         self.run_id = run_id # checkpoints are available from 0 to 4
         self.unblock_if_stuck = True
         self.using_log_wrapper = using_log_wrapper
@@ -68,12 +64,10 @@ class BCPolicy(AgentPolicy):
         self.featurizer = BCFeaturizer(layout, num_pots=2, max_steps=400)
     
     def _load_params(self):
-        """Load parameters from checkpoint based on layout name and run ID."""
-        if self.layout_name not in LAYOUT_TO_BASE_DIR:
-            raise ValueError(f"Layout '{self.layout_name}' not found in LAYOUT_TO_BASE_DIR mapping")
-        
-        base_dir = Path(LAYOUT_TO_BASE_DIR[self.layout_name])
-        model_dir = base_dir / str(self.run_id)
+        """Load parameters from checkpoint based on the model base dir and run ID."""
+        model_dir = self.model_base_dir / str(self.run_id)
+        if not model_dir.exists():
+            raise FileNotFoundError(f"BC checkpoint not found: {model_dir}")
         
         orbax_checkpointer = ocp.PyTreeCheckpointer()
         ckpt = orbax_checkpointer.restore(model_dir, item=None)
@@ -421,10 +415,8 @@ class BCHState:
 
         return pos_equal & dir_equal
 
-def test_bc_policy(layout_name: str, num_episodes=64, test_mode=True, do_reward_shaping=True):
+def test_bc_policy(layout_name: str, model_base_dir, num_episodes=64, test_mode=True, do_reward_shaping=True):
     """Load and evaluate a BC policy on Overcooked-v1"""
-    assert layout_name in LAYOUT_TO_BASE_DIR, f"Layout {layout_name} not found in LAYOUT_TO_BASE_DIR"
-
     num_timesteps = 400
     seed = 0
     
@@ -448,8 +440,8 @@ def test_bc_policy(layout_name: str, num_episodes=64, test_mode=True, do_reward_
                     })
     # env = OvercookedWrapper(layout=augmented_layouts[layout_name], max_steps=num_timesteps)
     
-    policy0 = BCPolicy(layout_name, using_log_wrapper=False)
-    policy1 = BCPolicy(layout_name, using_log_wrapper=False)
+    policy0 = BCPolicy(layout_name, model_base_dir, using_log_wrapper=False)
+    policy1 = BCPolicy(layout_name, model_base_dir, using_log_wrapper=False)
     
     # Initialize random key
     key = jax.random.PRNGKey(seed)
@@ -564,9 +556,11 @@ def test_bc_policy(layout_name: str, num_episodes=64, test_mode=True, do_reward_
     return mean_reward, std_reward, all_ep_rewards
 
 if __name__ == "__main__":
-    for layout_name in LAYOUT_TO_BASE_DIR.keys():
-        test_bc_policy(layout_name, 
-                       num_episodes=64, 
+    for layout_name in ["cramped_room", "asymm_advantages", "counter_circuit",
+                        "coord_ring", "forced_coord"]:
+        test_bc_policy(layout_name,
+                       model_base_dir=f"eval_teammates/overcooked-v1/{layout_name}/human_proxy/models",
+                       num_episodes=64,
                        test_mode=True,
                        do_reward_shaping=True
                        )

--- a/common/agent_loader_from_config.py
+++ b/common/agent_loader_from_config.py
@@ -165,8 +165,10 @@ def initialize_heuristic_agent_from_config(agent_config, agent_name, task_name, 
             )
         if actor_type == "bc_proxy":
             from agents.overcooked.bc_agent import BCPolicy, BCProxyPartnerWrapper
+            assert "path" in agent_config, "bc_proxy agents must provide 'path' (BC model base dir)."
             bc = BCPolicy(
                 layout_name=env_kwargs["layout"],
+                model_base_dir=_validate_teammate_path(agent_config["path"]),
                 using_log_wrapper=True,
                 run_id=agent_config.get("run_id", 0),
             )

--- a/common/agent_loader_from_config.py
+++ b/common/agent_loader_from_config.py
@@ -10,6 +10,7 @@ from agents.initialize_agents import initialize_s5_agent, initialize_mlp_agent, 
 from agents.lbf.agent_policy_wrappers import (
     LBFRandomPolicyWrapper, LBFSequentialFruitPolicyWrapper,
     LBFEntitledPolicyWrapper, LBFGreedyHeuristicPolicyWrapper,
+    LBFBCLSTMPolicyWrapper,
 )
 from agents.overcooked.agent_policy_wrappers import (
     OvercookedRandomPolicyWrapper, OvercookedIndependentPolicyWrapper,
@@ -134,6 +135,12 @@ def initialize_heuristic_agent_from_config(agent_config, agent_name, task_name, 
                 num_fruits=num_fruits,
                 heuristic=heuristic,
                 using_log_wrapper=True,
+            )
+        if actor_type == "bc_lstm":
+            return LBFBCLSTMPolicyWrapper(
+                weight_file=agent_config["weight_file"],
+                using_log_wrapper=True,
+                greedy=agent_config.get("greedy", True),
             )
         raise ValueError(f"Unrecognized actor type for {task_name}: '{actor_type}' ({agent_name})")
 

--- a/download_eval_data.py
+++ b/download_eval_data.py
@@ -112,7 +112,7 @@ def download_hf_directory(repo_id: str, remote_dir: str, destination_dir: str):
 
     Args:
         repo_id (str): The Hugging Face repository ID (e.g., "jaxaht/eval-teammates").
-        remote_dir (str): The directory in the HF repo to download (e.g., "lbf").
+        remote_dir (str): The directory in the HF repo to download (e.g., "lbf_7x7").
         destination_dir (str): Local directory to download into; remote_dir becomes a
                                subdirectory of this (e.g., destination_dir/lbf/...).
     Returns:
@@ -146,7 +146,7 @@ if __name__ == "__main__":
         },
         "lbf_teammates": {
             "type": "dir",
-            "filename": "lbf",
+            "filename": "lbf_7x7",
             "target_directory": "eval_teammates/",
         },
         "lbf_12x12_teammates": {

--- a/evaluation/configs/global_heldout_settings.yaml
+++ b/evaluation/configs/global_heldout_settings.yaml
@@ -10,7 +10,7 @@ global_heldout_settings:
 heldout_set:
   lbf/lbf_7x7_nolevels: # DONE - DO NOT MODIFY. In LBF, results are much better with test mode = false.
     ippo_mlp: 
-      path: "eval_teammates/lbf/ippo/2025-04-21_23-41-17/saved_train_run"
+      path: "eval_teammates/lbf_7x7/ippo/2025-04-21_23-41-17/saved_train_run"
       actor_type: mlp
       ckpt_key: final_params
       idx_list: [0] # load in seed 0 only
@@ -19,7 +19,7 @@ heldout_set:
         percent_eaten: [[0.0, 100.0]]
         returned_episode_returns: [[0.0, 0.5]]
     ippo_mlp_s2c0:
-      path: "eval_teammates/lbf/ippo/2025-04-21_23-41-17/saved_train_run"
+      path: "eval_teammates/lbf_7x7/ippo/2025-04-21_23-41-17/saved_train_run"
       actor_type: mlp
       idx_list: [[2, 0]] # load in seed 2 ckpt 0
       test_mode: false
@@ -27,7 +27,7 @@ heldout_set:
         percent_eaten: [[0.0, 93.75]]
         returned_episode_returns: [[0.0, 0.47]]
     brdiv-conf1: 
-      path: "eval_teammates/lbf/brdiv/2025-04-16/11-32-07/saved_train_run"
+      path: "eval_teammates/lbf_7x7/brdiv/2025-04-16/11-32-07/saved_train_run"
       actor_type: actor_with_conditional_critic
       idx_list: [0, 1, 2] # load in population members 0, 1, 2
       ckpt_key: final_params_conf # key to load from checkpoint.
@@ -37,7 +37,7 @@ heldout_set:
         percent_eaten: [[0.0, 90.10], [0.0, 98.96], [0.0, 76.56]]
         returned_episode_returns: [[0.0, 0.45], [0.0, 0.49], [0.0, 0.39]]
     brdiv-conf2:
-      path: "eval_teammates/lbf/brdiv/2025-04-23/13-48-47/saved_train_run"
+      path: "eval_teammates/lbf_7x7/brdiv/2025-04-23/13-48-47/saved_train_run"
       actor_type: actor_with_conditional_critic
       idx_list: [0, 1]
       ckpt_key: final_params_conf
@@ -94,7 +94,7 @@ heldout_set:
         percent_eaten: [0.0, 100.0]
         returned_episode_returns: [0.0, 0.5]
     lbrdiv-conf:
-      path: "eval_teammates/lbf/lbrdiv/2026-03-02_13-01-20/saved_train_run/"
+      path: "eval_teammates/lbf_7x7/lbrdiv/2026-03-02_13-01-20/saved_train_run/"
       actor_type: actor_with_conditional_critic
       idx_list: [[1, 0], [1, 1], [1, 2]]
       ckpt_key: final_params_conf
@@ -104,7 +104,7 @@ heldout_set:
         percent_eaten: [[0.0, 90.10], [0.0, 89.98], [0.0, 92.19]]
         returned_episode_returns: [[0.0, 0.45], [0.0, 0.45], [0.0, 0.46]]
     comedi:
-      path: "eval_teammates/lbf/comedi/2026-03-02_00-58-19/saved_train_run/"
+      path: "eval_teammates/lbf_7x7/comedi/2026-03-02_00-58-19/saved_train_run/"
       actor_type: actor_with_conditional_critic
       idx_list: [[1, 0], [1, 1], [1, 2], [1, 3], [1, 4]]
       ckpt_key: final_params_conf
@@ -113,7 +113,17 @@ heldout_set:
       performance_bounds:
         percent_eaten: [[0.0, 100.00], [0.0, 51.56], [0.0, 100.00], [0.0, 100.00], [0.0, 99.48]]
         returned_episode_returns: [[0.0, 0.50], [0.0, 0.32], [0.0, 0.50], [0.0, 0.50], [0.0, 0.50]]
-    # TODO: add human_proxy (human-regularized RL) once checkpoints are available.
+    # TODO: enable once the real 7x7 checkpoint is uploaded. The current file at
+    # lbf_7x7/human_proxy on HF is a byte-identical duplicate of the lbf_12x12
+    # checkpoint (obs_dim 24, incompatible with the 7x7 env's 15-dim obs).
+    # human_proxy:
+    #   actor_type: bc_lstm
+    #   weight_file: eval_teammates/lbf_7x7/human_proxy/policy.safetensors
+    #   greedy: true
+    #   test_mode: true
+    #   performance_bounds:
+    #     percent_eaten: [0.0, 100.0]
+    #     returned_episode_returns: [0.0, 0.5]
   lbf/lbf_12x12:
     ippo_mlp:
       path: "eval_teammates/lbf_12x12/ippo-lbf-12-levels/saved_train_run"
@@ -201,7 +211,14 @@ heldout_set:
       performance_bounds:
         percent_eaten: [0.0, 100.0]
         returned_episode_returns: [0.0, 0.5]
-    # TODO: add human_proxy (human-regularized RL) once checkpoints are available.
+    human_proxy:
+      actor_type: bc_lstm
+      weight_file: eval_teammates/lbf_12x12/human_proxy/policy.safetensors
+      greedy: true
+      test_mode: true
+      performance_bounds:
+        percent_eaten: [0.0, 70.34]
+        returned_episode_returns: [0.0, 0.3517]
   overcooked-v1/cramped_room: # DONE - DO NOT MODIFY
     ippo_mlp: 
       path: "eval_teammates/overcooked-v1/cramped_room/ippo/2025-04-21_22-53-04/saved_train_run"

--- a/evaluation/configs/global_heldout_settings.yaml
+++ b/evaluation/configs/global_heldout_settings.yaml
@@ -113,14 +113,7 @@ heldout_set:
       performance_bounds:
         percent_eaten: [[0.0, 100.00], [0.0, 51.56], [0.0, 100.00], [0.0, 100.00], [0.0, 99.48]]
         returned_episode_returns: [[0.0, 0.50], [0.0, 0.32], [0.0, 0.50], [0.0, 0.50], [0.0, 0.50]]
-    human_proxy:
-      path: "eval_teammates/lbf/lbf_7x7/human_proxy"
-      actor_type: bc_proxy
-      layout: lbf_7x7
-      test_mode: true
-      performance_bounds:
-        percent_eaten: [0.0, 100.0]
-        returned_episode_returns: [0.0, 0.5]
+    # TODO: add human_proxy (human-regularized RL) once checkpoints are available.
   lbf/lbf_12x12:
     ippo_mlp:
       path: "eval_teammates/lbf_12x12/ippo-lbf-12-levels/saved_train_run"
@@ -208,14 +201,7 @@ heldout_set:
       performance_bounds:
         percent_eaten: [0.0, 100.0]
         returned_episode_returns: [0.0, 0.5]
-    human_proxy:
-      path: "eval_teammates/lbf_12x12/human_proxy"
-      actor_type: bc_proxy
-      layout: lbf_12x12
-      test_mode: true
-      performance_bounds:
-        percent_eaten: [0.0, 70.34]
-        returned_episode_returns: [0.0, 0.3517]
+    # TODO: add human_proxy (human-regularized RL) once checkpoints are available.
   overcooked-v1/cramped_room: # DONE - DO NOT MODIFY
     ippo_mlp: 
       path: "eval_teammates/overcooked-v1/cramped_room/ippo/2025-04-21_22-53-04/saved_train_run"

--- a/evaluation/heldout_evaluator.py
+++ b/evaluation/heldout_evaluator.py
@@ -102,8 +102,9 @@ def load_heldout_set(heldout_config, env, task_name, env_kwargs, rng):
         params_list = None
         idx_labels = None
         test_mode = agent_config.get("test_mode", False)
-        # Load RL-based agents
-        if "path" in agent_config:
+        # Load RL-based agents. bc_proxy agents are loaded as heuristic agents
+        # (BCPolicy locates its own checkpoint; the config "path" is informational).
+        if "path" in agent_config and agent_config.get("actor_type") != "bc_proxy":
             # ensure that each rl agent has a unique initialization rng
             rng, init_rng = jax.random.split(rng)
             policy, params, init_params, idx_labels = initialize_rl_agent_from_config(agent_config, agent_name, env, init_rng)

--- a/scripts/test_algos.sh
+++ b/scripts/test_algos.sh
@@ -57,7 +57,7 @@ LOG="$RESULTS_DIR/summary.log"
 COMMON_FLAGS="logger.mode=offline logger.log_train_out=false logger.log_eval_out=false local_logger.save_train_out=false local_logger.save_eval_out=false"
 
 # Path to a pre-trained IPPO partner checkpoint (required by ego-training algos).
-PARTNER_PATH="eval_teammates/lbf/ippo/ippo-lbf-7-levels/saved_train_run/"
+PARTNER_PATH="eval_teammates/lbf_7x7/ippo/ippo-lbf-7-levels/saved_train_run/"
 
 # =============================================================================
 # ─── Job definitions ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Heldout evaluation crashed for any `bc_proxy` entry ("Indices to load from checkpoint must be provided") because `load_heldout_set` routed every config entry with a `path` key to the RL checkpoint loader. This broke `scripts/test_algos.sh` job `ppo_ego`, and the Overcooked `human_proxy` entries were equally affected.

Now `bc_proxy` entries route to the heuristic loader, and `BCPolicy` takes its model directory from the config's `path` instead of the hardcoded `LAYOUT_TO_BASE_DIR` map in `bc_agent.py`. The LBF `human_proxy` entries are removed for now — there is no LBF BC/human-proxy implementation or data yet; TODOs mark where the human-regularized RL proxies will go once the checkpoints are located.

Verified by running the `ppo_ego` job from `scripts/test_algos.sh` end to end (training + heldout eval complete).