### PR TITLE
Add CPU algorithm smoke tests

### DIFF
--- a/envs/lbf/lbf_wrapper.py
+++ b/envs/lbf/lbf_wrapper.py
@@ -49,6 +49,7 @@ class LBFWrapper(BaseEnv):
         self._jit_key = (
             self.num_agents,
             self.share_rewards,
+            self.env.time_limit,
             type(gen).__name__,
             getattr(gen, 'grid_size', None),
             getattr(gen, 'num_food', None),

--- a/human_data_collecting/test_app.py
+++ b/human_data_collecting/test_app.py
@@ -1,204 +1,103 @@
-"""
-Test script to verify the LBF human interaction app components work correctly.
-"""
-import sys
-import os
-
-# Add parent directory to path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import json
+import time
+from pathlib import Path
 
 import jax
-import jax.numpy as jnp
-from envs import make_env
+
 from agents.lbf import SequentialFruitAgent
+from envs import make_env
+
 
 def test_environment():
-    """Test that the LBF environment can be created and run."""
-    print("Testing LBF environment...")
-    
-    try:
-        env = make_env(
-            env_name="lbf", 
-            env_kwargs={
-                "time_limit": 50,
-                "grid_size": 7,
-                "num_agents": 2,
-                "num_food": 3,
-                "highlight_agent_idx": 0
-            }
-        )
-        
-        # Test reset
-        rng = jax.random.PRNGKey(0)
-        obs, state = env.reset(rng)
-        
-        print(f"  ✓ Environment created successfully")
-        print(f"  ✓ Grid size: 7x7")
-        print(f"  ✓ Number of agents: 2")
-        print(f"  ✓ Observation shape: {obs['agent_0'].shape}")
-        
-        return True
-    except Exception as e:
-        print(f"  ✗ Error: {e}")
-        return False
+    env = make_env(
+        "lbf",
+        {
+            "time_limit": 5,
+            "grid_size": 7,
+            "num_agents": 2,
+            "num_food": 3,
+            "highlight_agent_idx": 0,
+        },
+    )
+
+    observations, _ = env.reset(jax.random.PRNGKey(0))
+
+    assert observations["agent_0"].shape == (15,)
+
 
 def test_agent():
-    """Test that the heuristic agent works."""
-    print("\nTesting heuristic agent...")
-    
-    try:
-        agent = SequentialFruitAgent(
-            grid_size=7, 
-            num_fruits=3, 
-            ordering_strategy='nearest_agent'
-        )
-        
-        # Initialize agent state
-        agent_state = agent.init_agent_state(1)
-        
-        print(f"  ✓ Agent created successfully")
-        print(f"  ✓ Agent name: {agent.get_name()}")
-        
-        return True
-    except Exception as e:
-        print(f"  ✗ Error: {e}")
-        return False
+    agent = SequentialFruitAgent(
+        grid_size=7,
+        num_fruits=3,
+        ordering_strategy="nearest_agent",
+    )
+
+    assert agent.init_agent_state(1) is not None
+    assert agent.get_name()
+
 
 def test_episode():
-    """Test running a short episode."""
-    print("\nTesting episode execution...")
-    
-    try:
-        # Create environment and agent
-        env = make_env(
-            env_name="lbf", 
-            env_kwargs={"time_limit": 10, "grid_size": 7, "num_agents": 2, "num_food": 3}
-        )
-        agent = SequentialFruitAgent(grid_size=7, num_fruits=3, ordering_strategy='nearest_agent')
-        
-        # Initialize
-        rng = jax.random.PRNGKey(42)
-        obs, state = env.reset(rng)
-        agent_state = agent.init_agent_state(1)
-        
-        # Run a few steps
-        total_reward = 0
-        for step in range(5):
-            # Both agents take random actions for this test
-            rng, key1, key2, step_key = jax.random.split(rng, 4)
-            
-            action0 = jax.random.randint(key1, (), 0, 6)
-            action1, agent_state = agent.get_action(obs["agent_1"], state, agent_state, key2)
-            
-            actions = {"agent_0": action0, "agent_1": action1}
-            obs, state, rewards, done, info = env.step(step_key, state, actions)
-            
-            total_reward += float(rewards["agent_0"]) + float(rewards["agent_1"])
-            
-            if done["__all__"]:
-                break
-        
-        print(f"  ✓ Ran {step + 1} steps successfully")
-        print(f"  ✓ Total reward: {total_reward:.2f}")
-        
-        return True
-    except Exception as e:
-        print(f"  ✗ Error: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+    env = make_env(
+        "lbf",
+        {"time_limit": 5, "grid_size": 7, "num_agents": 2, "num_food": 3},
+    )
+    agent = SequentialFruitAgent(7, 3, "nearest_agent")
+    rng = jax.random.PRNGKey(42)
+    observations, state = env.reset(rng)
+    agent_state = agent.init_agent_state(1)
+
+    rng, human_key, agent_key, step_key = jax.random.split(rng, 4)
+    human_action = jax.random.randint(human_key, (), 0, 6)
+    agent_action, agent_state = agent.get_action(
+        observations["agent_1"], state, agent_state, agent_key
+    )
+    observations, _, rewards, dones, _ = env.step(
+        step_key,
+        state,
+        {"agent_0": human_action, "agent_1": agent_action},
+    )
+
+    assert set(observations) == set(env.agents)
+    assert set(rewards) == set(env.agents)
+    assert "__all__" in dones
+
 
 def test_flask_imports():
-    """Test that Flask dependencies are available."""
-    print("\nTesting Flask dependencies...")
-    
-    try:
-        import flask
-        from flask import Flask, jsonify
-        from flask_cors import CORS
-        
-        print(f"  ✓ Flask version: {flask.__version__}")
-        print(f"  ✓ flask-cors available")
-        
-        return True
-    except ImportError as e:
-        print(f"  ✗ Missing dependency: {e}")
-        print(f"  → Run: pip install flask flask-cors")
-        return False
+    from flask import Flask, jsonify
+    from flask_cors import CORS
 
-def main():
-    """Run all tests."""
-    print("=" * 60)
-    print("LBF Human Interaction App - Component Tests")
-    print("=" * 60)
-    
-    tests = [
-        test_flask_imports,
-        test_environment,
-        test_agent,
-        test_episode,
-        test_data_timestamps
-    ]
-    
-    results = []
-    for test in tests:
-        results.append(test())
-    
-    for _ in range(2):
-        test_episode()
-    # run the timestamp test a couple times as well
-    for _ in range(2):
-        test_data_timestamps()
-
-    print("\n" + "=" * 60)
-    print(f"Test Results: {sum(results)}/{len(results)} passed")
-    print("=" * 60)
-    
-    if all(results):
-        print("\n✅ All tests passed! You can run the app with:")
-        print("   ./start_server.sh")
-        print("   or")
-        print("   python app.py")
-    else:
-        print("\n⚠️  Some tests failed. Please fix the issues before running the app.")
-        return 1
-    
-    return 0
+    assert Flask
+    assert jsonify
+    assert CORS
 
 
-def test_data_timestamps():
-    """Verify that saved episode JSON contains start/end times and elapsed fields."""
-    print("\nTesting data timestamps in saved JSON...")
-    from human_data.app import GameSession
-    import tempfile, json, time
+def test_data_timestamps(monkeypatch, tmp_path):
+    import human_data_collecting.app as app_module
 
-    # create a short game and take a couple steps
-    game = GameSession(session_id="test", max_steps=5, grid_size=7, num_fruits=3)
-    # initial reset already sets start_time
+    def choose_test_agent(game):
+        return SequentialFruitAgent(
+            game.grid_size,
+            game.num_fruits,
+            "nearest_agent",
+        )
+
+    monkeypatch.setattr(app_module.GameSession, "_choose_agent", choose_test_agent)
+    monkeypatch.setattr(app_module, "__file__", str(tmp_path / "app.py"))
+
+    game = app_module.GameSession(
+        session_id="test-session",
+        max_steps=5,
+        env_kwargs={"grid_size": 7, "num_food": 3},
+    )
     game.step(0)
-    game.step(1)
-    # force finish by marking done
     game.done = True
     game.end_time = time.time()
-    path = game.save_episode(player_name="tester")
-    if not path:
-        print("  ✗ failed to save episode file")
-        return False
-    with open(path) as f:
-        data = json.load(f)
-    # check keys
-    ok = True
-    for key in ('start_time','end_time','duration'):
-        if key not in data:
-            print(f"  ✗ missing {key} in episode JSON")
-            ok = False
-    traj = data.get('trajectory', [])
-    if traj:
-        if 'elapsed' not in traj[0] or 'timestamp' not in traj[0]:
-            print("  ✗ trajectory entries missing timing info")
-            ok = False
-    print("  ✓ data timestamps present?", ok)
-    return ok
+    path = Path(game.save_episode(player_name="tester"))
 
-if __name__ == "__main__":
-    exit(main())
+    assert path.parent == tmp_path / "collected_data"
+    data = json.loads(path.read_text())
+    assert data["start_time"] is not None
+    assert data["end_time"] is not None
+    assert data["duration"] >= 0
+    assert data["trajectory"][0]["timestamp"] is not None
+    assert data["trajectory"][0]["elapsed"] >= 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,14 @@ dependencies = [
     "jaxmarl==0.0.7",
 ]
 
+[project.optional-dependencies]
+test = [
+    "flask>=2.3.0",
+    "flask-cors>=4.0.0",
+    "pytest>=8,<10",
+    "ruff>=0.11,<0.17",
+]
+
 [project.urls]
 Homepage = "https://github.com/LARG/jax-aht"
 Repository = "https://github.com/LARG/jax-aht"
@@ -62,3 +70,8 @@ include = ["agents*", "common*", "envs*", "evaluation*", "ego_agent_training*", 
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml", "*.yml", "*.json", "*.md"]
+
+[tool.pytest.ini_options]
+markers = [
+    "eval_data: requires locally downloaded eval teammate checkpoints",
+]

--- a/scripts/test_algos.sh
+++ b/scripts/test_algos.sh
@@ -1,227 +1,209 @@
 #!/usr/bin/env bash
-# =============================================================================
-# test_algos.sh — Smoke-test all algorithms in parallel across GPUs.
+# Smoke-test every training entry point on CPU or GPU.
 #
-# PURPOSE
-#   Runs a short training pass for every algorithm to verify that the code
-#   executes end-to-end without errors.  All runs use tiny timestep budgets,
-#   offline logging, and skip artifact saving so they finish quickly.
+# Usage:
+#   bash scripts/test_algos.sh --device cpu
+#   bash scripts/test_algos.sh --device gpu
 #
-# USAGE
-#   bash scripts/test_algos.sh
-#   Run from anywhere; the script locates the repo root automatically.
-#
-# OUTPUT
-#   Each job's stdout/stderr is written to:
-#     results/test_algos_<timestamp>/<job_name>.log
-#   A running status log and final summary are written to:
-#     results/test_algos_<timestamp>/summary.log
-#   The script exits 0 if all jobs passed, 1 if any failed.
-#
-# GPU REQUIREMENTS
-#   Any GPU reported by nvidia-smi with >= 20 GB of free memory is used.
-#   Jobs are distributed across available GPUs; up to N jobs run in parallel
-#   where N = number of qualifying GPUs.  The script aborts if none qualify.
-#
-# SELECTING WHICH ALGORITHMS TO RUN
-#   Edit the RUN_JOBS array (just below the job definitions).
-#   List the job names you want to run, e.g.:
-#     RUN_JOBS=(ippo brdiv liam_ego)
-#   Leave it empty to run every defined job:
-#     RUN_JOBS=()
-#
-# ADDING A NEW TEST
-#   1. Append a name to JOB_NAMES and the matching command to JOB_CMDS in the
-#      "Job definitions" section below.  The two arrays must stay in sync.
-#   2. Add the name to RUN_JOBS (or leave RUN_JOBS empty to run all).
-#   3. Each JOB_CMDS entry is a plain shell command string (no special quoting
-#      needed; use backslash-newline for readability as shown below).
-#   4. Use the shared COMMON_FLAGS variable for the standard set of flags that
-#      disable logging and artifact saving.
-#
-# PREREQUISITES
-#   nvidia-smi must be on PATH (standard on any machine with an Nvidia driver).
-#   The conda/venv environment that can run the project must be active.
-# =============================================================================
+# CPU mode runs one minimal training update per algorithm, sequentially. The
+# IPPO job creates the checkpoint consumed by the ego-training jobs. GPU mode
+# preserves the larger parallel smoke tests and is the default.
+
 set -uo pipefail
 
-# ─── Paths ───────────────────────────────────────────────────────────────────
+usage() {
+    echo "Usage: bash scripts/test_algos.sh [--device cpu|gpu]" >&2
+    exit 2
+}
+
+DEVICE="gpu"
+if [[ $# -gt 0 ]]; then
+    [[ "$1" == "--device" && $# -eq 2 ]] || usage
+    DEVICE="$2"
+fi
+[[ "$DEVICE" == "cpu" || "$DEVICE" == "gpu" ]] || usage
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 RESULTS_DIR="$REPO_ROOT/results/test_algos_$(date +%Y-%m-%d_%H-%M-%S)"
-mkdir -p "$RESULTS_DIR"
 LOG="$RESULTS_DIR/summary.log"
+mkdir -p "$RESULTS_DIR"
 
-# ─── Shared flags ─────────────────────────────────────────────────────────────
-# Appended to every command: disables W&B uploads and local artifact saving.
-COMMON_FLAGS="logger.mode=offline logger.log_train_out=false logger.log_eval_out=false local_logger.save_train_out=false local_logger.save_eval_out=false"
+COMMON_FLAGS="logger.mode=disabled logger.log_train_out=false logger.log_eval_out=false local_logger.save_train_out=false local_logger.save_eval_out=false"
 
-# Path to a pre-trained IPPO partner checkpoint (required by ego-training algos).
-PARTNER_PATH="eval_teammates/lbf_7x7/ippo/ippo-lbf-7-levels/saved_train_run/"
+if [[ "$DEVICE" == "cpu" ]]; then
+    PARTNER_PATH="$RESULTS_DIR/ippo_partner/saved_train_run"
+    IPPO_FLAGS="algorithm.TOTAL_TIMESTEPS=128 algorithm.NUM_ENVS=1 algorithm.NUM_SEEDS=1 algorithm.NUM_CHECKPOINTS=1 algorithm.UPDATE_EPOCHS=1 algorithm.NUM_MINIBATCHES=1 local_logger.save_train_out=true hydra.run.dir=$RESULTS_DIR/ippo_partner"
+    BRDIV_FLAGS="algorithm.TOTAL_TIMESTEPS=256 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_ENVS=2 algorithm.NUM_SEEDS=1 algorithm.NUM_CHECKPOINTS=1 algorithm.UPDATE_EPOCHS=1 algorithm.NUM_MINIBATCHES=1"
+    LBRDIV_FLAGS="$BRDIV_FLAGS"
+    COMEDI_FLAGS="algorithm.TOTAL_TIMESTEPS_PER_ITERATION=1152 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_ARGMAX_ROLLOUT_EPS=1 algorithm.NUM_EVAL_EPISODES=1 algorithm.NUM_ENVS=2 algorithm.NUM_SEEDS=1 algorithm.NUM_CHECKPOINTS=1 algorithm.UPDATE_EPOCHS=1 algorithm.NUM_MINIBATCHES=1"
+    FCP_FLAGS="algorithm.TOTAL_TIMESTEPS=128 algorithm.PARTNER_POP_SIZE=1 algorithm.NUM_ENVS=1 algorithm.NUM_SEEDS=1 algorithm.NUM_CHECKPOINTS=1 algorithm.UPDATE_EPOCHS=1 algorithm.NUM_MINIBATCHES=1"
+    PPO_EGO_FLAGS="algorithm.TOTAL_TIMESTEPS=256 algorithm.NUM_ENVS=2 algorithm.NUM_EGO_TRAIN_SEEDS=1 algorithm.NUM_CHECKPOINTS=1 algorithm.UPDATE_EPOCHS=1 algorithm.NUM_MINIBATCHES=1 algorithm.S5_D_MODEL=16 algorithm.S5_SSM_SIZE=16 algorithm.S5_ACTOR_CRITIC_HIDDEN_DIM=64 algorithm.FC_N_LAYERS=2"
+    LIAM_EGO_FLAGS="algorithm.TOTAL_TIMESTEPS=256 algorithm.NUM_ENVS=2 algorithm.NUM_EGO_TRAIN_SEEDS=1 algorithm.NUM_CHECKPOINTS=1 algorithm.UPDATE_EPOCHS=1 algorithm.NUM_MINIBATCHES=1 algorithm.ENCODER_HIDDEN_DIM=16 algorithm.ENCODER_OUTPUT_DIM=8 algorithm.DECODER_HIDDEN_DIM=16 algorithm.POLICY_INPUT_DIM=8"
+    MELIBA_EGO_FLAGS="algorithm.TOTAL_TIMESTEPS=256 algorithm.NUM_ENVS=2 algorithm.NUM_EGO_TRAIN_SEEDS=1 algorithm.NUM_CHECKPOINTS=1 algorithm.UPDATE_EPOCHS=1 algorithm.NUM_MINIBATCHES=1 algorithm.ENCODER_STATE_EMBED_DIM=16 algorithm.ENCODER_ACTION_EMBED_DIM=16 algorithm.ENCODER_REWARD_EMBED_DIM=16 algorithm.ENCODER_RNN_HIDDEN_DIM=16 algorithm.ENCODER_LAYERS_BEFORE_RNN=16 algorithm.ENCODER_LAYERS_AFTER_RNN=16 algorithm.ENCODER_LATENT_DIM=16 algorithm.DECODER_STATE_EMBED_DIM=16 algorithm.DECODER_AGENT_CHARACTER_EMBED_DIM=8 algorithm.DECODER_HIDDEN_DIM=16"
+    ROTATE_FLAGS="algorithm.NUM_OPEN_ENDED_ITERS=1 algorithm.TIMESTEPS_PER_ITER_PARTNER=1024 algorithm.TIMESTEPS_PER_ITER_EGO=256 algorithm.PARTNER_POP_SIZE=1 algorithm.NUM_ENVS=2 algorithm.NUM_SEEDS=1 algorithm.NUM_CHECKPOINTS=1 algorithm.UPDATE_EPOCHS=1 algorithm.NUM_MINIBATCHES=1 algorithm.EGO_ARGS.UPDATE_EPOCHS=1 algorithm.EGO_ARGS.S5_D_MODEL=16 algorithm.EGO_ARGS.S5_SSM_SIZE=16 algorithm.EGO_ARGS.S5_ACTOR_CRITIC_HIDDEN_DIM=64 algorithm.EGO_ARGS.FC_N_LAYERS=2"
+    COLE_FLAGS="algorithm.TOTAL_TIMESTEPS_PER_ITERATION=1024 algorithm.PARTNER_POP_SIZE=2 algorithm.XP_EVAL_ROLLOUT_EPS=1 algorithm.NUM_EVAL_EPISODES=1 algorithm.NUM_ENVS=2 algorithm.NUM_SEEDS=1 algorithm.NUM_CHECKPOINTS=1 algorithm.UPDATE_EPOCHS=1 algorithm.NUM_MINIBATCHES=1 algorithm.SHAPLEY_MAX_ITER=1 algorithm.SHAPLEY_PAGERANK_ITER=2"
+    TRAJEDI_FLAGS="algorithm.TOTAL_TIMESTEPS=768 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_ENVS_CONFS=2 algorithm.NUM_ENVS_BR=2 algorithm.NUM_SEEDS=1 algorithm.NUM_CHECKPOINTS=1 algorithm.UPDATE_EPOCHS=1 algorithm.NUM_MINIBATCHES=1"
+    FCP_TRAIN_EGO="false"
+    PPO_EGO_HELDOUT_EVAL="false"
+else
+    PARTNER_PATH="eval_teammates/lbf_7x7/ippo/ippo-lbf-7-levels/saved_train_run/"
+    IPPO_FLAGS="algorithm.NUM_SEEDS=1"
+    BRDIV_FLAGS="algorithm.TOTAL_TIMESTEPS=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1"
+    LBRDIV_FLAGS="$BRDIV_FLAGS"
+    COMEDI_FLAGS="algorithm.TOTAL_TIMESTEPS_PER_ITERATION=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1"
+    FCP_FLAGS="algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_CHECKPOINTS=2 algorithm.ego_train_algorithm.TOTAL_TIMESTEPS=1e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1"
+    PPO_EGO_FLAGS="algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_EGO_TRAIN_SEEDS=1"
+    LIAM_EGO_FLAGS="$PPO_EGO_FLAGS"
+    MELIBA_EGO_FLAGS="$PPO_EGO_FLAGS"
+    ROTATE_FLAGS="algorithm.NUM_OPEN_ENDED_ITERS=1 algorithm.TIMESTEPS_PER_ITER_PARTNER=1e5 algorithm.TIMESTEPS_PER_ITER_EGO=1e5 algorithm.NUM_SEEDS=1"
+    COLE_FLAGS="algorithm.TOTAL_TIMESTEPS_PER_ITERATION=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1"
+    TRAJEDI_FLAGS="algorithm.TOTAL_TIMESTEPS=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1"
+    FCP_TRAIN_EGO="true"
+    PPO_EGO_HELDOUT_EVAL="true"
+fi
 
-# =============================================================================
-# ─── Job definitions ──────────────────────────────────────────────────────────
-# To add a new test:
-#   JOB_NAMES+=("my_algo_name")
-#   JOB_CMDS+=("python my_module/run.py algorithm=my_algo/lbf ... $COMMON_FLAGS")
-#
-# The two arrays are parallel: JOB_NAMES[i] is the label for JOB_CMDS[i].
-# Use backslash-newline for multi-line readability (bash strips them).
-# =============================================================================
 JOB_NAMES=()
 JOB_CMDS=()
 
-# ── MARL ──────────────────────────────────────────────────────────────────────
 JOB_NAMES+=("ippo")
-JOB_CMDS+=("python marl/run.py \
-    algorithm=ippo/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_ippo \
-    algorithm.NUM_SEEDS=1 \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python marl/run.py algorithm=ippo/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_ippo $COMMON_FLAGS $IPPO_FLAGS")
 
-# ── Teammate generation ───────────────────────────────────────────────────────
 JOB_NAMES+=("brdiv")
-JOB_CMDS+=("python teammate_generation/run.py \
-    algorithm=brdiv/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_brdiv \
-    run_heldout_eval=false train_ego=false \
-    algorithm.TOTAL_TIMESTEPS=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python teammate_generation/run.py algorithm=brdiv/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_brdiv run_heldout_eval=false train_ego=false $COMMON_FLAGS $BRDIV_FLAGS")
 
 JOB_NAMES+=("lbrdiv")
-JOB_CMDS+=("python teammate_generation/run.py \
-    algorithm=lbrdiv/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_lbrdiv \
-    run_heldout_eval=false train_ego=false \
-    algorithm.TOTAL_TIMESTEPS=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python teammate_generation/run.py algorithm=lbrdiv/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_lbrdiv run_heldout_eval=false train_ego=false $COMMON_FLAGS $LBRDIV_FLAGS")
 
 JOB_NAMES+=("comedi")
-JOB_CMDS+=("python teammate_generation/run.py \
-    algorithm=comedi/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_comedi \
-    run_heldout_eval=false train_ego=false \
-    algorithm.TOTAL_TIMESTEPS_PER_ITERATION=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python teammate_generation/run.py algorithm=comedi/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_comedi run_heldout_eval=false train_ego=false $COMMON_FLAGS $COMEDI_FLAGS")
 
-# test training ego agent
 JOB_NAMES+=("fcp")
-JOB_CMDS+=("python teammate_generation/run.py \
-    algorithm=fcp/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_fcp \
-    run_heldout_eval=false train_ego=true \
-    algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_CHECKPOINTS=2 \
-    algorithm.ego_train_algorithm.TOTAL_TIMESTEPS=1e5 \
-    algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python teammate_generation/run.py algorithm=fcp/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_fcp run_heldout_eval=false train_ego=$FCP_TRAIN_EGO $COMMON_FLAGS $FCP_FLAGS")
 
-# ── Ego training ──────────────────────────────────────────────────────────────
-# Run heldout eval for ppo ego only
 JOB_NAMES+=("ppo_ego")
-JOB_CMDS+=("python ego_agent_training/run.py \
-    algorithm=ppo_ego/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_ppo_ego \
-    algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_EGO_TRAIN_SEEDS=1 \
-    algorithm.partner_agent.ippo.path=$PARTNER_PATH \
-    run_heldout_eval=true \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python ego_agent_training/run.py algorithm=ppo_ego/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_ppo_ego algorithm.partner_agent.ippo.path=$PARTNER_PATH run_heldout_eval=$PPO_EGO_HELDOUT_EVAL $COMMON_FLAGS $PPO_EGO_FLAGS")
 
 JOB_NAMES+=("liam_ego")
-JOB_CMDS+=("python ego_agent_training/run.py \
-    algorithm=liam_ego/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_liam_ego \
-    algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_EGO_TRAIN_SEEDS=1 \
-    algorithm.partner_agent.ippo.path=$PARTNER_PATH \
-    run_heldout_eval=false \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python ego_agent_training/run.py algorithm=liam_ego/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_liam_ego algorithm.partner_agent.ippo.path=$PARTNER_PATH run_heldout_eval=false $COMMON_FLAGS $LIAM_EGO_FLAGS")
 
 JOB_NAMES+=("meliba_ego")
-JOB_CMDS+=("python ego_agent_training/run.py \
-    algorithm=meliba_ego/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_meliba_ego \
-    algorithm.TOTAL_TIMESTEPS=1e5 algorithm.NUM_EGO_TRAIN_SEEDS=1 \
-    algorithm.partner_agent.ippo.path=$PARTNER_PATH \
-    run_heldout_eval=false \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python ego_agent_training/run.py algorithm=meliba_ego/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_meliba_ego algorithm.partner_agent.ippo.path=$PARTNER_PATH run_heldout_eval=false $COMMON_FLAGS $MELIBA_EGO_FLAGS")
 
-# ── Open-ended / unified training ─────────────────────────────────────────────
 JOB_NAMES+=("rotate")
-JOB_CMDS+=("python open_ended_training/run.py \
-    algorithm=rotate/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_rotate \
-    algorithm.NUM_OPEN_ENDED_ITERS=1 \
-    algorithm.TIMESTEPS_PER_ITER_PARTNER=1e5 algorithm.TIMESTEPS_PER_ITER_EGO=1e5 \
-    algorithm.NUM_SEEDS=1 \
-    run_heldout_eval=false \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python open_ended_training/run.py algorithm=rotate/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_rotate run_heldout_eval=false $COMMON_FLAGS $ROTATE_FLAGS")
 
 JOB_NAMES+=("cole")
-JOB_CMDS+=("python open_ended_training/run.py \
-    algorithm=cole/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_cole \
-    algorithm.TOTAL_TIMESTEPS_PER_ITERATION=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
-    run_heldout_eval=false \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python open_ended_training/run.py algorithm=cole/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_cole run_heldout_eval=false $COMMON_FLAGS $COLE_FLAGS")
 
 JOB_NAMES+=("trajedi")
-JOB_CMDS+=("python open_ended_training/run.py \
-    algorithm=trajedi/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_trajedi \
-    algorithm.TOTAL_TIMESTEPS=2e5 algorithm.PARTNER_POP_SIZE=2 algorithm.NUM_SEEDS=1 \
-    run_heldout_eval=false \
-    $COMMON_FLAGS")
+JOB_CMDS+=("python open_ended_training/run.py algorithm=trajedi/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_trajedi run_heldout_eval=false $COMMON_FLAGS $TRAJEDI_FLAGS")
 
-# =============================================================================
-# ─── Selection — which jobs to run ────────────────────────────────────────────
-# List the job names you want to run.  Empty = run all defined jobs.
-# Example (run a subset):
-#   RUN_JOBS=(ippo brdiv liam_ego)
-# =============================================================================
+# Empty means all jobs. Keep IPPO selected when running ego-training jobs in
+# CPU mode because it creates their temporary partner checkpoint.
 RUN_JOBS=(
     ippo
     brdiv
     lbrdiv
     comedi
     fcp
+    ppo_ego
     liam_ego
     meliba_ego
-    ppo_ego
     rotate
     cole
     trajedi
 )
 
-# =============================================================================
-# ─── Implementation — no edits needed below this line ─────────────────────────
-# =============================================================================
+should_run() {
+    local candidate="$1"
+    local selected
+    [[ ${#RUN_JOBS[@]} -eq 0 ]] && return 0
+    for selected in "${RUN_JOBS[@]}"; do
+        [[ "$selected" == "$candidate" ]] && return 0
+    done
+    return 1
+}
 
-echo "Logs → $RESULTS_DIR" | tee "$LOG"
+print_summary() {
+    {
+        echo ""
+        echo "======================================================"
+        echo "  RESULTS"
+        echo "======================================================"
+        printf "  PASSED (%d):" "${#SUCCEEDED[@]}"; printf " %s" "${SUCCEEDED[@]:-}"; echo ""
+        printf "  FAILED (%d):" "${#FAILED[@]}"; printf " %s" "${FAILED[@]:-}"; echo ""
+        echo "======================================================"
+        echo "  Full logs: $RESULTS_DIR"
+    } | tee -a "$LOG"
+}
 
-# ─── GPU detection ────────────────────────────────────────────────────────────
+echo "Mode: $DEVICE" | tee "$LOG"
+echo "Logs: $RESULTS_DIR" | tee -a "$LOG"
+cd "$REPO_ROOT"
+
+if [[ "$DEVICE" == "cpu" ]]; then
+    export JAX_PLATFORMS=cpu
+    export JAX_AHT_FORCE_CPU_RESTORE=1
+    export MPLCONFIGDIR="$RESULTS_DIR/matplotlib"
+    export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+    mkdir -p "$MPLCONFIGDIR"
+
+    SUCCEEDED=()
+    FAILED=()
+    for i in "${!JOB_NAMES[@]}"; do
+        name="${JOB_NAMES[$i]}"
+        if should_run "$name"; then
+            logfile="$RESULTS_DIR/${name}.log"
+            echo "[$(date '+%H:%M:%S')] [START] $name (CPU)" | tee -a "$LOG"
+            if bash -c "${JOB_CMDS[$i]}" >"$logfile" 2>&1; then
+                SUCCEEDED+=("$name")
+                echo "[$(date '+%H:%M:%S')] [OK]    $name (CPU)" | tee -a "$LOG"
+            else
+                FAILED+=("$name")
+                echo "[$(date '+%H:%M:%S')] [FAIL]  $name (CPU), see ${name}.log" | tee -a "$LOG"
+            fi
+        else
+            echo "[SKIP]  $name" | tee -a "$LOG"
+        fi
+    done
+
+    print_summary
+    [[ ${#FAILED[@]} -eq 0 ]] && exit 0 || exit 1
+fi
+
 mapfile -t GPUS < <(
     nvidia-smi --query-gpu=index,memory.free --format=csv,noheader,nounits 2>/dev/null \
     | awk -F',' '{ gsub(/ /,"",$1); gsub(/ /,"",$2); if ($2+0 >= 20000) print $1 }'
 )
 
 if [[ ${#GPUS[@]} -eq 0 ]]; then
-    echo "ERROR: no GPUs with >= 20 GB free memory found. Aborting." | tee -a "$LOG" >&2
+    echo "ERROR: no GPUs with at least 20 GB free memory found." | tee -a "$LOG" >&2
     exit 1
 fi
-echo "GPUs with >= 20 GB free: ${GPUS[*]}" | tee -a "$LOG"
+echo "GPUs with at least 20 GB free: ${GPUS[*]}" | tee -a "$LOG"
 
-# ─── Parallel job manager ─────────────────────────────────────────────────────
 declare -a FREE_GPUS=("${GPUS[@]}")
-declare -A PID_GPU    # pid -> gpu index
-declare -A PID_NAME   # pid -> job name
+declare -A PID_GPU
+declare -A PID_NAME
 SUCCEEDED=()
 FAILED=()
 
-# Reap any finished jobs and return their GPUs to the pool.
 reap() {
     local -a done_pids=()
+    local pid name gpu
     for pid in "${!PID_GPU[@]}"; do
-        if ! kill -0 "$pid" 2>/dev/null; then
-            done_pids+=("$pid")
-        fi
+        kill -0 "$pid" 2>/dev/null || done_pids+=("$pid")
     done
     for pid in "${done_pids[@]}"; do
-        local name="${PID_NAME[$pid]}"
-        local gpu="${PID_GPU[$pid]}"
+        name="${PID_NAME[$pid]}"
+        gpu="${PID_GPU[$pid]}"
         if wait "$pid"; then
             SUCCEEDED+=("$name")
-            echo "[$(date '+%H:%M:%S')] [OK]   $name  (GPU $gpu)" | tee -a "$LOG"
+            echo "[$(date '+%H:%M:%S')] [OK]    $name (GPU $gpu)" | tee -a "$LOG"
         else
             FAILED+=("$name")
-            echo "[$(date '+%H:%M:%S')] [FAIL] $name  (GPU $gpu) — see ${name}.log" | tee -a "$LOG"
+            echo "[$(date '+%H:%M:%S')] [FAIL]  $name (GPU $gpu), see ${name}.log" | tee -a "$LOG"
         fi
         FREE_GPUS+=("$gpu")
         unset 'PID_GPU[$pid]'
@@ -229,7 +211,6 @@ reap() {
     done
 }
 
-# Block until a GPU slot is free; sets FREE_GPU to the acquired GPU index.
 acquire_gpu() {
     while [[ ${#FREE_GPUS[@]} -eq 0 ]]; do
         reap
@@ -239,57 +220,33 @@ acquire_gpu() {
     FREE_GPUS=("${FREE_GPUS[@]:1}")
 }
 
-# Launch a job: launch <name> <cmd...>
 launch() {
-    local name="$1"; shift
+    local name="$1"
+    local gpu logfile pid
+    shift
     acquire_gpu
-    local gpu="$FREE_GPU"
-    local logfile="$RESULTS_DIR/${name}.log"
-    echo "[$(date '+%H:%M:%S')] [START] $name  (GPU $gpu)" | tee -a "$LOG"
+    gpu="$FREE_GPU"
+    logfile="$RESULTS_DIR/${name}.log"
+    echo "[$(date '+%H:%M:%S')] [START] $name (GPU $gpu)" | tee -a "$LOG"
     CUDA_VISIBLE_DEVICES="$gpu" "$@" >"$logfile" 2>&1 &
-    local pid=$!
+    pid=$!
     PID_GPU[$pid]="$gpu"
     PID_NAME[$pid]="$name"
 }
 
-# Wait for all running jobs to finish.
-wait_all() {
-    while [[ ${#PID_GPU[@]} -gt 0 ]]; do
-        reap
-        [[ ${#PID_GPU[@]} -gt 0 ]] && sleep 2
-    done
-}
-
-# ─── Dispatch selected jobs ───────────────────────────────────────────────────
-cd "$REPO_ROOT"
-
-# Build a lookup set from RUN_JOBS (empty RUN_JOBS = run everything).
-declare -A _RUN_SET
-if [[ ${#RUN_JOBS[@]} -gt 0 ]]; then
-    for name in "${RUN_JOBS[@]}"; do _RUN_SET["$name"]=1; done
-fi
-
 for i in "${!JOB_NAMES[@]}"; do
     name="${JOB_NAMES[$i]}"
-    if [[ ${#RUN_JOBS[@]} -eq 0 || -n "${_RUN_SET[$name]+x}" ]]; then
+    if should_run "$name"; then
         launch "$name" bash -c "${JOB_CMDS[$i]}"
     else
         echo "[SKIP]  $name" | tee -a "$LOG"
     fi
 done
 
-wait_all
+while [[ ${#PID_GPU[@]} -gt 0 ]]; do
+    reap
+    [[ ${#PID_GPU[@]} -gt 0 ]] && sleep 2
+done
 
-# ─── Summary ──────────────────────────────────────────────────────────────────
-{
-echo ""
-echo "══════════════════════════════════════════════════════"
-echo "  RESULTS"
-echo "══════════════════════════════════════════════════════"
-printf "  PASSED (%d):" "${#SUCCEEDED[@]}"; printf " %s" "${SUCCEEDED[@]:-}"; echo ""
-printf "  FAILED (%d):" "${#FAILED[@]}";   printf " %s" "${FAILED[@]:-}";   echo ""
-echo "══════════════════════════════════════════════════════"
-echo "  Full logs: $RESULTS_DIR"
-} | tee -a "$LOG"
-
+print_summary
 [[ ${#FAILED[@]} -eq 0 ]] && exit 0 || exit 1

--- a/tests/test_heldout_loading.py
+++ b/tests/test_heldout_loading.py
@@ -1,56 +1,101 @@
-"""Smoke test: load every heldout agent for every task in global_heldout_settings.yaml.
+"""Validation and optional integration tests for heldout teammate configs."""
 
-Catches config/checkpoint mismatches (bad paths, missing idx_list, wrong
-actor_type routing) without running any evaluation rollouts.
-
-Run with: PYTHONPATH=. python tests/test_heldout_loading.py
-Requires the eval_teammates data (see download_eval_data.py).
-"""
 import os
+from pathlib import Path
 
 import jax
+import jax.numpy as jnp
+import pytest
 import yaml
 
 from envs import make_env
 from envs.log_wrapper import LogWrapper
 from evaluation.heldout_evaluator import load_heldout_set
 
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-HELDOUT_CONFIG = os.path.join(REPO_ROOT, "evaluation/configs/global_heldout_settings.yaml")
-TASK_CONFIG_DIR = os.path.join(REPO_ROOT, "evaluation/configs/task")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELDOUT_CONFIG = REPO_ROOT / "evaluation/configs/global_heldout_settings.yaml"
+TASK_CONFIG_DIR = REPO_ROOT / "evaluation/configs/task"
+
+
+def load_heldout_config():
+    return yaml.safe_load(HELDOUT_CONFIG.read_text())["heldout_set"]
 
 
 def load_task_config(task_name):
-    with open(os.path.join(TASK_CONFIG_DIR, f"{task_name}.yaml")) as f:
-        return yaml.safe_load(f)
+    return yaml.safe_load((TASK_CONFIG_DIR / f"{task_name}.yaml").read_text())
 
 
+def assert_agent_can_act(agent_name, agent, env, rng):
+    policy, params, test_mode, _ = agent
+    rng, reset_rng, action_rng = jax.random.split(rng, 3)
+    observations, env_state = env.reset(reset_rng)
+    acting_agent = env.agents[1]
+    available_actions = env.get_avail_actions(env_state)[acting_agent].astype(
+        jnp.float32
+    )
+    hstate = policy.init_hstate(1, aux_info={"agent_id": 1})
+
+    action, _ = policy.get_action(
+        params=params,
+        obs=observations[acting_agent].reshape(1, 1, -1),
+        done=jnp.zeros((1, 1), dtype=bool),
+        avail_actions=available_actions,
+        hstate=hstate,
+        rng=action_rng,
+        aux_obs=None,
+        env_state=env_state,
+        test_mode=test_mode,
+    )
+    action = int(jnp.asarray(action).squeeze())
+
+    assert 0 <= action < env.action_space(acting_agent).n, (
+        f"{agent_name}: returned invalid action {action}"
+    )
+
+
+def test_heldout_tasks_have_valid_environments():
+    for task_name, heldout_config in load_heldout_config().items():
+        task_config = load_task_config(task_name)
+        env_kwargs = task_config["ENV_KWARGS"] or {}
+
+        assert heldout_config, f"{task_name}: heldout set is empty"
+        assert make_env(task_config["ENV_NAME"], env_kwargs).agents
+
+
+def test_heldout_checkpoint_paths_are_repo_relative():
+    for task_name, heldout_config in load_heldout_config().items():
+        for agent_name, agent_config in heldout_config.items():
+            assert "actor_type" in agent_config, (
+                f"{task_name}/{agent_name}: missing actor_type"
+            )
+            for path_key in ("path", "weight_file"):
+                if path_key not in agent_config:
+                    continue
+
+                checkpoint_path = Path(agent_config[path_key])
+                assert not checkpoint_path.is_absolute(), (
+                    f"{task_name}/{agent_name}: {path_key} must be relative to the repository"
+                )
+                assert ".." not in checkpoint_path.parts
+                assert checkpoint_path.parts[0] == "eval_teammates"
+
+
+@pytest.mark.eval_data
 def test_load_all_heldout_agents():
-    with open(HELDOUT_CONFIG) as f:
-        heldout_set = yaml.safe_load(f)["heldout_set"]
+    if os.environ.get("JAX_AHT_RUN_HELDOUT_LOADING") != "1":
+        pytest.skip(
+            "set JAX_AHT_RUN_HELDOUT_LOADING=1 after running download_eval_data.py"
+        )
 
     rng = jax.random.PRNGKey(0)
-    failures = []
-    for task_name, heldout_config in heldout_set.items():
-        task_cfg = load_task_config(task_name)
-        env_kwargs = task_cfg["ENV_KWARGS"] or {}
-        env = LogWrapper(make_env(task_cfg["ENV_NAME"], env_kwargs))
-        try:
-            agents = load_heldout_set(heldout_config, env, task_name, env_kwargs, rng)
-        except FileNotFoundError as e:
-            # Checkpoint data not downloaded on this machine (see download_eval_data.py).
-            print(f"[skip] {task_name}: {e}")
-            continue
-        except Exception as e:
-            failures.append((task_name, e))
-            print(f"[FAIL] {task_name}: {type(e).__name__}: {e}")
-            continue
+    for task_name, heldout_config in load_heldout_config().items():
+        task_config = load_task_config(task_name)
+        env_kwargs = task_config["ENV_KWARGS"] or {}
+        env = LogWrapper(make_env(task_config["ENV_NAME"], env_kwargs))
+
+        agents = load_heldout_set(heldout_config, env, task_name, env_kwargs, rng)
+
         assert agents, f"{task_name}: no heldout agents loaded"
-        print(f"[ok] {task_name}: loaded {len(agents)} agents: {sorted(agents)}")
-
-    assert not failures, f"Failed to load heldout agents for: {[t for t, _ in failures]}"
-
-
-if __name__ == "__main__":
-    test_load_all_heldout_agents()
-    print("All heldout sets loaded successfully.")
+        for agent_name, agent in agents.items():
+            rng, action_rng = jax.random.split(rng)
+            assert_agent_can_act(agent_name, agent, env, action_rng)

--- a/tests/test_lbf_reward_shaping_wrapper.py
+++ b/tests/test_lbf_reward_shaping_wrapper.py
@@ -1,90 +1,40 @@
 import jax
-import jumanji
-from jumanji.environments.routing.lbf.generator import RandomGenerator
-from envs.log_wrapper import LogWrapper
 
-from envs.lbf.lbf_wrapper import LBFWrapper
-from envs.lbf.reward_shaping_lbf_wrapper import RewardShapingLBFWrapper
+from envs import make_env
 
-"""
-The purpose of this file is to test the LBFWrapper wrapper for the LevelBasedForaging environment.
-"""
 
-agent_reward_shaping_params = {
-    "agent_0": {
-        "DISTANCE_TO_NEAREST_FOOD_REW": 1.5, # Reward for moving closer to food (H1)
-        "DISTANCE_TO_FARTHEST_FOOD_REW": 0.0, # Reward for moving further from food (H2)
-        # "SEQUENCE_REW": 0.0, # Reward for completing a sequence of actions (H3-H8)
-        "FOLLOWING_TEAMMATE_REW": 0.0, # Reward for following another agent
-        "CENTERED_FOOD_DISTANCE_REW": 0.0, # Reward for moving towards towards the food that is closest to the midpoint of the two agents
-        "PROXIMITY_TO_TEAMMATE_REW": 0.1, # Reward for Proimity to teammate
-        "COLLECT_FOOD_REW": 3.0},
-    "agent_1": { 
-        "DISTANCE_TO_NEAREST_FOOD_REW": 0.0, # Reward for moving closer to food (H1)
-        "DISTANCE_TO_FARTHEST_FOOD_REW": 0.0, # Reward for moving further from food (H2)
-        # "SEQUENCE_REW": 0.0, # Reward for completing a sequence of actions (H3-H8)
-        "FOLLOWING_TEAMMATE_REW": 1.5, # Reward for following another agent
-        "CENTERED_FOOD_DISTANCE_REW": 0.0, # Reward for moving towards towards the food that is closest to the midpoint of the two agents
-        "PROXIMITY_TO_TEAMMATE_REW": 0.3, # Reward for Proimity to teammate
-        "COLLECT_FOOD_REW": 3.0},
-}
+def test_lbf_reward_shaping_wrapper_reset_and_step():
+    env = make_env(
+        "lbf-reward-shaping",
+        {
+            "grid_size": 7,
+            "num_agents": 2,
+            "num_food": 3,
+            "time_limit": 1,
+        },
+    )
+    key = jax.random.PRNGKey(0)
+    key, reset_key = jax.random.split(key)
+    _, state = env.reset(reset_key)
 
-# Instantiate a Jumanji environment
-env = jumanji.make('LevelBasedForaging-v0', 
-                   generator=RandomGenerator(grid_size=7,
-                                             fov=7,
-                                             num_agents=2,
-                                             num_food=3,
-                                             force_coop=True,
-                                            ),
-                   time_limit=100, penalty=0.1)
+    assert state.target_food_idx.shape == (len(env.agents), 3)
 
-wrapper = RewardShapingLBFWrapper(
-    env,
-    reward_shaping_params=agent_reward_shaping_params,
-)
-wrapper = LogWrapper(wrapper)
+    actions = {}
+    for agent in env.agents:
+        key, action_key = jax.random.split(key)
+        actions[agent] = env.action_space(agent).sample(action_key)
 
-NUM_EPISODES = 4
-key = jax.random.PRNGKey(20394)
+    key, step_key = jax.random.split(key)
+    observations, state, rewards, dones, info = env.step(step_key, state, actions)
 
-# reset outside of for loop over episodes to test auto-reset behavior
-key, subkey = jax.random.split(key)
-obs, state = wrapper.reset(subkey)
+    assert set(observations) == set(env.agents)
+    assert set(rewards) == set(env.agents)
+    assert set(dones) == {*env.agents, "__all__"}
+    assert bool(dones["__all__"])
+    assert int(env.get_step_count(state)) == 0
+    assert info["original_reward"].shape == (len(env.agents),)
 
-for episode in range(NUM_EPISODES):
-    done = {agent: False for agent in wrapper.agents}
-    done['__all__'] = False
-    total_rewards = {agent: 0.0 for agent in wrapper.agents}
-    num_steps = 0
-    while not done['__all__']:
-        # Sample actions for each agent
-        actions = {}
-        for agent in wrapper.agents:
-            action_space = wrapper.action_space(agent)
-            key, action_key = jax.random.split(key)
-            action = int(action_space.sample(action_key))
-            actions[agent] = action
-        
-        # hardcoded actions
-        # actions = {"agent_0": 1, "agent_1": 2}
-        key, subkey = jax.random.split(key)
-        obs, state, rewards, done, info = wrapper.step(subkey, state, actions)
-
-        # Process observations, rewards, dones, and info as needed
-        for agent in wrapper.agents:
-            total_rewards[agent] += rewards[agent]
-
-            print(f"\nEpisode {episode}, agent {agent}, timestep {wrapper.get_step_count(state.env_state)}")
-
-            # print("action is ", actions[agent])
-            # print("obs", obs[agent], "type", type(obs[agent]))
-            # print("rewards", rewards[agent], "type", type(rewards[agent]))
-            print("dones", done[agent], "type", type(done[agent]))
-            print("avail actions are ", wrapper.get_avail_actions(state.env_state)[agent])
-
-        print("info", info, "type", type(info))
-
-        num_steps += 1
-
-    print(f"Episode {episode} finished. Total rewards: {total_rewards}. Num steps: {num_steps}")
+    key, step_key = jax.random.split(key)
+    _, state, _, dones, _ = env.step(step_key, state, actions)
+    assert bool(dones["__all__"])
+    assert int(env.get_step_count(state)) == 0

--- a/tests/test_lbf_wrapper.py
+++ b/tests/test_lbf_wrapper.py
@@ -1,64 +1,53 @@
 import jax
-from envs.log_wrapper import LogWrapper
+
 from envs import make_env
-from envs.lbf.adhoc_lbf_viewer import AdHocLBFViewer
 
-"""
-The purpose of this file is to test the LBFWrapper wrapper for the LevelBasedForaging environment.
-"""
-grid_size = 8
 
-# Instantiate environment via factory to keep behaviour consistent with other tests
-env = make_env('lbf', env_kwargs={
-    'grid_size': grid_size,
-    'num_agents': 3,
-    'num_food': 3,
-    'time_limit': 100,
-    'penalty': 0.1,
-})
+def test_lbf_wrapper_reset_and_step():
+    env = make_env(
+        "lbf",
+        {
+            "grid_size": 7,
+            "num_agents": 2,
+            "num_food": 3,
+            "time_limit": 1,
+        },
+    )
+    longer_env = make_env(
+        "lbf",
+        {
+            "grid_size": 7,
+            "num_agents": 2,
+            "num_food": 3,
+            "time_limit": 5,
+        },
+    )
+    assert env != longer_env
 
-# env returned by make_env is already wrapped (LBFWrapper). Add logging wrapper.
-wrapper = LogWrapper(env)
+    key = jax.random.PRNGKey(0)
+    key, reset_key = jax.random.split(key)
+    observations, state = env.reset(reset_key)
 
-NUM_EPISODES = 2
-key = jax.random.PRNGKey(20394)
+    assert set(observations) == set(env.agents)
+    assert all(observations[agent].ndim == 1 for agent in env.agents)
 
-# reset outside of for loop over episodes to test auto-reset behavior
-key, subkey = jax.random.split(key)
-obs, state = wrapper.reset(subkey)
+    actions = {}
+    for agent in env.agents:
+        key, action_key = jax.random.split(key)
+        actions[agent] = env.action_space(agent).sample(action_key)
 
-for episode in range(NUM_EPISODES):
-    done = {agent: False for agent in wrapper.agents}
-    done['__all__'] = False
-    total_rewards = {agent: 0.0 for agent in wrapper.agents}
-    num_steps = 0
-    while not done['__all__']:
-        # Sample actions for each agent
-        actions = {}
-        for agent in wrapper.agents:
-            action_space = wrapper.action_space(agent)
-            key, action_key = jax.random.split(key)
-            action = int(action_space.sample(action_key))
-            actions[agent] = action
-        
-        # hardcoded actions
-        # actions = {"agent_0": 1, "agent_1": 2}
-        key, subkey = jax.random.split(key)
-        obs, state, rewards, done, info = wrapper.step(subkey, state, actions)
+    key, step_key = jax.random.split(key)
+    observations, state, rewards, dones, info = env.step(step_key, state, actions)
 
-        # Process observations, rewards, dones, and info as needed
-        for agent in wrapper.agents:
-            total_rewards[agent] += rewards[agent]
+    assert set(observations) == set(env.agents)
+    assert set(rewards) == set(env.agents)
+    assert set(dones) == {*env.agents, "__all__"}
+    assert bool(dones["__all__"])
+    assert int(env.get_step_count(state)) == 0
+    assert isinstance(info, dict)
+    assert env.get_avail_actions(state).keys() == observations.keys()
 
-            print(f"\nEpisode {episode}, agent {agent}, timestep {wrapper.get_step_count(state.env_state)}")
-
-            # print("action is ", actions[agent])
-            # print("obs", obs[agent], "type", type(obs[agent]))
-            # print("rewards", rewards[agent], "type", type(rewards[agent]))
-            print("dones", done[agent], "type", type(done[agent]))
-            print("avail actions are ", wrapper.get_avail_actions(state.env_state)[agent])
-
-        print("info", info, "type", type(info))
-        num_steps += 1
-
-    print(f"Episode {episode} finished. Total rewards: {total_rewards}. Num steps: {num_steps}")
+    key, step_key = jax.random.split(key)
+    _, state, _, dones, _ = env.step(step_key, state, actions)
+    assert bool(dones["__all__"])
+    assert int(env.get_step_count(state)) == 0

--- a/tests/test_overcooked_wrapper.py
+++ b/tests/test_overcooked_wrapper.py
@@ -1,53 +1,41 @@
 import jax
-from envs.log_wrapper import LogWrapper
-from jaxmarl.environments.overcooked import overcooked_layouts
+
 from envs import make_env
 
-# Instantiate the Overcooked environment via factory
-env = make_env(env_name='overcooked-v1', env_kwargs={
-    'layout': 'cramped_room',
-    'random_reset': True,
-    'max_steps': 400,
-})
-wrapper = LogWrapper(env)
 
-NUM_EPISODES = 2
-key = jax.random.PRNGKey(20394)
+def test_overcooked_wrapper_reset_and_step():
+    env = make_env(
+        "overcooked-v1",
+        {
+            "layout": "cramped_room",
+            "random_reset": True,
+            "max_steps": 1,
+        },
+    )
+    key = jax.random.PRNGKey(0)
+    key, reset_key = jax.random.split(key)
+    observations, state = env.reset(reset_key)
 
-# reset outside of for loop over episodes to test auto-reset behavior
-key, subkey = jax.random.split(key)
-obs, state = wrapper.reset(subkey)
+    assert set(observations) == set(env.agents)
+    assert all(observations[agent].ndim == 1 for agent in env.agents)
 
-for episode in range(NUM_EPISODES):
-    done = {agent: False for agent in wrapper.agents}
-    done['__all__'] = False
-    total_rewards = {agent: 0.0 for agent in wrapper.agents}
-    num_steps = 0
-    while not done['__all__']:
-        # Sample actions for each agent
-        actions = {}
-        for agent in wrapper.agents:
-            action_space = wrapper.action_space(agent)
-            key, action_key = jax.random.split(key)
-            action = int(action_space.sample(action_key))
-            actions[agent] = action
-        
-        key, subkey = jax.random.split(key)
-        obs, state, rewards, done, info = wrapper.step(subkey, state, actions)
+    actions = {}
+    for agent in env.agents:
+        key, action_key = jax.random.split(key)
+        actions[agent] = env.action_space(agent).sample(action_key)
 
-        # Process observations, rewards, dones, and info as needed
-        for agent in wrapper.agents:
-            total_rewards[agent] += rewards[agent]
+    key, step_key = jax.random.split(key)
+    observations, state, rewards, dones, info = env.step(step_key, state, actions)
 
-            print(f"\nEpisode {episode}, agent {agent}, timestep {wrapper.get_step_count(state.env_state)}")
+    assert set(observations) == set(env.agents)
+    assert set(rewards) == set(env.agents)
+    assert set(dones) == {*env.agents, "__all__"}
+    assert bool(dones["__all__"])
+    assert int(env.get_step_count(state)) == 0
+    assert "base_return" in info
+    assert env.get_avail_actions(state).keys() == observations.keys()
 
-            print("obs shape is ", obs[agent].shape, "type", type(obs[agent]))
-            print("action is ", actions[agent])
-            print("rewards", rewards[agent], "type", type(rewards[agent]))
-            print("info", info, "type", type(info))
-            print("avail actions are ", wrapper.get_avail_actions(state.env_state)[agent])
-            print("dones", done[agent], "type", type(done[agent]))
-
-        num_steps += 1
-
-    print(f"Episode {episode} finished. Total rewards: {total_rewards}. Num steps: {num_steps}")
+    key, step_key = jax.random.split(key)
+    _, state, _, dones, _ = env.step(step_key, state, actions)
+    assert bool(dones["__all__"])
+    assert int(env.get_step_count(state)) == 0


### PR DESCRIPTION
## Summary

- add a CPU mode to the existing algorithm smoke script with one real training update for all 11 algorithms
- generate the temporary IPPO checkpoint used by the ego-training smoke tests
- replace import-time wrapper demos and boolean-returning app checks with bounded pytest assertions
- validate heldout configs without downloads and keep full checkpoint loading as an explicit eval-data integration test

## Verification

- `JAX_PLATFORMS=cpu PYTHONPATH=. python -m pytest -q` (39 passed, 1 skipped)
- `bash scripts/test_algos.sh --device cpu` (11 passed, 0 failed)
- `ruff check` on all modified Python test files
- `bash -n scripts/test_algos.sh`