### PR TITLE
Run CPU tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JAX_PLATFORMS: cpu
+  MPLCONFIGDIR: /tmp/matplotlib
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  WANDB_MODE: disabled
+  XLA_PYTHON_CLIENT_PREALLOCATE: "false"
+
+jobs:
+  package:
+    name: Package build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Build distributions
+        run: |
+          python -m pip install build
+          python -m build
+      - name: Verify wheel installation
+        shell: bash
+        run: |
+          python -m venv "$RUNNER_TEMP/wheel-venv"
+          wheel_python="$RUNNER_TEMP/wheel-venv/bin/python"
+          "$wheel_python" -m pip install dist/*.whl
+          "$wheel_python" -m pip check
+          cd "$RUNNER_TEMP"
+          "$wheel_python" -c "import agents, common, ego_agent_training, envs, evaluation, marl, open_ended_training, teammate_generation"
+          "$wheel_python" "$GITHUB_WORKSPACE/scripts/verify_install.py"
+
+  tests:
+    name: CPU tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install test dependencies
+        run: python -m pip install -e ".[test]"
+      - name: Run tests
+        run: python -m pytest -q
+
+  algorithms:
+    name: CPU algorithm smoke tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install test dependencies
+        run: python -m pip install -e ".[test]"
+      - name: Run one update for each algorithm
+        run: bash scripts/test_algos.sh --device cpu

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+import yaml
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_ROOTS = (
+    "agents",
+    "ego_agent_training",
+    "evaluation",
+    "marl",
+    "open_ended_training",
+    "teammate_generation",
+)
+HYDRA_CONFIGS = (
+    ("marl/configs", "base_config_marl"),
+    ("teammate_generation/configs", "base_config_teammate"),
+    ("ego_agent_training/configs", "base_config_ego"),
+    ("open_ended_training/configs", "base_config_oel"),
+    ("evaluation/configs", "heldout_ego"),
+    ("evaluation/configs", "heldout_xp"),
+)
+
+
+def test_yaml_configs_parse():
+    config_paths = []
+    for root_name in YAML_ROOTS:
+        root = REPO_ROOT / root_name
+        config_paths.extend(root.rglob("*.yaml"))
+        config_paths.extend(root.rglob("*.yml"))
+
+    assert config_paths
+    for config_path in config_paths:
+        yaml.safe_load(config_path.read_text())
+
+
+@pytest.mark.parametrize(("config_dir", "config_name"), HYDRA_CONFIGS)
+def test_entrypoint_configs_compose(config_dir, config_name):
+    with initialize_config_dir(
+        version_base=None,
+        config_dir=str(REPO_ROOT / config_dir),
+    ):
+        config = compose(config_name=config_name)
+        OmegaConf.to_container(config, resolve=True, throw_on_missing=True)


### PR DESCRIPTION
## Summary

- add pull-request CI for package building, CPU pytest, and all 11 algorithm smoke tests
- parse every tracked YAML config and compose all six Hydra entrypoint configs
- keep heldout checkpoint downloads out of routine CI while validating their environments and repository-relative paths

## Checks

- `Package build` builds the source distribution and wheel
- `CPU tests` runs pytest, YAML parsing, Hydra composition, wrappers, and heldout config validation
- `CPU algorithm smoke tests` runs one real training update for every supported algorithm

## Local verification

- `actionlint .github/workflows/*.yml`
- `JAX_PLATFORMS=cpu PYTHONPATH=. python -m pytest -q` (46 passed, 1 skipped)
- `bash scripts/test_algos.sh --device cpu` (11 passed, 0 failed)

The skipped test is the explicit eval-data integration test, which requires running `download_eval_data.py` and setting `JAX_AHT_RUN_HELDOUT_LOADING=1`.

Stacked on #104, which provides the CPU-safe package installation used by these jobs.