### PR TITLE
Support CPU and CUDA installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,16 @@ Our modularization is restricted to environments, agents, and populations, which
 ## 🚀 Installation Guide
 
 Follow instructions at [docs/install_instructions.md](docs/install_instructions.md) to install the necessary libraries.
-The default install path remains Linux/CUDA-first:
+JaxAHT currently supports Python 3.11.
+The default install supports CPU-only Linux and macOS environments:
 ```bash
-pip install -e .
+python -m pip install -e .
 ```
 
-On macOS, the platform-specific dependency path automatically installs CPU JAX instead of the CUDA build.
+On Linux machines with NVIDIA GPUs and CUDA 12, install the CUDA extra:
+```bash
+python -m pip install -e ".[cuda12]"
+```
 
 Verify the install with:
 ```bash

--- a/docs/install_instructions.md
+++ b/docs/install_instructions.md
@@ -1,5 +1,5 @@
 # Instructions
-Instructions were tested on 9/4/25 with a fresh install w/Python 3.11.
+These instructions target Python 3.11.
 
 1. Create a conda environment: 
 
@@ -21,10 +21,15 @@ conda activate your_env_name
 3. Navigate to the repository directory and install in development mode:
 ```bash
 cd /path/to/jax-aht
-pip install -e .
+python -m pip install -e .
 ```
 
-This installs the default cross-platform dependency set from `pyproject.toml` and sets up the package for development.
+This installs the CPU-compatible dependency set from `pyproject.toml` and sets up the package for development.
+
+On Linux machines with NVIDIA GPUs and CUDA 12, install the CUDA extra instead:
+```bash
+python -m pip install -e ".[cuda12]"
+```
 
 4. Verify the installation:
 ```bash
@@ -32,18 +37,18 @@ python scripts/verify_install.py
 ```
 
 This reports the devices JAX can see and runs the array operations the training
-code relies on. On Linux with an NVIDIA GPU, the output should end with
-`All checks passed.` and look like:
+code relies on. The output should end with `All checks passed.`. A default CPU
+installation looks like:
 ```
-jax 0.5.3, backend gpu, [CudaDevice(id=0)]
+jax 0.5.3, backend cpu, [CpuDevice(id=0)]
 [ok] devices
-[ok] matmul (cuBLAS)
-[ok] QR decomposition (cuSolver)
+[ok] matrix multiplication
+[ok] QR decomposition
 [ok] orthogonal init (as used by agents/)
 All checks passed.
 ```
-Machines with several GPUs list one `CudaDevice` per GPU. On macOS, CPU JAX is
-installed automatically, so the backend is `cpu` and the device is `[CpuDevice(id=0)]`.
+With the CUDA extra installed, the backend should be `gpu` and the devices should
+be listed as `CudaDevice` entries.
 
 5. Download evaluation data to get the evaluation agents:
 ```bash
@@ -61,7 +66,9 @@ python marl/run.py task=lbf/lbf_7x7_nolevels algorithm=ippo/lbf/lbf_7x7_nolevels
 If you prefer the manual setup or encounter issues with the pip installation:
 
 1. Follow steps 1-2 above
