### PR TITLE
Fix heldout eval routing for bc_proxy agents; add LBF human proxy support

### DIFF
--- a/agents/lbf/agent_policy_wrappers.py
+++ b/agents/lbf/agent_policy_wrappers.py
@@ -1,12 +1,80 @@
 '''Wrap heuristic agent policies in AgentPolicy interface.
 TODO: clean up logic by vectorizing init_hstate. See HeuristicPolicyPopulation.
 '''
+import os
+
 import jax
+import jax.numpy as jnp
+import yaml
+
 from agents.agent_interface import AgentPolicy
+from agents.bc import BCLSTMAgent, BCLSTMConfig
 from agents.lbf.random_agent import RandomAgent
 from agents.lbf.sequential_fruit_agent import SequentialFruitAgent
 from agents.lbf.entitled_agent import EntitledAgent
 from agents.lbf.greedy_heuristic_agent import GreedyHeuristicAgent
+from common.save_load_utils import REPO_PATH
+
+
+class LBFBCLSTMPolicyWrapper(AgentPolicy):
+    """Load an LBF BC-LSTM checkpoint and adapt observations for evaluation."""
+
+    def __init__(self, weight_file: str, greedy: bool = True):
+        yaml_path = weight_file.rsplit('.', 1)[0] + '.yaml'
+        abs_yaml_path = (
+            yaml_path if os.path.isabs(yaml_path)
+            else os.path.join(REPO_PATH, yaml_path)
+        )
+        with open(abs_yaml_path) as config_file:
+            saved_config = yaml.safe_load(config_file)
+
+        config = BCLSTMConfig(
+            obs_dim=saved_config["obs_dim"],
+            action_dim=saved_config["action_dim"],
+            preprocess_dim=saved_config.get("preprocess_dim", 1024),
+            lstm_dim=saved_config.get("lstm_dim", 512),
+            postprocess_dim=saved_config.get("postprocess_dim", 256),
+            dropout_rate=saved_config.get("dropout_rate", 0.0),
+        )
+        super().__init__(config.action_dim, config.obs_dim)
+        self.agent = BCLSTMAgent(config, weight_path=weight_file)
+        self.greedy = greedy
+
+    def _prepare_obs(self, obs):
+        obs = jnp.asarray(obs).reshape(-1)
+        if obs.shape[0] > self.obs_dim:
+            raise ValueError(
+                f"BC-LSTM expects at most {self.obs_dim} observation values, "
+                f"received {obs.shape[0]}."
+            )
+        if obs.shape[0] < self.obs_dim:
+            obs = jnp.pad(obs, (0, self.obs_dim - obs.shape[0]))
+        return obs
+
+    def get_action(self, params, obs, done, avail_actions, hstate, rng,
+                   aux_obs=None, env_state=None, test_mode=False):
+        del params, env_state, aux_obs
+        obs = self._prepare_obs(obs)
+        if avail_actions is None:
+            legal_mask = jnp.ones(self.action_dim, dtype=jnp.float32)
+        else:
+            legal_mask = jnp.asarray(avail_actions).reshape(-1).astype(jnp.float32)
+
+        done = jnp.asarray(done).reshape(-1)[0].astype(bool)
+        hstate = jax.lax.cond(
+            done,
+            lambda: self.agent.init_carry(),
+            lambda: hstate,
+        )
+        if self.greedy or test_mode:
+            carry, action = self.agent.greedy_act(hstate, obs, legal_mask)
+        else:
+            carry, action = self.agent.sample_act(hstate, obs, legal_mask, rng)
+        return action, carry
+
+    def init_hstate(self, batch_size: int, aux_info=None):
+        del batch_size, aux_info
+        return self.agent.init_carry()
 
 
 
@@ -91,55 +159,3 @@ class LBFGreedyHeuristicPolicyWrapper(AgentPolicy):
 
     def init_hstate(self, batch_size: int, aux_info):
         return self.policy.init_agent_state(aux_info["agent_id"])
