### PR TITLE
Add LBF BC-LSTM loader

### DIFF
--- a/agents/lbf/agent_policy_wrappers.py
+++ b/agents/lbf/agent_policy_wrappers.py
@@ -1,12 +1,80 @@
 '''Wrap heuristic agent policies in AgentPolicy interface.
 TODO: clean up logic by vectorizing init_hstate. See HeuristicPolicyPopulation.
 '''
+import os
+
 import jax
+import jax.numpy as jnp
+import yaml
+
 from agents.agent_interface import AgentPolicy
+from agents.bc import BCLSTMAgent, BCLSTMConfig
 from agents.lbf.random_agent import RandomAgent
 from agents.lbf.sequential_fruit_agent import SequentialFruitAgent
 from agents.lbf.entitled_agent import EntitledAgent
 from agents.lbf.greedy_heuristic_agent import GreedyHeuristicAgent
+from common.save_load_utils import REPO_PATH
+
+
+class LBFBCLSTMPolicyWrapper(AgentPolicy):
+    """Load an LBF BC-LSTM checkpoint and adapt observations for evaluation."""
+
+    def __init__(self, weight_file: str, greedy: bool = True):
+        yaml_path = weight_file.rsplit('.', 1)[0] + '.yaml'
+        abs_yaml_path = (
+            yaml_path if os.path.isabs(yaml_path)
+            else os.path.join(REPO_PATH, yaml_path)
+        )
+        with open(abs_yaml_path) as config_file:
+            saved_config = yaml.safe_load(config_file)
+
+        config = BCLSTMConfig(
+            obs_dim=saved_config["obs_dim"],
+            action_dim=saved_config["action_dim"],
+            preprocess_dim=saved_config.get("preprocess_dim", 1024),
+            lstm_dim=saved_config.get("lstm_dim", 512),
+            postprocess_dim=saved_config.get("postprocess_dim", 256),
+            dropout_rate=saved_config.get("dropout_rate", 0.0),
+        )
+        super().__init__(config.action_dim, config.obs_dim)
+        self.agent = BCLSTMAgent(config, weight_path=weight_file)
+        self.greedy = greedy
+
+    def _prepare_obs(self, obs):
+        obs = jnp.asarray(obs).reshape(-1)
+        if obs.shape[0] > self.obs_dim:
+            raise ValueError(
+                f"BC-LSTM expects at most {self.obs_dim} observation values, "
+                f"received {obs.shape[0]}."
+            )
+        if obs.shape[0] < self.obs_dim:
+            obs = jnp.pad(obs, (0, self.obs_dim - obs.shape[0]))
+        return obs
+
+    def get_action(self, params, obs, done, avail_actions, hstate, rng,
+                   env_state, aux_obs=None, test_mode=False):
+        del params, env_state, aux_obs
+        obs = self._prepare_obs(obs)
+        if avail_actions is None:
+            legal_mask = jnp.ones(self.action_dim, dtype=jnp.float32)
+        else:
+            legal_mask = jnp.asarray(avail_actions).reshape(-1).astype(jnp.float32)
+
+        done = jnp.asarray(done).reshape(-1)[0].astype(bool)
+        hstate = jax.lax.cond(
+            done,
+            lambda: self.agent.init_carry(),
+            lambda: hstate,
+        )
+        if self.greedy or test_mode:
+            carry, action = self.agent.greedy_act(hstate, obs, legal_mask)
+        else:
+            carry, action = self.agent.sample_act(hstate, obs, legal_mask, rng)
+        return action, carry
+
+    def init_hstate(self, batch_size: int, aux_info=None):
+        del batch_size, aux_info
+        return self.agent.init_carry()
 
 
 