-2. Install packages manually: `pip install -r requirements.txt`
+2. Install packages manually: `python -m pip install -r requirements.txt`
+
+   On Linux machines with NVIDIA GPUs and CUDA 12, also run `python -m pip install "jax[cuda12]==0.5.3"`.
 3. Add project path to PYTHONPATH as a conda env var:
 ```bash
 conda env config vars set PYTHONPATH=/path/to/repository/directory
@@ -106,11 +113,11 @@ python -m pip install -e .
 
 ## CUDA library conflicts
 
-`pip install -e .` installs its own CUDA 12 libraries. If a system CUDA toolkit is
-also on the library search path, the two can be mixed at runtime, which causes
-segfaults or cuBLAS/cuSolver errors *after* `jax.devices()` already reports a GPU.
-
-Check with `echo $LD_LIBRARY_PATH`. If the output is not empty, use:
+If you installed the `cuda12` extra, pip installed its own CUDA 12 libraries. If a
+system CUDA toolkit is also on the library search path, the two can be mixed at
+runtime, which causes segfaults or cuBLAS/cuSolver errors after `jax.devices()`
+already reports a GPU. Check with `echo $LD_LIBRARY_PATH`.
+If the output is not empty, use:
 ```bash
 export LD_LIBRARY_PATH="" #so that it defaults to the pip-installed CUDA.
 conda env config vars set LD_LIBRARY_PATH= #so that it unsets the LD_LIBRARY_PATH when the conda environment is activated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "JAX-based benchmark for Ad Hoc Teamwork research"
 authors = [{name = "Learning Agents Research Group"}]
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.12"
 keywords = ["reinforcement-learning", "multi-agent", "jax", "ad-hoc-teamwork", "benchmark"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -22,8 +22,7 @@ classifiers = [
 
 dependencies = [
     # JAX AI stack v2025.2.5
-    "jax[cuda12]==0.5.3; platform_system == 'Linux'",
-    "jax==0.5.3; platform_system == 'Darwin'",
+    "jax==0.5.3",
     "chex==0.1.88",
     "flax==0.10.2",
     "ml_dtypes==0.4.0",
@@ -51,6 +50,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+cuda12 = [
+    "jax[cuda12]==0.5.3; platform_system == 'Linux'",
+]
 test = [
     "flask>=2.3.0",
     "flask-cors>=4.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,7 @@
 # pip install -e .
 
 # from jax ai stack v2025.2.5
-jax[cuda12]==0.5.3; platform_system == "Linux"
-jax==0.5.3; platform_system == "Darwin"
+jax==0.5.3
 chex==0.1.88
 flax==0.10.2
 ml_dtypes==0.4.0

--- a/scripts/verify_install.py
+++ b/scripts/verify_install.py
@@ -1,4 +1,4 @@
-"""Check that the installation can actually run GPU training.
+"""Check that JAX can run the operations used during training.
 
 Usage: python scripts/verify_install.py
 """
@@ -6,9 +6,9 @@ Usage: python scripts/verify_install.py
 import sys
 import traceback
 
+import flax.linen as nn
 import jax
 import jax.numpy as jnp
-import flax.linen as nn
 from flax.linen.initializers import orthogonal
 
 
@@ -32,12 +32,12 @@ def orthogonal_init():
 
 CHECKS = [
     ("devices", devices),
-    ("matmul (cuBLAS)", matmul),
-    ("QR decomposition (cuSolver)", qr),
+    ("matrix multiplication", matmul),
+    ("QR decomposition", qr),
     ("orthogonal init (as used by agents/)", orthogonal_init),
 ]
 
-HINT = """
+GPU_HINT = """
 A segfault or a cuSolver/cuBLAS error here usually means a system CUDA toolkit on
 LD_LIBRARY_PATH is being mixed with the pip-installed CUDA libraries. See the
 troubleshooting section of docs/install_instructions.md.
@@ -48,10 +48,11 @@ def main():
     for name, fn in CHECKS:
         try:
             fn()
-        except Exception:
+        except Exception:  # noqa: BLE001 - report any backend check failure cleanly
             traceback.print_exc()
             print(f"[FAIL] {name}")
-            print(HINT)
+            if jax.default_backend() == "gpu":
+                print(GPU_HINT)
             return 1
         print(f"[ok] {name}")
     print("All checks passed.")


### PR DESCRIPTION
## Summary

- make CPU JAX the portable default on Linux and macOS
- move CUDA 12 support behind the explicit `cuda12` package extra
- add a `test` extra for the CPU test and lint tooling
- update the installation instructions for CPU and NVIDIA users

## Verification

- built the wheel and inspected its dependency metadata
- installed the wheel into a fresh Python 3.11 environment
- confirmed JAX reports `CpuDevice` and no NVIDIA packages are installed
- `python -m pip check`
- `JAX_PLATFORMS=cpu PYTHONPATH=. python -m pytest -q` (39 passed, 1 skipped)
- completed one IPPO training update in the clean CPU environment

Stacked on #103 so the test extra includes the CPU test suite introduced there.