-
-class LBFBCLSTMPolicyWrapper(AgentPolicy):
-    """BC-LSTM human proxy for LBF, loaded from a safetensors weight file with a
-    sibling .yaml describing the architecture (see agents/bc)."""
-
-    def __init__(self, weight_file: str, using_log_wrapper: bool = False,
-                 greedy: bool = True):
-        import os, yaml
-        from common.save_load_utils import REPO_PATH
-        from agents.bc import BCLSTMAgent, BCLSTMConfig
-
-        yaml_path = weight_file.rsplit('.', 1)[0] + '.yaml'
-        abs_yaml = yaml_path if os.path.isabs(yaml_path) else os.path.join(REPO_PATH, yaml_path)
-        with open(abs_yaml) as f:
-            cfg = yaml.safe_load(f)
-
-        config = BCLSTMConfig(
-            obs_dim=cfg['obs_dim'], action_dim=cfg['action_dim'],
-            preprocess_dim=cfg.get('preprocess_dim', 1024),
-            lstm_dim=cfg.get('lstm_dim', 512),
-            postprocess_dim=cfg.get('postprocess_dim', 256),
-            dropout_rate=cfg.get('dropout_rate', 0.0),
-        )
-        self.agent = BCLSTMAgent(config, weight_path=weight_file)
-        self.action_dim = cfg['action_dim']
-        self.using_log_wrapper = using_log_wrapper
-        self.greedy = greedy
-
-    def get_action(self, params, obs, done, avail_actions, hstate, rng,
-                   env_state, aux_obs=None, test_mode=False):
-        import jax.numpy as jnp
-        obs_flat = obs.reshape(-1)
-
-        if avail_actions is not None and avail_actions.ndim >= 1:
-            legal_mask = avail_actions.reshape(-1).astype(jnp.float32)
-        else:
-            legal_mask = jnp.ones(self.action_dim, dtype=jnp.float32)
-
-        if self.greedy or test_mode:
-            carry, action = self.agent.greedy_act(hstate, obs_flat, legal_mask)
-        else:
-            carry, action = self.agent.sample_act(hstate, obs_flat, legal_mask, rng)
-
-        carry = jax.lax.cond(
-            done.squeeze().astype(bool),
-            lambda: self.agent.init_carry(),
-            lambda: carry,
-        )
-        return action, carry
-
-    def init_hstate(self, batch_size: int, aux_info=None):
-        return self.agent.init_carry()

--- a/agents/lbf/agent_policy_wrappers.py
+++ b/agents/lbf/agent_policy_wrappers.py
@@ -1,80 +1,12 @@
 '''Wrap heuristic agent policies in AgentPolicy interface.
 TODO: clean up logic by vectorizing init_hstate. See HeuristicPolicyPopulation.
 '''
-import os
-
 import jax
-import jax.numpy as jnp
-import yaml
-
 from agents.agent_interface import AgentPolicy
-from agents.bc import BCLSTMAgent, BCLSTMConfig
 from agents.lbf.random_agent import RandomAgent
 from agents.lbf.sequential_fruit_agent import SequentialFruitAgent
 from agents.lbf.entitled_agent import EntitledAgent
 from agents.lbf.greedy_heuristic_agent import GreedyHeuristicAgent
-from common.save_load_utils import REPO_PATH
-
-
-class LBFBCLSTMPolicyWrapper(AgentPolicy):
-    """Load an LBF BC-LSTM checkpoint and adapt observations for evaluation."""
-
-    def __init__(self, weight_file: str, greedy: bool = True):
-        yaml_path = weight_file.rsplit('.', 1)[0] + '.yaml'
-        abs_yaml_path = (
-            yaml_path if os.path.isabs(yaml_path)
-            else os.path.join(REPO_PATH, yaml_path)
-        )
-        with open(abs_yaml_path) as config_file:
-            saved_config = yaml.safe_load(config_file)
-
-        config = BCLSTMConfig(
-            obs_dim=saved_config["obs_dim"],
-            action_dim=saved_config["action_dim"],
-            preprocess_dim=saved_config.get("preprocess_dim", 1024),
-            lstm_dim=saved_config.get("lstm_dim", 512),
-            postprocess_dim=saved_config.get("postprocess_dim", 256),
-            dropout_rate=saved_config.get("dropout_rate", 0.0),
-        )
-        super().__init__(config.action_dim, config.obs_dim)
-        self.agent = BCLSTMAgent(config, weight_path=weight_file)
-        self.greedy = greedy
-
-    def _prepare_obs(self, obs):
-        obs = jnp.asarray(obs).reshape(-1)
-        if obs.shape[0] > self.obs_dim:
-            raise ValueError(
-                f"BC-LSTM expects at most {self.obs_dim} observation values, "
-                f"received {obs.shape[0]}."
-            )
-        if obs.shape[0] < self.obs_dim:
-            obs = jnp.pad(obs, (0, self.obs_dim - obs.shape[0]))
-        return obs
-
-    def get_action(self, params, obs, done, avail_actions, hstate, rng,
-                   aux_obs=None, env_state=None, test_mode=False):
-        del params, env_state, aux_obs
-        obs = self._prepare_obs(obs)
-        if avail_actions is None:
-            legal_mask = jnp.ones(self.action_dim, dtype=jnp.float32)
-        else:
-            legal_mask = jnp.asarray(avail_actions).reshape(-1).astype(jnp.float32)
-
-        done = jnp.asarray(done).reshape(-1)[0].astype(bool)
-        hstate = jax.lax.cond(
-            done,
-            lambda: self.agent.init_carry(),
-            lambda: hstate,
-        )
-        if self.greedy or test_mode:
-            carry, action = self.agent.greedy_act(hstate, obs, legal_mask)
-        else:
-            carry, action = self.agent.sample_act(hstate, obs, legal_mask, rng)
-        return action, carry
-
-    def init_hstate(self, batch_size: int, aux_info=None):
-        del batch_size, aux_info
-        return self.agent.init_carry()
 
 
 
