### PR TITLE
Enforce lint on changed Python files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
@@ -59,6 +61,20 @@ jobs:
           cache-dependency-path: pyproject.toml
       - name: Install test dependencies
         run: python -m pip install -e ".[test]"
+      - name: Check changed Python files
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          changed_files="$RUNNER_TEMP/changed-python-files"
+          git diff --name-only --diff-filter=ACMR -z "$BASE_SHA" HEAD -- '*.py' > "$changed_files"
+          if [[ ! -s "$changed_files" ]]; then
+            echo "No changed Python files to check."
+            exit 0
+          fi
+          xargs -0 ruff check < "$changed_files"
+          xargs -0 ruff format --check < "$changed_files"
       - name: Run tests
         run: python -m pytest -q
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,6 @@ include = ["agents*", "common*", "envs*", "evaluation*", "ego_agent_training*", 
 markers = [
     "eval_data: requires locally downloaded eval teammate checkpoints",
 ]
+
+[tool.ruff]
+target-version = "py311"


### PR DESCRIPTION
## Summary
- set Ruff to the project Python 3.11 target
- lint and format-check only Python files changed by each pull request
- avoid a repository-wide reformat while existing lint debt is handled incrementally

## Verification
- actionlint passed for all workflows
- simulated the changed-file check against the stacked base
- Ruff check and format check passed for the changed Python file
- pytest: 46 passed, 1 skipped