--- a/agents/lbf/agent_policy_wrappers.py
+++ b/agents/lbf/agent_policy_wrappers.py
@@ -52,7 +52,7 @@ class LBFBCLSTMPolicyWrapper(AgentPolicy):
         return obs
 
     def get_action(self, params, obs, done, avail_actions, hstate, rng,
-                   env_state, aux_obs=None, test_mode=False):
+                   aux_obs=None, env_state=None, test_mode=False):
         del params, env_state, aux_obs
         obs = self._prepare_obs(obs)
         if avail_actions is None:

--- a/common/agent_loader_from_config.py
+++ b/common/agent_loader_from_config.py
@@ -10,6 +10,7 @@ from agents.initialize_agents import initialize_s5_agent, initialize_mlp_agent, 
 from agents.lbf.agent_policy_wrappers import (
     LBFRandomPolicyWrapper, LBFSequentialFruitPolicyWrapper,
     LBFEntitledPolicyWrapper, LBFGreedyHeuristicPolicyWrapper,
+    LBFBCLSTMPolicyWrapper,
 )
 from agents.overcooked.agent_policy_wrappers import (
     OvercookedRandomPolicyWrapper, OvercookedIndependentPolicyWrapper,
@@ -134,6 +135,11 @@ def initialize_heuristic_agent_from_config(agent_config, agent_name, task_name, 
                 num_fruits=num_fruits,
                 heuristic=heuristic,
                 using_log_wrapper=True,
+            )
+        if actor_type == "bc_lstm":
+            return LBFBCLSTMPolicyWrapper(
+                weight_file=agent_config["weight_file"],
+                greedy=agent_config.get("greedy", True),
             )
         raise ValueError(f"Unrecognized actor type for {task_name}: '{actor_type}' ({agent_name})")
 

--- a/tests/test_lbf_bc_lstm_policy.py
+++ b/tests/test_lbf_bc_lstm_policy.py
@@ -1,0 +1,107 @@
+import jax
+import jax.numpy as jnp
+import pytest
+import yaml
+
+from agents.bc import BCLSTMAgent, BCLSTMConfig
+from agents.lbf.agent_policy_wrappers import LBFBCLSTMPolicyWrapper
+from common.agent_loader_from_config import initialize_heuristic_agent_from_config
+from envs import make_env
+from envs.log_wrapper import LogWrapper
+
+
+def _write_checkpoint(tmp_path):
+    config = BCLSTMConfig(
+        obs_dim=24,
+        action_dim=6,
+        preprocess_dim=16,
+        lstm_dim=8,
+        postprocess_dim=8,
+    )
+    agent = BCLSTMAgent(config)
+    agent.init_params(jax.random.PRNGKey(0))
+
+    weight_path = tmp_path / "policy.safetensors"
+    agent.save_weights(str(weight_path))
+    with open(tmp_path / "policy.yaml", "w") as config_file:
+        yaml.safe_dump(config._asdict(), config_file)
+    return weight_path
+
+
+def test_lbf_bc_lstm_loader_pads_7x7_observations(tmp_path):
+    weight_path = _write_checkpoint(tmp_path)
+    policy = initialize_heuristic_agent_from_config(
+        {
+            "actor_type": "bc_lstm",
+            "weight_file": str(weight_path),
+            "greedy": True,
+        },
+        agent_name="human_proxy",
+        task_name="lbf/lbf_7x7_nolevels",
+    )
+
+    obs_7x7 = jnp.arange(15, dtype=jnp.float32).reshape(1, 1, 15)
+    obs_12x12 = jnp.pad(obs_7x7, ((0, 0), (0, 0), (0, 9)))
+    legal_actions = jnp.array([0, 0, 0, 1, 0, 0], dtype=jnp.float32)
+    done = jnp.array([[False]])
+    hstate = policy.init_hstate(1)
+
+    action_7x7, carry_7x7 = policy.get_action(
+        None, obs_7x7, done, legal_actions, hstate,
+        jax.random.PRNGKey(1), env_state=None, test_mode=True,
+    )
+    action_12x12, carry_12x12 = policy.get_action(
+        None, obs_12x12, done, legal_actions, hstate,
+        jax.random.PRNGKey(1), env_state=None, test_mode=True,
+    )
+
+    assert isinstance(policy, LBFBCLSTMPolicyWrapper)
+    assert int(action_7x7) == 3
+    assert int(action_12x12) == 3
+    assert all(jax.tree.leaves(
+        jax.tree.map(jnp.array_equal, carry_7x7, carry_12x12)
+    ))
+
+
+def test_lbf_bc_lstm_loader_rejects_oversized_observations(tmp_path):
+    weight_path = _write_checkpoint(tmp_path)
+    policy = LBFBCLSTMPolicyWrapper(str(weight_path))
+
+    with pytest.raises(ValueError, match="expects at most 24"):
+        policy._prepare_obs(jnp.zeros(25))
+
+
+@pytest.mark.parametrize(
+    ("env_kwargs", "expected_obs_dim"),
+    [
+        ({"grid_size": 7, "num_food": 3, "different_levels": False}, 15),
+        ({"grid_size": 12, "num_food": 6, "different_levels": True}, 24),
+    ],
+)
+def test_lbf_bc_lstm_policy_steps_both_domains(
+        tmp_path, env_kwargs, expected_obs_dim):
+    weight_path = _write_checkpoint(tmp_path)
+    policy = LBFBCLSTMPolicyWrapper(str(weight_path), greedy=True)
+    env = LogWrapper(make_env("lbf", env_kwargs))
+
+    rng = jax.random.PRNGKey(2)
+    rng, reset_rng, action_rng, step_rng = jax.random.split(rng, 4)
+    obs, env_state = env.reset(reset_rng)
+    assert obs["agent_1"].shape[-1] == expected_obs_dim
+
+    avail_actions = env.get_avail_actions(env_state)["agent_1"]
+    action, _ = policy.get_action(
+        None,
+        obs["agent_1"].reshape(1, 1, -1),
+        jnp.array([[False]]),
+        avail_actions,
+        policy.init_hstate(1),
+        action_rng,
+        env_state=env_state,
+        test_mode=True,
+    )
+    env.step(
+        step_rng,
+        env_state,
+        {"agent_0": jnp.array(0), "agent_1": action.squeeze()},
+    )

--- a/tests/test_lbf_bc_lstm_policy.py
+++ b/tests/test_lbf_bc_lstm_policy.py
@@ -48,7 +48,7 @@ def test_lbf_bc_lstm_loader_pads_7x7_observations(tmp_path):
 
     action_7x7, carry_7x7 = policy.get_action(
         None, obs_7x7, done, legal_actions, hstate,
-        jax.random.PRNGKey(1), env_state=None, test_mode=True,
+        jax.random.PRNGKey(1),
     )
     action_12x12, carry_12x12 = policy.get_action(
         None, obs_12x12, done, legal_actions, hstate,


### PR DESCRIPTION
## Summary

- add an LBF BC-LSTM policy wrapper and config-based loader
- load the saved architecture from the checkpoint's sibling YAML file
- pad 7x7 observations from 15 to the pooled model's 24 inputs while leaving 12x12 observations unchanged
- preserve legal-action masking, recurrent state handling, and greedy or sampled evaluation

## Fix

The pooled LBF human-proxy checkpoint was published for both 7x7 and 12x12, but the padding-aware BC-LSTM wrapper was never merged into `main`. This left benchmark users without a loader and made 7x7 observations incompatible with the model's 24-dimensional input.

## Testing

- `tests/test_lbf_bc_lstm_policy.py`: 4 passed locally on macOS
- 4 passed on Pepi using CPU JAX 0.5.3 at commit `0233d83`
- loaded the checksum-matched public `jaxaht/eval-teammates` checkpoint
- completed an environment step in LBF 7x7 with 15-to-24 padding
- completed an environment step in LBF 12x12 with its unchanged 24-dimensional observation