@@ -159,3 +91,55 @@ class LBFGreedyHeuristicPolicyWrapper(AgentPolicy):
 
     def init_hstate(self, batch_size: int, aux_info):
         return self.policy.init_agent_state(aux_info["agent_id"])
+
+class LBFBCLSTMPolicyWrapper(AgentPolicy):
+    """BC-LSTM human proxy for LBF, loaded from a safetensors weight file with a
+    sibling .yaml describing the architecture (see agents/bc)."""
+
+    def __init__(self, weight_file: str, using_log_wrapper: bool = False,
+                 greedy: bool = True):
+        import os, yaml
+        from common.save_load_utils import REPO_PATH
+        from agents.bc import BCLSTMAgent, BCLSTMConfig
+
+        yaml_path = weight_file.rsplit('.', 1)[0] + '.yaml'
+        abs_yaml = yaml_path if os.path.isabs(yaml_path) else os.path.join(REPO_PATH, yaml_path)
+        with open(abs_yaml) as f:
+            cfg = yaml.safe_load(f)
+
+        config = BCLSTMConfig(
+            obs_dim=cfg['obs_dim'], action_dim=cfg['action_dim'],
+            preprocess_dim=cfg.get('preprocess_dim', 1024),
+            lstm_dim=cfg.get('lstm_dim', 512),
+            postprocess_dim=cfg.get('postprocess_dim', 256),
+            dropout_rate=cfg.get('dropout_rate', 0.0),
+        )
+        self.agent = BCLSTMAgent(config, weight_path=weight_file)
+        self.action_dim = cfg['action_dim']
+        self.using_log_wrapper = using_log_wrapper
+        self.greedy = greedy
+
+    def get_action(self, params, obs, done, avail_actions, hstate, rng,
+                   env_state, aux_obs=None, test_mode=False):
+        import jax.numpy as jnp
+        obs_flat = obs.reshape(-1)
+
+        if avail_actions is not None and avail_actions.ndim >= 1:
+            legal_mask = avail_actions.reshape(-1).astype(jnp.float32)
+        else:
+            legal_mask = jnp.ones(self.action_dim, dtype=jnp.float32)
+
+        if self.greedy or test_mode:
+            carry, action = self.agent.greedy_act(hstate, obs_flat, legal_mask)
+        else:
+            carry, action = self.agent.sample_act(hstate, obs_flat, legal_mask, rng)
+
+        carry = jax.lax.cond(
+            done.squeeze().astype(bool),
+            lambda: self.agent.init_carry(),
+            lambda: carry,
+        )
+        return action, carry
+
+    def init_hstate(self, batch_size: int, aux_info=None):
+        return self.agent.init_carry()

--- a/agents/overcooked/bc_agent.py
+++ b/agents/overcooked/bc_agent.py
@@ -27,27 +27,21 @@ ACTION_DIM = len(Actions)
 STATE_HISTORY_LEN = 3
 
 
-# Layout name to base directory mapping
 # Get path to repo root
 REPO_ROOT = Path(__file__).parent.parent.parent
-LAYOUT_TO_BASE_DIR = {
-    "cramped_room": REPO_ROOT / "eval_teammates/overcooked-v1/cramped_room/human_proxy/models",
-    "asymm_advantages": REPO_ROOT / "eval_teammates/overcooked-v1/asymm_advantages/human_proxy/models",
-    "counter_circuit": REPO_ROOT / "eval_teammates/overcooked-v1/counter_circuit/human_proxy/models",
-    "coord_ring": REPO_ROOT / "eval_teammates/overcooked-v1/coord_ring/human_proxy/models",
-    "forced_coord": REPO_ROOT / "eval_teammates/overcooked-v1/forced_coord/human_proxy/models",
-}
 
 
 class BCPolicy(AgentPolicy):
     """Behavior Cloning policy that directly implements the AgentPolicy interface."""
-    def __init__(self, layout_name, using_log_wrapper=True, run_id=0):
+    def __init__(self, layout_name, model_base_dir, using_log_wrapper=True, run_id=0):
         """
         Initialize BC policy with layout name.
         The agent_id must be provided through init_hstate via aux_info.
 
         Args:
             layout_name: Name of the layout (e.g., "cramped_room")
+            model_base_dir: Directory containing the BC checkpoints, one subdirectory
+                per run_id. Relative paths are resolved against the repo root.
             using_log_wrapper: If True, assume that the agent is interacting with the wrapped Overcooked-v1
                 environment. If False, assume that the agent is interacting with the original Overcooked-v1
                 environment.
@@ -56,6 +50,8 @@ class BCPolicy(AgentPolicy):
         super().__init__(action_dim=ACTION_DIM, obs_dim=None)
         self.network = BCModel(action_dim=ACTION_DIM, hidden_dims=(64, 64))
         self.layout_name = layout_name
+        base_dir = Path(model_base_dir)
+        self.model_base_dir = base_dir if base_dir.is_absolute() else REPO_ROOT / base_dir
         self.run_id = run_id # checkpoints are available from 0 to 4
         self.unblock_if_stuck = True
         self.using_log_wrapper = using_log_wrapper
@@ -68,12 +64,10 @@ class BCPolicy(AgentPolicy):
         self.featurizer = BCFeaturizer(layout, num_pots=2, max_steps=400)
     
     def _load_params(self):
-        """Load parameters from checkpoint based on layout name and run ID."""
-        if self.layout_name not in LAYOUT_TO_BASE_DIR:
-            raise ValueError(f"Layout '{self.layout_name}' not found in LAYOUT_TO_BASE_DIR mapping")
-        
-        base_dir = Path(LAYOUT_TO_BASE_DIR[self.layout_name])
-        model_dir = base_dir / str(self.run_id)
+        """Load parameters from checkpoint based on the model base dir and run ID."""
+        model_dir = self.model_base_dir / str(self.run_id)
+        if not model_dir.exists():
+            raise FileNotFoundError(f"BC checkpoint not found: {model_dir}")
         
         orbax_checkpointer = ocp.PyTreeCheckpointer()
         ckpt = orbax_checkpointer.restore(model_dir, item=None)
@@ -421,10 +415,8 @@ class BCHState:
 
         return pos_equal & dir_equal
 
-def test_bc_policy(layout_name: str, num_episodes=64, test_mode=True, do_reward_shaping=True):
+def test_bc_policy(layout_name: str, model_base_dir, num_episodes=64, test_mode=True, do_reward_shaping=True):
     """Load and evaluate a BC policy on Overcooked-v1"""
-    assert layout_name in LAYOUT_TO_BASE_DIR, f"Layout {layout_name} not found in LAYOUT_TO_BASE_DIR"
-
     num_timesteps = 400
     seed = 0
     
@@ -448,8 +440,8 @@ def test_bc_policy(layout_name: str, num_episodes=64, test_mode=True, do_reward_
                     })
     # env = OvercookedWrapper(layout=augmented_layouts[layout_name], max_steps=num_timesteps)
     
-    policy0 = BCPolicy(layout_name, using_log_wrapper=False)
-    policy1 = BCPolicy(layout_name, using_log_wrapper=False)
+    policy0 = BCPolicy(layout_name, model_base_dir, using_log_wrapper=False)
+    policy1 = BCPolicy(layout_name, model_base_dir, using_log_wrapper=False)
     
     # Initialize random key
     key = jax.random.PRNGKey(seed)
@@ -564,9 +556,11 @@ def test_bc_policy(layout_name: str, num_episodes=64, test_mode=True, do_reward_
     return mean_reward, std_reward, all_ep_rewards
 
 if __name__ == "__main__":
-    for layout_name in LAYOUT_TO_BASE_DIR.keys():
-        test_bc_policy(layout_name, 
-                       num_episodes=64, 
+    for layout_name in ["cramped_room", "asymm_advantages", "counter_circuit",
+                        "coord_ring", "forced_coord"]:
+        test_bc_policy(layout_name,
+                       model_base_dir=f"eval_teammates/overcooked-v1/{layout_name}/human_proxy/models",
+                       num_episodes=64,
                        test_mode=True,
                        do_reward_shaping=True
                        )

--- a/common/agent_loader_from_config.py
+++ b/common/agent_loader_from_config.py
@@ -139,7 +139,6 @@ def initialize_heuristic_agent_from_config(agent_config, agent_name, task_name, 
         if actor_type == "bc_lstm":
             return LBFBCLSTMPolicyWrapper(
                 weight_file=agent_config["weight_file"],
-                using_log_wrapper=True,
                 greedy=agent_config.get("greedy", True),
             )
         raise ValueError(f"Unrecognized actor type for {task_name}: '{actor_type}' ({agent_name})")

--- a/common/agent_loader_from_config.py
+++ b/common/agent_loader_from_config.py
@@ -139,6 +139,7 @@ def initialize_heuristic_agent_from_config(agent_config, agent_name, task_name, 
         if actor_type == "bc_lstm":
             return LBFBCLSTMPolicyWrapper(
                 weight_file=agent_config["weight_file"],
+                using_log_wrapper=True,
                 greedy=agent_config.get("greedy", True),
             )
         raise ValueError(f"Unrecognized actor type for {task_name}: '{actor_type}' ({agent_name})")

--- a/common/agent_loader_from_config.py
+++ b/common/agent_loader_from_config.py
@@ -171,8 +171,10 @@ def initialize_heuristic_agent_from_config(agent_config, agent_name, task_name, 
             )
         if actor_type == "bc_proxy":
             from agents.overcooked.bc_agent import BCPolicy, BCProxyPartnerWrapper
+            assert "path" in agent_config, "bc_proxy agents must provide 'path' (BC model base dir)."
             bc = BCPolicy(
                 layout_name=env_kwargs["layout"],
+                model_base_dir=_validate_teammate_path(agent_config["path"]),
                 using_log_wrapper=True,
                 run_id=agent_config.get("run_id", 0),
             )

--- a/download_eval_data.py
+++ b/download_eval_data.py
@@ -112,7 +112,7 @@ def download_hf_directory(repo_id: str, remote_dir: str, destination_dir: str):
 
     Args:
         repo_id (str): The Hugging Face repository ID (e.g., "jaxaht/eval-teammates").
-        remote_dir (str): The directory in the HF repo to download (e.g., "lbf").
+        remote_dir (str): The directory in the HF repo to download (e.g., "lbf_7x7").
         destination_dir (str): Local directory to download into; remote_dir becomes a
                                subdirectory of this (e.g., destination_dir/lbf/...).
     Returns:
@@ -146,7 +146,7 @@ if __name__ == "__main__":
         },
         "lbf_teammates": {
             "type": "dir",
-            "filename": "lbf",
+            "filename": "lbf_7x7",
             "target_directory": "eval_teammates/",
         },
         "lbf_12x12_teammates": {

--- a/evaluation/configs/global_heldout_settings.yaml
+++ b/evaluation/configs/global_heldout_settings.yaml
@@ -113,17 +113,16 @@ heldout_set:
       performance_bounds:
         percent_eaten: [[0.0, 100.00], [0.0, 51.56], [0.0, 100.00], [0.0, 100.00], [0.0, 99.48]]
         returned_episode_returns: [[0.0, 0.50], [0.0, 0.32], [0.0, 0.50], [0.0, 0.50], [0.0, 0.50]]
-    # TODO: enable once the real 7x7 checkpoint is uploaded. The current file at
-    # lbf_7x7/human_proxy on HF is a byte-identical duplicate of the lbf_12x12
-    # checkpoint (obs_dim 24, incompatible with the 7x7 env's 15-dim obs).
-    # human_proxy:
-    #   actor_type: bc_lstm
-    #   weight_file: eval_teammates/lbf_7x7/human_proxy/policy.safetensors
-    #   greedy: true
-    #   test_mode: true
-    #   performance_bounds:
-    #     percent_eaten: [0.0, 100.0]
-    #     returned_episode_returns: [0.0, 0.5]
+    # Pooled BC-LSTM human proxy shared with lbf_12x12 (obs_dim 24); the
+    # wrapper zero-pads the 7x7 env's 15-dim observations to fit.
+    human_proxy:
+      actor_type: bc_lstm
+      weight_file: eval_teammates/lbf_7x7/human_proxy/policy.safetensors
+      greedy: true
+      test_mode: true
+      performance_bounds:
+        percent_eaten: [0.0, 100.0]
+        returned_episode_returns: [0.0, 0.5]
   lbf/lbf_12x12:
     ippo_mlp:
       path: "eval_teammates/lbf_12x12/ippo-lbf-12-levels/saved_train_run"

--- a/evaluation/configs/global_heldout_settings.yaml
+++ b/evaluation/configs/global_heldout_settings.yaml
@@ -682,7 +682,7 @@ heldout_set:
       S5_D_MODEL: 128
       S5_SSM_SIZE: 128
       S5_ACTOR_CRITIC_HIDDEN_DIM: 1024
-      FC_N_LAYERS: 2
+      FC_N_LAYERS: 3
       test_mode: false
       performance_bounds:
         returned_episode_returns: [[0.0, 16.35]]
@@ -694,7 +694,7 @@ heldout_set:
       S5_D_MODEL: 128
       S5_SSM_SIZE: 128
       S5_ACTOR_CRITIC_HIDDEN_DIM: 1024
-      FC_N_LAYERS: 2
+      FC_N_LAYERS: 3
       test_mode: false
       performance_bounds:
         returned_episode_returns: [[0.0, 18.08]]
@@ -706,7 +706,7 @@ heldout_set:
       S5_D_MODEL: 128
       S5_SSM_SIZE: 128
       S5_ACTOR_CRITIC_HIDDEN_DIM: 1024
-      FC_N_LAYERS: 2
+      FC_N_LAYERS: 3
       test_mode: false
       performance_bounds:
         returned_episode_returns: [[0.0, 21.34]]
@@ -715,10 +715,10 @@ heldout_set:
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
-      S5_D_MODEL: 16
-      S5_SSM_SIZE: 16
-      S5_ACTOR_CRITIC_HIDDEN_DIM: 64
-      FC_N_LAYERS: 2
+      S5_D_MODEL: 128
+      S5_SSM_SIZE: 128
+      S5_ACTOR_CRITIC_HIDDEN_DIM: 1024
+      FC_N_LAYERS: 3
       test_mode: false
       performance_bounds:
         returned_episode_returns: [[0.0, 12.87]]
@@ -727,10 +727,10 @@ heldout_set:
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
-      S5_D_MODEL: 16
-      S5_SSM_SIZE: 16
-      S5_ACTOR_CRITIC_HIDDEN_DIM: 64
-      FC_N_LAYERS: 2
+      S5_D_MODEL: 128
+      S5_SSM_SIZE: 128
+      S5_ACTOR_CRITIC_HIDDEN_DIM: 1024
+      FC_N_LAYERS: 3
       test_mode: false
       performance_bounds:
         returned_episode_returns: [[0.0, 11.91]]
@@ -739,10 +739,10 @@ heldout_set:
       actor_type: s5
       ckpt_key: final_params
       idx_list: [0]
-      S5_D_MODEL: 16
-      S5_SSM_SIZE: 16
-      S5_ACTOR_CRITIC_HIDDEN_DIM: 64
-      FC_N_LAYERS: 2
+      S5_D_MODEL: 128
+      S5_SSM_SIZE: 128
+      S5_ACTOR_CRITIC_HIDDEN_DIM: 1024
+      FC_N_LAYERS: 3
       test_mode: false
       performance_bounds:
         returned_episode_returns: [[0.0, 11.11]]

--- a/evaluation/configs/global_heldout_settings.yaml
+++ b/evaluation/configs/global_heldout_settings.yaml
@@ -10,7 +10,7 @@ global_heldout_settings:
 heldout_set:
   lbf/lbf_7x7_nolevels: # DONE - DO NOT MODIFY. In LBF, results are much better with test mode = false.
     ippo_mlp: 
-      path: "eval_teammates/lbf/ippo/2025-04-21_23-41-17/saved_train_run"
+      path: "eval_teammates/lbf_7x7/ippo/2025-04-21_23-41-17/saved_train_run"
       actor_type: mlp
       ckpt_key: final_params
       idx_list: [0] # load in seed 0 only
@@ -19,7 +19,7 @@ heldout_set:
         percent_eaten: [[0.0, 100.0]]
         returned_episode_returns: [[0.0, 0.5]]
     ippo_mlp_s2c0:
-      path: "eval_teammates/lbf/ippo/2025-04-21_23-41-17/saved_train_run"
+      path: "eval_teammates/lbf_7x7/ippo/2025-04-21_23-41-17/saved_train_run"
       actor_type: mlp
       idx_list: [[2, 0]] # load in seed 2 ckpt 0
       test_mode: false
@@ -27,7 +27,7 @@ heldout_set:
         percent_eaten: [[0.0, 93.75]]
         returned_episode_returns: [[0.0, 0.47]]
     brdiv-conf1: 
-      path: "eval_teammates/lbf/brdiv/2025-04-16/11-32-07/saved_train_run"
+      path: "eval_teammates/lbf_7x7/brdiv/2025-04-16/11-32-07/saved_train_run"
       actor_type: actor_with_conditional_critic
       idx_list: [0, 1, 2] # load in population members 0, 1, 2
       ckpt_key: final_params_conf # key to load from checkpoint.
@@ -37,7 +37,7 @@ heldout_set:
         percent_eaten: [[0.0, 90.10], [0.0, 98.96], [0.0, 76.56]]
         returned_episode_returns: [[0.0, 0.45], [0.0, 0.49], [0.0, 0.39]]
     brdiv-conf2:
-      path: "eval_teammates/lbf/brdiv/2025-04-23/13-48-47/saved_train_run"
+      path: "eval_teammates/lbf_7x7/brdiv/2025-04-23/13-48-47/saved_train_run"
       actor_type: actor_with_conditional_critic
       idx_list: [0, 1]
       ckpt_key: final_params_conf
@@ -94,7 +94,7 @@ heldout_set:
         percent_eaten: [0.0, 100.0]
         returned_episode_returns: [0.0, 0.5]
     lbrdiv-conf:
-      path: "eval_teammates/lbf/lbrdiv/2026-03-02_13-01-20/saved_train_run/"
+      path: "eval_teammates/lbf_7x7/lbrdiv/2026-03-02_13-01-20/saved_train_run/"
       actor_type: actor_with_conditional_critic
       idx_list: [[1, 0], [1, 1], [1, 2]]
       ckpt_key: final_params_conf
@@ -104,7 +104,7 @@ heldout_set:
         percent_eaten: [[0.0, 90.10], [0.0, 89.98], [0.0, 92.19]]
         returned_episode_returns: [[0.0, 0.45], [0.0, 0.45], [0.0, 0.46]]
     comedi:
-      path: "eval_teammates/lbf/comedi/2026-03-02_00-58-19/saved_train_run/"
+      path: "eval_teammates/lbf_7x7/comedi/2026-03-02_00-58-19/saved_train_run/"
       actor_type: actor_with_conditional_critic
       idx_list: [[1, 0], [1, 1], [1, 2], [1, 3], [1, 4]]
       ckpt_key: final_params_conf
@@ -113,7 +113,17 @@ heldout_set:
       performance_bounds:
         percent_eaten: [[0.0, 100.00], [0.0, 51.56], [0.0, 100.00], [0.0, 100.00], [0.0, 99.48]]
         returned_episode_returns: [[0.0, 0.50], [0.0, 0.32], [0.0, 0.50], [0.0, 0.50], [0.0, 0.50]]
-    # TODO: add human_proxy (human-regularized RL) once checkpoints are available.
+    # TODO: enable once the real 7x7 checkpoint is uploaded. The current file at
+    # lbf_7x7/human_proxy on HF is a byte-identical duplicate of the lbf_12x12
+    # checkpoint (obs_dim 24, incompatible with the 7x7 env's 15-dim obs).
+    # human_proxy:
+    #   actor_type: bc_lstm
+    #   weight_file: eval_teammates/lbf_7x7/human_proxy/policy.safetensors
+    #   greedy: true
+    #   test_mode: true
+    #   performance_bounds:
+    #     percent_eaten: [0.0, 100.0]
+    #     returned_episode_returns: [0.0, 0.5]
   lbf/lbf_12x12:
     ippo_mlp:
       path: "eval_teammates/lbf_12x12/ippo-lbf-12-levels/saved_train_run"
@@ -201,7 +211,14 @@ heldout_set:
       performance_bounds:
         percent_eaten: [0.0, 100.0]
         returned_episode_returns: [0.0, 0.5]
-    # TODO: add human_proxy (human-regularized RL) once checkpoints are available.
+    human_proxy:
+      actor_type: bc_lstm
+      weight_file: eval_teammates/lbf_12x12/human_proxy/policy.safetensors
+      greedy: true
+      test_mode: true
+      performance_bounds:
+        percent_eaten: [0.0, 70.34]
+        returned_episode_returns: [0.0, 0.3517]
   overcooked-v1/cramped_room: # DONE - DO NOT MODIFY
     ippo_mlp: 
       path: "eval_teammates/overcooked-v1/cramped_room/ippo/2025-04-21_22-53-04/saved_train_run"

--- a/evaluation/configs/global_heldout_settings.yaml
+++ b/evaluation/configs/global_heldout_settings.yaml
@@ -113,14 +113,7 @@ heldout_set:
       performance_bounds:
         percent_eaten: [[0.0, 100.00], [0.0, 51.56], [0.0, 100.00], [0.0, 100.00], [0.0, 99.48]]
         returned_episode_returns: [[0.0, 0.50], [0.0, 0.32], [0.0, 0.50], [0.0, 0.50], [0.0, 0.50]]
-    human_proxy:
-      path: "eval_teammates/lbf/lbf_7x7/human_proxy"
-      actor_type: bc_proxy
-      layout: lbf_7x7
-      test_mode: true
-      performance_bounds:
-        percent_eaten: [0.0, 100.0]
-        returned_episode_returns: [0.0, 0.5]
+    # TODO: add human_proxy (human-regularized RL) once checkpoints are available.
   lbf/lbf_12x12:
     ippo_mlp:
       path: "eval_teammates/lbf_12x12/ippo-lbf-12-levels/saved_train_run"
@@ -208,14 +201,7 @@ heldout_set:
       performance_bounds:
         percent_eaten: [0.0, 100.0]
         returned_episode_returns: [0.0, 0.5]
-    human_proxy:
-      path: "eval_teammates/lbf_12x12/human_proxy"
-      actor_type: bc_proxy
-      layout: lbf_12x12
-      test_mode: true
-      performance_bounds:
-        percent_eaten: [0.0, 70.34]
-        returned_episode_returns: [0.0, 0.3517]
+    # TODO: add human_proxy (human-regularized RL) once checkpoints are available.
   overcooked-v1/cramped_room: # DONE - DO NOT MODIFY
     ippo_mlp: 
       path: "eval_teammates/overcooked-v1/cramped_room/ippo/2025-04-21_22-53-04/saved_train_run"

--- a/evaluation/heldout_evaluator.py
+++ b/evaluation/heldout_evaluator.py
@@ -102,8 +102,9 @@ def load_heldout_set(heldout_config, env, task_name, env_kwargs, rng):
         params_list = None
         idx_labels = None
         test_mode = agent_config.get("test_mode", False)
-        # Load RL-based agents
-        if "path" in agent_config:
+        # Load RL-based agents. bc_proxy agents are loaded as heuristic agents
+        # (BCPolicy locates its own checkpoint; the config "path" is informational).
+        if "path" in agent_config and agent_config.get("actor_type") != "bc_proxy":
             # ensure that each rl agent has a unique initialization rng
             rng, init_rng = jax.random.split(rng)
             policy, params, init_params, idx_labels = initialize_rl_agent_from_config(agent_config, agent_name, env, init_rng)

--- a/scripts/test_algos.sh
+++ b/scripts/test_algos.sh
@@ -57,7 +57,7 @@ LOG="$RESULTS_DIR/summary.log"
 COMMON_FLAGS="logger.mode=offline logger.log_train_out=false logger.log_eval_out=false local_logger.save_train_out=false local_logger.save_eval_out=false"
 
 # Path to a pre-trained IPPO partner checkpoint (required by ego-training algos).
-PARTNER_PATH="eval_teammates/lbf/ippo/ippo-lbf-7-levels/saved_train_run/"
+PARTNER_PATH="eval_teammates/lbf_7x7/ippo/ippo-lbf-7-levels/saved_train_run/"
 
 # =============================================================================
 # ─── Job definitions ──────────────────────────────────────────────────────────

--- a/tests/test_heldout_loading.py
+++ b/tests/test_heldout_loading.py
@@ -1,0 +1,56 @@
+"""Smoke test: load every heldout agent for every task in global_heldout_settings.yaml.
+
+Catches config/checkpoint mismatches (bad paths, missing idx_list, wrong
+actor_type routing) without running any evaluation rollouts.
+
+Run with: PYTHONPATH=. python tests/test_heldout_loading.py
+Requires the eval_teammates data (see download_eval_data.py).
+"""
+import os
+
+import jax
+import yaml
+
+from envs import make_env
+from envs.log_wrapper import LogWrapper
+from evaluation.heldout_evaluator import load_heldout_set
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+HELDOUT_CONFIG = os.path.join(REPO_ROOT, "evaluation/configs/global_heldout_settings.yaml")
+TASK_CONFIG_DIR = os.path.join(REPO_ROOT, "evaluation/configs/task")
+
+
+def load_task_config(task_name):
+    with open(os.path.join(TASK_CONFIG_DIR, f"{task_name}.yaml")) as f:
+        return yaml.safe_load(f)
+
+
+def test_load_all_heldout_agents():
+    with open(HELDOUT_CONFIG) as f:
+        heldout_set = yaml.safe_load(f)["heldout_set"]
+
+    rng = jax.random.PRNGKey(0)
+    failures = []
+    for task_name, heldout_config in heldout_set.items():
+        task_cfg = load_task_config(task_name)
+        env_kwargs = task_cfg["ENV_KWARGS"] or {}
+        env = LogWrapper(make_env(task_cfg["ENV_NAME"], env_kwargs))
+        try:
+            agents = load_heldout_set(heldout_config, env, task_name, env_kwargs, rng)
+        except FileNotFoundError as e:
+            # Checkpoint data not downloaded on this machine (see download_eval_data.py).
+            print(f"[skip] {task_name}: {e}")
+            continue
+        except Exception as e:
+            failures.append((task_name, e))
+            print(f"[FAIL] {task_name}: {type(e).__name__}: {e}")
+            continue
+        assert agents, f"{task_name}: no heldout agents loaded"
+        print(f"[ok] {task_name}: loaded {len(agents)} agents: {sorted(agents)}")
+
+    assert not failures, f"Failed to load heldout agents for: {[t for t, _ in failures]}"
+
+
+if __name__ == "__main__":
+    test_load_all_heldout_agents()
+    print("All heldout sets loaded successfully.")


### PR DESCRIPTION
Replaces #99, which was closed by a branch rename.

Heldout evaluation crashed for any `bc_proxy` entry ("Indices to load from checkpoint must be provided") because `load_heldout_set` routed every config entry with a `path` key to the RL checkpoint loader. Now `bc_proxy` entries route to the heuristic loader, and `BCPolicy` takes its model directory from the config's `path` instead of the hardcoded map in `bc_agent.py`.

Also renames `eval_teammates/lbf` → `lbf_7x7` (mirrored on the HF hub), adds an LBF BC-LSTM `human_proxy` loader (no `idx_list` needed), and enables the `lbf_12x12` human_proxy heldout entry. The 7x7 entry is commented out: the checkpoint on HF is a byte-identical duplicate of the 12x12 one (obs_dim 24, incompatible with the 7x7 env).

Verified via the `ppo_ego` job from `scripts/test_algos.sh` end to end, and by loading the full heldout sets for both LBF tasks.