### PR TITLE
Reuse XLA compilations across heldout eval partners

### DIFF
--- a/common/run_episodes.py
+++ b/common/run_episodes.py
@@ -1,24 +1,41 @@
-'''
+"""
 This file contains the code for running evaluation episodes with an ego agent and a partner agent.
 Does not currently support actors that require aux_obs.
-'''
+"""
+
 from functools import lru_cache
 
 import jax
 import jax.numpy as jnp
 
 
-def run_single_episode(rng, env, agent_0_param, agent_0_policy,
-                       agent_1_param, agent_1_policy,
-                       max_episode_steps, agent_0_test_mode=False, agent_1_test_mode=False):
+def run_single_episode(
+    rng,
+    env,
+    agent_0_param,
+    agent_0_policy,
+    agent_1_param,
+    agent_1_policy,
+    max_episode_steps,
+    agent_0_test_mode=False,
+    agent_1_test_mode=False,
+):
     # Reset the env.
     rng, reset_rng = jax.random.split(rng)
     init_obs, init_env_state = env.reset(reset_rng)
     init_done = {k: jnp.zeros((1), dtype=bool) for k in env.agents + ["__all__"]}
-    init_act_onehot = {k: jnp.zeros((env.action_space(env.agents[i]).n)) for i, k in enumerate(env.agents)}
-    init_reward = {k: jnp.zeros((1)) for i, k in enumerate(env.agents)}
-    init_joint_act_onehot = jnp.concatenate((init_act_onehot["agent_0"].reshape(1, 1, -1),
-                                             init_act_onehot["agent_1"].reshape(1, 1, -1)), axis=-1)
+    init_act_onehot = {
+        k: jnp.zeros(env.action_space(env.agents[i]).n)
+        for i, k in enumerate(env.agents)
+    }
+    init_reward = {k: jnp.zeros(1) for i, k in enumerate(env.agents)}
+    init_joint_act_onehot = jnp.concatenate(
+        (
+            init_act_onehot["agent_0"].reshape(1, 1, -1),
+            init_act_onehot["agent_1"].reshape(1, 1, -1),
+        ),
+        axis=-1,
+    )
 
     # Initialize hidden states. Agent id is passed as part of the hstate initialization to support heuristic agents.
     init_hstate_0 = agent_0_policy.init_hstate(1, aux_info={"agent_id": 0})
@@ -41,9 +58,13 @@ def run_single_episode(rng, env, agent_0_param, agent_0_policy,
         avail_actions=avail_actions_0,
         hstate=init_hstate_0,
         rng=act0_rng,
-        aux_obs=(init_act_onehot["agent_0"].reshape(1, 1, -1), init_joint_act_onehot, init_reward["agent_0"].reshape(1, 1, -1)),
+        aux_obs=(
+            init_act_onehot["agent_0"].reshape(1, 1, -1),
+            init_joint_act_onehot,
+            init_reward["agent_0"].reshape(1, 1, -1),
+        ),
         env_state=init_env_state,
-        test_mode=agent_0_test_mode
+        test_mode=agent_0_test_mode,
     )
     act_0 = act_0.squeeze()
 
@@ -57,29 +78,62 @@ def run_single_episode(rng, env, agent_0_param, agent_0_policy,
         rng=act1_rng,
         aux_obs=None,
         env_state=init_env_state,
-        test_mode=agent_1_test_mode
+        test_mode=agent_1_test_mode,
     )
     act_1 = act_1.squeeze()
 
     both_actions = [act_0, act_1]
     env_act = {k: both_actions[i] for i, k in enumerate(env.agents)}
-    env_act_onehot = {k: jax.nn.one_hot(both_actions[i], env.action_space(env.agents[i]).n) for i, k in enumerate(env.agents)}
-    obs, env_state, reward, done, dummy_info = env.step(step_rng, init_env_state, env_act)
+    env_act_onehot = {
+        k: jax.nn.one_hot(both_actions[i], env.action_space(env.agents[i]).n)
+        for i, k in enumerate(env.agents)
+    }
+    obs, env_state, reward, done, dummy_info = env.step(
+        step_rng, init_env_state, env_act
+    )
 
     # We'll use a scan to iterate steps until the episode is done.
     ep_ts = 1
-    init_carry = (ep_ts, env_state, obs, rng, done, reward, env_act_onehot, hstate_0, hstate_1, dummy_info)
+    init_carry = (
+        ep_ts,
+        env_state,
+        obs,
+        rng,
+        done,
+        reward,
+        env_act_onehot,
+        hstate_0,
+        hstate_1,
+        dummy_info,
+    )
+
     def scan_step(carry, _):
         def take_step(carry_step):
-            ep_ts, env_state, obs, rng, done, reward, act_onehot, hstate_0, hstate_1, last_info = carry_step
+            (
+                ep_ts,
+                env_state,
+                obs,
+                rng,
+                done,
+                reward,
+                act_onehot,
+                hstate_0,
+                hstate_1,
+                _last_info,
+            ) = carry_step
             # Get available actions for agent 0 from environment state
             avail_actions = env.get_avail_actions(env_state)
             avail_actions = jax.lax.stop_gradient(avail_actions)
             avail_actions_0 = avail_actions["agent_0"].astype(jnp.float32)
             avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
-            joint_act_onehot = jnp.concatenate((act_onehot["agent_0"].reshape(1, 1, -1),
-                                                act_onehot["agent_1"].reshape(1, 1, -1)), axis=-1)
+            joint_act_onehot = jnp.concatenate(
+                (
+                    act_onehot["agent_0"].reshape(1, 1, -1),
+                    act_onehot["agent_1"].reshape(1, 1, -1),
+                ),
+                axis=-1,
+            )
 
             # Get ego action
             rng, act0_rng, act1_rng, step_rng = jax.random.split(rng, 4)
@@ -90,9 +144,13 @@ def run_single_episode(rng, env, agent_0_param, agent_0_policy,
                 avail_actions=avail_actions_0,
                 hstate=hstate_0,
                 rng=act0_rng,
-                aux_obs=(act_onehot["agent_0"].reshape(1, 1, -1), joint_act_onehot, reward["agent_0"].reshape(1, 1, -1)),
+                aux_obs=(
+                    act_onehot["agent_0"].reshape(1, 1, -1),
+                    joint_act_onehot,
+                    reward["agent_0"].reshape(1, 1, -1),
+                ),
                 env_state=env_state,
-                test_mode=agent_0_test_mode
+                test_mode=agent_0_test_mode,
             )
             act_0 = act_0.squeeze()
 
@@ -105,56 +163,103 @@ def run_single_episode(rng, env, agent_0_param, agent_0_policy,
                 hstate=hstate_1,
                 rng=act1_rng,
                 env_state=env_state,
-                test_mode=agent_1_test_mode
+                test_mode=agent_1_test_mode,
             )
             act_1 = act_1.squeeze()
 
             both_actions = [act_0, act_1]
             env_act = {k: both_actions[i] for i, k in enumerate(env.agents)}
-            env_act_onehot = {k: jax.nn.one_hot(both_actions[i], env.action_space(env.agents[i]).n) for i, k in enumerate(env.agents)}
-            obs_next, env_state_next, reward, done_next, info_next = env.step(step_rng, env_state, env_act)
+            env_act_onehot = {
+                k: jax.nn.one_hot(both_actions[i], env.action_space(env.agents[i]).n)
+                for i, k in enumerate(env.agents)
+            }
+            obs_next, env_state_next, reward, done_next, info_next = env.step(
+                step_rng, env_state, env_act
+            )
 
-            return (ep_ts + 1, env_state_next, obs_next, rng, done_next, reward, env_act_onehot, hstate_0_next, hstate_1_next, info_next)
+            return (
+                ep_ts + 1,
+                env_state_next,
+                obs_next,
+                rng,
+                done_next,
+                reward,
+                env_act_onehot,
+                hstate_0_next,
+                hstate_1_next,
+                info_next,
+            )
 
-        ep_ts, env_state, obs, rng, done, reward, act_onehot, hstate_0, hstate_1, last_info = carry
+        done = carry[4]
         new_carry = jax.lax.cond(
             done["__all__"],
-            lambda curr_carry: curr_carry, # True fn
-            take_step, # False fn
-            operand=carry
+            lambda curr_carry: curr_carry,  # True fn
+            take_step,  # False fn
+            operand=carry,
         )
         return new_carry, None
 
-    final_carry, _ = jax.lax.scan(
-        scan_step, init_carry, None, length=max_episode_steps)
+    final_carry, _ = jax.lax.scan(scan_step, init_carry, None, length=max_episode_steps)
     # Return the final info (which includes the episode return via LogWrapper).
     return final_carry[-1]
 
+
 @lru_cache(maxsize=128)
-def _compiled_run_episodes(env, agent_0_policy, agent_1_policy, max_episode_steps,
-                           agent_0_test_mode, agent_1_test_mode):
-    '''Memoized, with params as arguments rather than closed-over constants, so agents
-    sharing a policy reuse one XLA compilation instead of each triggering a recompile.'''
+def _compiled_run_episodes(
+    env,
+    agent_0_policy,
+    agent_1_policy,
+    max_episode_steps,
+    agent_0_test_mode,
+    agent_1_test_mode,
+):
+    """Memoized, with params as arguments rather than closed-over constants, so agents
+    sharing a policy reuse one XLA compilation instead of each triggering a recompile."""
+
     @jax.jit
     def _run(ep_rngs, agent_0_param, agent_1_param):
-        return jax.vmap(lambda ep_rng: run_single_episode(
-            ep_rng, env, agent_0_param, agent_0_policy,
-            agent_1_param, agent_1_policy, max_episode_steps,
-            agent_0_test_mode, agent_1_test_mode
-        ))(ep_rngs)
+        return jax.vmap(
+            lambda ep_rng: run_single_episode(
+                ep_rng,
+                env,
+                agent_0_param,
+                agent_0_policy,
+                agent_1_param,
+                agent_1_policy,
+                max_episode_steps,
+                agent_0_test_mode,
+                agent_1_test_mode,
+            )
+        )(ep_rngs)
+
     return _run
 
-def run_episodes(rng, env, agent_0_param, agent_0_policy,
-                 agent_1_param, agent_1_policy,
-                 max_episode_steps, num_eps, agent_0_test_mode=False, agent_1_test_mode=False):
-    '''Given a single ego agent and a single partner agent, run num_eps episodes in parallel using vmap.'''
+
+def run_episodes(
+    rng,
+    env,
+    agent_0_param,
+    agent_0_policy,
+    agent_1_param,
+    agent_1_policy,
+    max_episode_steps,
+    num_eps,
+    agent_0_test_mode=False,
+    agent_1_test_mode=False,
+):
+    """Given a single ego agent and a single partner agent, run num_eps episodes in parallel using vmap."""
     # Create episode-specific RNGs
     rngs = jax.random.split(rng, num_eps + 1)
     ep_rngs = rngs[1:]
 
     vmap_run_single_episode = _compiled_run_episodes(
-        env, agent_0_policy, agent_1_policy, max_episode_steps,
-        agent_0_test_mode, agent_1_test_mode)
+        env,
+        agent_0_policy,
+        agent_1_policy,
+        max_episode_steps,
+        agent_0_test_mode,
+        agent_1_test_mode,
+    )
     # Run episodes in parallel
     all_outs = vmap_run_single_episode(ep_rngs, agent_0_param, agent_1_param)
     return all_outs  # each leaf has shape (num_eps, ...)

--- a/common/run_episodes.py
+++ b/common/run_episodes.py
@@ -2,6 +2,8 @@
 This file contains the code for running evaluation episodes with an ego agent and a partner agent.
 Does not currently support actors that require aux_obs.
 '''
+from functools import lru_cache
+
 import jax
 import jax.numpy as jnp
 
@@ -128,6 +130,21 @@ def run_single_episode(rng, env, agent_0_param, agent_0_policy,
     # Return the final info (which includes the episode return via LogWrapper).
     return final_carry[-1]
 
+@lru_cache(maxsize=128)
+def _compiled_run_episodes(env, agent_0_policy, agent_1_policy, max_episode_steps,
+                           agent_0_test_mode, agent_1_test_mode):
+    '''Memoized so repeated calls reuse one XLA compilation. Agent params are runtime
+    arguments rather than closed-over constants, so two agents sharing a policy (e.g.
+    members of one heldout population) do not each trigger a recompile.'''
+    @jax.jit
+    def _run(ep_rngs, agent_0_param, agent_1_param):
+        return jax.vmap(lambda ep_rng: run_single_episode(
+            ep_rng, env, agent_0_param, agent_0_policy,
+            agent_1_param, agent_1_policy, max_episode_steps,
+            agent_0_test_mode, agent_1_test_mode
+        ))(ep_rngs)
+    return _run
+
 def run_episodes(rng, env, agent_0_param, agent_0_policy,
                  agent_1_param, agent_1_policy,
                  max_episode_steps, num_eps, agent_0_test_mode=False, agent_1_test_mode=False):
@@ -136,14 +153,9 @@ def run_episodes(rng, env, agent_0_param, agent_0_policy,
     rngs = jax.random.split(rng, num_eps + 1)
     ep_rngs = rngs[1:]
 
-    # Vectorize run_single_episode over the first argument (rng)
-    vmap_run_single_episode = jax.jit(jax.vmap(
-        lambda ep_rng: run_single_episode(
-            ep_rng, env, agent_0_param, agent_0_policy,
-            agent_1_param, agent_1_policy, max_episode_steps,
-            agent_0_test_mode, agent_1_test_mode
-        )
-    ))
+    vmap_run_single_episode = _compiled_run_episodes(
+        env, agent_0_policy, agent_1_policy, max_episode_steps,
+        agent_0_test_mode, agent_1_test_mode)
     # Run episodes in parallel
-    all_outs = vmap_run_single_episode(ep_rngs)
+    all_outs = vmap_run_single_episode(ep_rngs, agent_0_param, agent_1_param)
     return all_outs  # each leaf has shape (num_eps, ...)

--- a/common/run_episodes.py
+++ b/common/run_episodes.py
@@ -133,9 +133,8 @@ def run_single_episode(rng, env, agent_0_param, agent_0_policy,
 @lru_cache(maxsize=128)
 def _compiled_run_episodes(env, agent_0_policy, agent_1_policy, max_episode_steps,
                            agent_0_test_mode, agent_1_test_mode):
-    '''Memoized so repeated calls reuse one XLA compilation. Agent params are runtime
-    arguments rather than closed-over constants, so two agents sharing a policy (e.g.
-    members of one heldout population) do not each trigger a recompile.'''
+    '''Memoized, with params as arguments rather than closed-over constants, so agents
+    sharing a policy reuse one XLA compilation instead of each triggering a recompile.'''
     @jax.jit
     def _run(ep_rngs, agent_0_param, agent_1_param):
         return jax.vmap(lambda ep_rng: run_single_episode(

--- a/common/run_n_agent_episodes.py
+++ b/common/run_n_agent_episodes.py
@@ -189,8 +189,7 @@ def run_n_agent_single_episode(
 def _compiled_run_n_agent_episodes(env, ego_policy, teammate_policy, ego_indices,
                                    teammate_indices, max_episode_steps,
                                    ego_test_mode, teammate_test_mode):
-    '''Memoized so repeated calls reuse one XLA compilation. See the equivalent
-    helper in common/run_episodes.py.'''
+    '''See the equivalent helper in common/run_episodes.py.'''
     @jax.jit
     def _run(ep_rngs, ego_param, teammate_param):
         return jax.vmap(lambda ep_rng: run_n_agent_single_episode(

--- a/common/run_n_agent_episodes.py
+++ b/common/run_n_agent_episodes.py
@@ -1,4 +1,4 @@
-'''
+"""
 Episode runner for N-agent AHT evaluation.
 
 Analogous to common/run_episodes.py but supports N agents organized into
@@ -13,19 +13,19 @@ heldout evaluation of trained ego agents.
 
 Output format is identical to LogWrapper / run_episodes so existing logging
 helpers remain compatible.
-'''
-from functools import lru_cache, partial
-from typing import List
+"""
+
+from functools import lru_cache
 
 import jax
 import jax.numpy as jnp
 
 from common.n_agent_utils import augment_obs_with_id
 
-
 # ---------------------------------------------------------------------------
 # Single-episode runner
 # ---------------------------------------------------------------------------
+
 
 def run_n_agent_single_episode(
     rng,
@@ -34,13 +34,13 @@ def run_n_agent_single_episode(
     ego_param,
     teammate_policy,
     teammate_param,
-    ego_indices: List[int],
-    teammate_indices: List[int],
+    ego_indices: list[int],
+    teammate_indices: list[int],
     max_episode_steps: int,
     ego_test_mode: bool = False,
     teammate_test_mode: bool = False,
 ):
-    '''Run one episode with two parameter-sharing agent groups.
+    """Run one episode with two parameter-sharing agent groups.
 
     Args:
         rng:                 JAX PRNGKey
@@ -57,7 +57,7 @@ def run_n_agent_single_episode(
 
     Returns:
         The final LogWrapper info dict (same structure as run_single_episode).
-    '''
+    """
     num_agents = env.num_agents
     n_ego = len(ego_indices)
     n_teammate = len(teammate_indices)
@@ -65,17 +65,17 @@ def run_n_agent_single_episode(
     # Reset
     rng, reset_rng = jax.random.split(rng)
     init_obs, init_env_state = env.reset(reset_rng)
-    init_done = {k: jnp.zeros((1,), dtype=bool) for k in env.agents + ['__all__']}
+    init_done = {k: jnp.zeros((1,), dtype=bool) for k in env.agents + ["__all__"]}
 
     # Initialise hidden states for every agent slot
     # ego: one hstate per ego slot, batch_size=1 each
     ego_hstates = [
-        ego_policy.init_hstate(1, aux_info={'agent_id': agent_idx})
+        ego_policy.init_hstate(1, aux_info={"agent_id": agent_idx})
         for agent_idx in ego_indices
     ]
     # teammate: one hstate per teammate slot, batch_size=1 each
     teammate_hstates = [
-        teammate_policy.init_hstate(1, aux_info={'agent_id': agent_idx})
+        teammate_policy.init_hstate(1, aux_info={"agent_id": agent_idx})
         for agent_idx in teammate_indices
     ]
 
@@ -90,18 +90,18 @@ def run_n_agent_single_episode(
 
         for slot, agent_idx in enumerate(ego_indices):
             rng, act_rng = jax.random.split(rng)
-            agent_key = f'agent_{agent_idx}'
+            agent_key = f"agent_{agent_idx}"
             aug_obs = augment_obs_with_id(obs[agent_key], agent_idx, num_agents)
             avail = avail_actions_dict[agent_key].astype(jnp.float32).reshape(1, -1)
             # Truncate obs to expected_obs_dim for compatibility with policies
             # that do not use agent_id as a feature. A policy with obs_dim=None
             # (e.g. heuristic heldout agents) expects the raw, un-augmented obs,
             # so strip the one-hot agent-ID we appended above.
-            expected_obs_dim = getattr(ego_policy, 'obs_dim', None)
+            expected_obs_dim = getattr(ego_policy, "obs_dim", None)
             if expected_obs_dim is None:
                 expected_obs_dim = aug_obs.shape[-1] - num_agents
             policy_obs = aug_obs[..., :expected_obs_dim]
-            
+
             act, new_h = ego_policy.get_action(
                 params=ego_param,
                 obs=policy_obs.reshape(1, 1, -1),
@@ -117,18 +117,18 @@ def run_n_agent_single_episode(
 
         for slot, agent_idx in enumerate(teammate_indices):
             rng, act_rng = jax.random.split(rng)
-            agent_key = f'agent_{agent_idx}'
+            agent_key = f"agent_{agent_idx}"
             aug_obs = augment_obs_with_id(obs[agent_key], agent_idx, num_agents)
             avail = avail_actions_dict[agent_key].astype(jnp.float32).reshape(1, -1)
             # Truncate obs to expected_obs_dim for compatibility with policies
             # that do not use agent_id as a feature. A policy with obs_dim=None
             # (e.g. heuristic heldout agents) expects the raw, un-augmented obs,
             # so strip the one-hot agent-ID we appended above.
-            expected_obs_dim = getattr(teammate_policy, 'obs_dim', None)
+            expected_obs_dim = getattr(teammate_policy, "obs_dim", None)
             if expected_obs_dim is None:
                 expected_obs_dim = aug_obs.shape[-1] - num_agents
             policy_obs = aug_obs[..., :expected_obs_dim]
-            
+
             act, new_h = teammate_policy.get_action(
                 params=teammate_param,
                 obs=policy_obs.reshape(1, 1, -1),
@@ -145,23 +145,41 @@ def run_n_agent_single_episode(
         return rng, actions, new_ego_hstates, new_teammate_hstates
 
     # Bootstrap one step to get dummy info for scan
-    avail_actions = env.get_avail_actions(init_env_state.env_state)
-    rng, act0_rng, step_rng = jax.random.split(rng, 3)
+    rng, _act0_rng, step_rng = jax.random.split(rng, 3)
 
     rng, boot_actions, ego_hstates, teammate_hstates = _get_all_actions(
         rng, init_obs, init_done, init_env_state, ego_hstates, teammate_hstates
     )
-    obs, env_state, _, done, dummy_info = env.step(step_rng, init_env_state, boot_actions)
+    obs, env_state, _, done, dummy_info = env.step(
+        step_rng, init_env_state, boot_actions
+    )
 
     # Scan
     ep_ts = 1
     # Pack hstates as tuples for JAX pytree compatibility inside scan
-    init_carry = (ep_ts, env_state, obs, rng, done,
-                  tuple(ego_hstates), tuple(teammate_hstates), dummy_info)
+    init_carry = (
+        ep_ts,
+        env_state,
+        obs,
+        rng,
+        done,
+        tuple(ego_hstates),
+        tuple(teammate_hstates),
+        dummy_info,
+    )
 
     def scan_step(carry, _):
         def take_step(carry_step):
-            ep_ts, env_state, obs, rng, done, ego_hstates, teammate_hstates, last_info = carry_step
+            (
+                ep_ts,
+                env_state,
+                obs,
+                rng,
+                done,
+                ego_hstates,
+                teammate_hstates,
+                _last_info,
+            ) = carry_step
             rng, step_rng = jax.random.split(rng)
             rng, actions, new_ego_hstates, new_teammate_hstates = _get_all_actions(
                 rng, obs, done, env_state, list(ego_hstates), list(teammate_hstates)
@@ -169,15 +187,23 @@ def run_n_agent_single_episode(
             obs_next, env_state_next, _, done_next, info_next = env.step(
                 step_rng, env_state, actions
             )
-            return (ep_ts + 1, env_state_next, obs_next, rng, done_next,
-                    tuple(new_ego_hstates), tuple(new_teammate_hstates), info_next)
+            return (
+                ep_ts + 1,
+                env_state_next,
+                obs_next,
+                rng,
+                done_next,
+                tuple(new_ego_hstates),
+                tuple(new_teammate_hstates),
+                info_next,
+            )
 
-        ep_ts, env_state, obs, rng, done, ego_hstates, teammate_hstates, last_info = carry
+        done = carry[4]
         new_carry = jax.lax.cond(
-            done['__all__'],
-            lambda c: c,    # episode over: hold state
+            done["__all__"],
+            lambda c: c,  # episode over: hold state
             take_step,
-            operand=carry
+            operand=carry,
         )
         return new_carry, None
 
@@ -186,21 +212,38 @@ def run_n_agent_single_episode(
 
 
 @lru_cache(maxsize=128)
-def _compiled_run_n_agent_episodes(env, ego_policy, teammate_policy, ego_indices,
-                                   teammate_indices, max_episode_steps,
-                                   ego_test_mode, teammate_test_mode):
-    '''See the equivalent helper in common/run_episodes.py.'''
+def _compiled_run_n_agent_episodes(
+    env,
+    ego_policy,
+    teammate_policy,
+    ego_indices,
+    teammate_indices,
+    max_episode_steps,
+    ego_test_mode,
+    teammate_test_mode,
+):
+    """See the equivalent helper in common/run_episodes.py."""
+
     @jax.jit
     def _run(ep_rngs, ego_param, teammate_param):
-        return jax.vmap(lambda ep_rng: run_n_agent_single_episode(
-            ep_rng, env,
-            ego_policy, ego_param,
-            teammate_policy, teammate_param,
-            ego_indices, teammate_indices,
-            max_episode_steps,
-            ego_test_mode, teammate_test_mode,
-        ))(ep_rngs)
+        return jax.vmap(
+            lambda ep_rng: run_n_agent_single_episode(
+                ep_rng,
+                env,
+                ego_policy,
+                ego_param,
+                teammate_policy,
+                teammate_param,
+                ego_indices,
+                teammate_indices,
+                max_episode_steps,
+                ego_test_mode,
+                teammate_test_mode,
+            )
+        )(ep_rngs)
+
     return _run
+
 
 def run_n_agent_episodes(
     rng,
@@ -209,25 +252,31 @@ def run_n_agent_episodes(
     ego_param,
     teammate_policy,
     teammate_param,
-    ego_indices: List[int],
-    teammate_indices: List[int],
+    ego_indices: list[int],
+    teammate_indices: list[int],
     max_episode_steps: int,
     num_eps: int,
     ego_test_mode: bool = False,
     teammate_test_mode: bool = False,
 ):
-    '''Run num_eps parallel episodes via vmap.
+    """Run num_eps parallel episodes via vmap.
 
     Args:
         (same as run_n_agent_single_episode, plus num_eps)
 
     Returns:
         Dict where each leaf has shape (num_eps, ...).
-    '''
+    """
     rngs = jax.random.split(rng, num_eps)
 
     vmap_episode = _compiled_run_n_agent_episodes(
-        env, ego_policy, teammate_policy,
-        tuple(ego_indices), tuple(teammate_indices),
-        max_episode_steps, ego_test_mode, teammate_test_mode)
+        env,
+        ego_policy,
+        teammate_policy,
+        tuple(ego_indices),
+        tuple(teammate_indices),
+        max_episode_steps,
+        ego_test_mode,
+        teammate_test_mode,
+    )
     return vmap_episode(rngs, ego_param, teammate_param)

--- a/common/run_n_agent_episodes.py
+++ b/common/run_n_agent_episodes.py
@@ -14,7 +14,7 @@ heldout evaluation of trained ego agents.
 Output format is identical to LogWrapper / run_episodes so existing logging
 helpers remain compatible.
 '''
-from functools import partial
+from functools import lru_cache, partial
 from typing import List
 
 import jax
@@ -185,6 +185,24 @@ def run_n_agent_single_episode(
     return final_carry[-1]  # final info dict
 
 
+@lru_cache(maxsize=128)
+def _compiled_run_n_agent_episodes(env, ego_policy, teammate_policy, ego_indices,
+                                   teammate_indices, max_episode_steps,
+                                   ego_test_mode, teammate_test_mode):
+    '''Memoized so repeated calls reuse one XLA compilation. See the equivalent
+    helper in common/run_episodes.py.'''
+    @jax.jit
+    def _run(ep_rngs, ego_param, teammate_param):
+        return jax.vmap(lambda ep_rng: run_n_agent_single_episode(
+            ep_rng, env,
+            ego_policy, ego_param,
+            teammate_policy, teammate_param,
+            ego_indices, teammate_indices,
+            max_episode_steps,
+            ego_test_mode, teammate_test_mode,
+        ))(ep_rngs)
+    return _run
+
 def run_n_agent_episodes(
     rng,
     env,
@@ -209,14 +227,8 @@ def run_n_agent_episodes(
     '''
     rngs = jax.random.split(rng, num_eps)
 
-    vmap_episode = jax.jit(jax.vmap(
-        lambda ep_rng: run_n_agent_single_episode(
-            ep_rng, env,
-            ego_policy, ego_param,
-            teammate_policy, teammate_param,
-            ego_indices, teammate_indices,
-            max_episode_steps,
-            ego_test_mode, teammate_test_mode,
-        )
-    ))
-    return vmap_episode(rngs)
+    vmap_episode = _compiled_run_n_agent_episodes(
+        env, ego_policy, teammate_policy,
+        tuple(ego_indices), tuple(teammate_indices),
+        max_episode_steps, ego_test_mode, teammate_test_mode)
+    return vmap_episode(rngs, ego_param, teammate_param)

--- a/ego_agent_training/ppo_br.py
+++ b/ego_agent_training/ppo_br.py
@@ -18,7 +18,7 @@ from envs import make_env
 from envs.log_wrapper import LogWrapper
 from ego_agent_training.ppo_ego import train_ppo_ego_agent, log_metrics
 from ego_agent_training.utils import initialize_ego_agent
-from evaluation.heldout_evaluator import load_heldout_set
+from evaluation.heldout_core import load_heldout_set
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)

--- a/ego_agent_training/ppo_br.py
+++ b/ego_agent_training/ppo_br.py
@@ -1,112 +1,153 @@
-'''Train an ego agent against a *single* partner agent.
+"""Train an ego agent against a *single* partner agent.
 Supports training against both RL and heuristic partner agents.
 
-If running the script directly, please specify a partner agent config at 
+If running the script directly, please specify a partner agent config at
 `ego_agent_training/configs/algorithm/ppo_br/_base_.yaml`.
 
-'''
-from functools import partial
-import time
+"""
+
 import logging
+import time
+from functools import partial
 
 import jax
 import jax.numpy as jnp
 
 from agents.population_interface import AgentPopulation
 from common.plot_utils import get_metric_names
+from ego_agent_training.ppo_ego import log_metrics, train_ppo_ego_agent
+from ego_agent_training.utils import initialize_ego_agent
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from ego_agent_training.ppo_ego import train_ppo_ego_agent, log_metrics
-from ego_agent_training.utils import initialize_ego_agent
 from evaluation.heldout_core import load_heldout_set
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+
 class DummyPolicyPopulation(AgentPopulation):
-    '''A wrapper around the AgentPopulation class that allows for a single policy to be used.
-    The main difference from the AgentPopulation is that the test mode is a class attribute, 
+    """A wrapper around the AgentPopulation class that allows for a single policy to be used.
+    The main difference from the AgentPopulation is that the test mode is a class attribute,
     so it remains static for the lifetime of the object
-    '''
+    """
+
     def __init__(self, policy_cls, test_mode=False):
         super().__init__(pop_size=1, policy_cls=policy_cls)
         self.test_mode = test_mode
-    
-    def get_actions(self, pop_params, agent_indices, obs, done, avail_actions, hstate, rng, 
-                    env_state=None, aux_obs=None):
-        '''
-        Get the actions of the agents specified by agent_indices. Does not support agents that 
+
+    def get_actions(
+        self,
+        pop_params,
+        agent_indices,
+        obs,
+        done,
+        avail_actions,
+        hstate,
+        rng,
+        env_state=None,
+        aux_obs=None,
+    ):
+        """
+        Get the actions of the agents specified by agent_indices. Does not support agents that
         require auxiliary observations.
         Returns:
             actions: actions with shape (num_envs,)
             new_hstate: new hidden state with shape (num_envs, ...) or None
-        '''
+        """
         gathered_params = self.gather_agent_params(pop_params, agent_indices)
         num_envs = agent_indices.squeeze().shape[0]
         rngs_batched = jax.random.split(rng, num_envs)
-        vmapped_get_action = jax.vmap(partial(self.policy_cls.get_action, 
-                                              aux_obs=aux_obs, 
-                                              env_state=env_state, 
-                                              test_mode=self.test_mode))
+        vmapped_get_action = jax.vmap(
+            partial(
+                self.policy_cls.get_action,
+                aux_obs=aux_obs,
+                env_state=env_state,
+                test_mode=self.test_mode,
+            )
+        )
         actions, new_hstate = vmapped_get_action(
-            gathered_params, obs, done, avail_actions, hstate, 
-            rngs_batched)
+            gathered_params, obs, done, avail_actions, hstate, rngs_batched
+        )
         return actions, new_hstate
 
     def init_hstate(self, n: int):
-        '''Initialize the hidden state for n members of the population.'''
+        """Initialize the hidden state for n members of the population."""
         hstate = self.policy_cls.init_hstate(n)
         return hstate
 
+
 class HeuristicPolicyPopulation(AgentPopulation):
-    '''A wrapper around the AgentPopulation class that allows for a heuristic policy to be used.
+    """A wrapper around the AgentPopulation class that allows for a heuristic policy to be used.
     The main difference from the AgentPopulation is that:
     - test mode is not used b/c heuristic agents do not have a test mode
     - get_actions requires the environment state
     - the init_hstate method is overridden to vmap over the hidden state initialization.
-    '''
+    """
+
     def __init__(self, policy_cls):
         super().__init__(pop_size=1, policy_cls=policy_cls)
 
-    def get_actions(self, pop_params, agent_indices, obs, done, avail_actions, hstate, rng, 
-                    env_state, aux_obs=None):
-        '''
-        Get the actions of the agents specified by agent_indices. Requires env_state. 
+    def get_actions(
+        self,
+        pop_params,
+        agent_indices,
+        obs,
+        done,
+        avail_actions,
+        hstate,
+        rng,
+        env_state,
+        aux_obs=None,
+    ):
+        """
+        Get the actions of the agents specified by agent_indices. Requires env_state.
         Does not support agents that require auxiliary observations.
         Returns:
             actions: actions with shape (num_envs,)
             new_hstate: new hidden state with shape (num_envs, ...) or None
-        '''
+        """
         gathered_params = self.gather_agent_params(pop_params, agent_indices)
         num_envs = agent_indices.squeeze().shape[0]
         rngs_batched = jax.random.split(rng, num_envs)
-        
-        def _policy_cls_get_action(params, obs, done, avail_actions, hstate, rng, env_state
-                                   ):
-            return self.policy_cls.get_action(params=params, obs=obs, done=done, 
-                                              avail_actions=avail_actions, hstate=hstate, 
-                                              rng=rng, env_state=env_state, 
-                                              aux_obs=None, test_mode=False)
+
+        def _policy_cls_get_action(
+            params, obs, done, avail_actions, hstate, rng, env_state
+        ):
+            return self.policy_cls.get_action(
+                params=params,
+                obs=obs,
+                done=done,
+                avail_actions=avail_actions,
+                hstate=hstate,
+                rng=rng,
+                env_state=env_state,
+                aux_obs=None,
+                test_mode=False,
+            )
+
         vmapped_get_action = jax.vmap(_policy_cls_get_action)
         actions, new_hstate = vmapped_get_action(
-            params=gathered_params, 
-            obs=obs, 
-            done=done, 
-            avail_actions=avail_actions, 
-            hstate=hstate, 
-            rng=rngs_batched, 
-            env_state=env_state)
+            params=gathered_params,
+            obs=obs,
+            done=done,
+            avail_actions=avail_actions,
+            hstate=hstate,
+            rng=rngs_batched,
+            env_state=env_state,
+        )
         return actions, new_hstate
 
     def init_hstate(self, n: int):
-        '''Initialize the hidden state for n members of the population.'''
+        """Initialize the hidden state for n members of the population."""
         # partner agent is always agent 1 in the ppo_ego training code
         vmap_dummy_input = jnp.ones(n)
-        return jax.vmap(partial(self.policy_cls.init_hstate, aux_info={"agent_id": 1}))(vmap_dummy_input)
+        return jax.vmap(partial(self.policy_cls.init_hstate, aux_info={"agent_id": 1}))(
+            vmap_dummy_input
+        )
+
 
 def run_br_training(config, wandb_logger):
-    '''Run ego agent training against a single partner agent.
-    '''
+    """Run ego agent training against a single partner agent."""
     algorithm_config = dict(config["algorithm"])
 
     # Create only one environment instance
@@ -121,29 +162,32 @@ def run_br_training(config, wandb_logger):
 
     # Initialize partner agent
     partner_agent_config = dict(algorithm_config["partner_agent"])
-    heldout_agents = load_heldout_set(partner_agent_config, env, config["TASK_NAME"], config["ENV_KWARGS"], init_rng)
-    assert len(heldout_agents) == 1, "Only supports training against one partner agent. Use ppo_ego.py for training against a population of partner agents."
+    heldout_agents = load_heldout_set(
+        partner_agent_config, env, config["TASK_NAME"], config["ENV_KWARGS"], init_rng
+    )
+    assert len(heldout_agents) == 1, (
+        "Only supports training against one partner agent. Use ppo_ego.py for training against a population of partner agents."
+    )
 
-    partner_policy, partner_params, partner_test_mode, _ = list(heldout_agents.values())[0]
+    partner_policy, partner_params, partner_test_mode, _ = next(
+        iter(heldout_agents.values())
+    )
 
-    if partner_params is not None: # RL agent
+    if partner_params is not None:  # RL agent
         partner_params = jax.tree.map(lambda x: x[jnp.newaxis, ...], partner_params)
         partner_population = DummyPolicyPopulation(
-            policy_cls=partner_policy,
-            test_mode=partner_test_mode
+            policy_cls=partner_policy, test_mode=partner_test_mode
         )
-    
-    else: # heuristic agent
+
+    else:  # heuristic agent
         # Doesn't matter what we pass for params, since the heuristic agent doesn't use params.
         # We just need to pass something to vmap over.
         partner_params = jax.tree.map(lambda x: x[jnp.newaxis, ...], init_ego_params)
-        partner_population = HeuristicPolicyPopulation(
-            policy_cls=partner_policy
-        )
+        partner_population = HeuristicPolicyPopulation(policy_cls=partner_policy)
 
     log.info("Starting ego agent training...")
     start_time = time.time()
-    
+
     # Run the training
     out = train_ppo_ego_agent(
         config=algorithm_config,
@@ -153,13 +197,13 @@ def run_br_training(config, wandb_logger):
         init_ego_params=init_ego_params,
         n_ego_train_seeds=algorithm_config["NUM_EGO_TRAIN_SEEDS"],
         partner_population=partner_population,
-        partner_params=partner_params
+        partner_params=partner_params,
     )
-    
+
     log.info(f"Training completed in {time.time() - start_time:.2f} seconds")
-    
+
     # process and log metrics
     metric_names = get_metric_names(config["ENV_NAME"])
     log_metrics(config, out, wandb_logger, metric_names)
-    
+
     return out["final_params"], ego_policy, init_ego_params

--- a/ego_agent_training/run.py
+++ b/ego_agent_training/run.py
@@ -4,7 +4,7 @@ from omegaconf import OmegaConf
 
 from common.plot_utils import get_metric_names
 from common.wandb_visualizations import Logger
-from evaluation.heldout_eval import run_heldout_evaluation, log_heldout_metrics
+from evaluation.heldout_runner import run_heldout_evaluation, log_heldout_metrics
 from ppo_ego import run_ego_training as run_ego_ppo_training
 from liam_ego import run_ego_training as run_ego_liam_training
 from meliba_ego import run_ego_training as run_ego_meliba_training

--- a/ego_agent_training/run.py
+++ b/ego_agent_training/run.py
@@ -1,39 +1,56 @@
-'''Main entry point for running ego agent training algorithms against a fixed partner population.'''
+"""Main entry point for running ego agent training algorithms against a fixed partner population."""
+
 import hydra
+from liam_ego import run_ego_training as run_ego_liam_training
+from meliba_ego import run_ego_training as run_ego_meliba_training
 from omegaconf import OmegaConf
+from ppo_ego import run_ego_training as run_ego_ppo_training
 
 from common.plot_utils import get_metric_names
 from common.wandb_visualizations import Logger
-from evaluation.heldout_runner import run_heldout_evaluation, log_heldout_metrics
-from ppo_ego import run_ego_training as run_ego_ppo_training
-from liam_ego import run_ego_training as run_ego_liam_training
-from meliba_ego import run_ego_training as run_ego_meliba_training
 from ego_agent_training.ppo_br import run_br_training
+from evaluation.heldout_runner import log_heldout_metrics, run_heldout_evaluation
 
 
 @hydra.main(version_base=None, config_path="configs", config_name="base_config_ego")
 def run_training(cfg):
-    '''Runs the ego agent training against a fixed partner population.'''
+    """Runs the ego agent training against a fixed partner population."""
     print(OmegaConf.to_yaml(cfg, resolve=True))
     wandb_logger = Logger(cfg)
 
     if cfg["algorithm"]["ALG"] == "ppo_ego":
-        ego_params, ego_policy, init_ego_params = run_ego_ppo_training(cfg, wandb_logger)
+        ego_params, ego_policy, init_ego_params = run_ego_ppo_training(
+            cfg, wandb_logger
+        )
     elif cfg["algorithm"]["ALG"] == "ppo_br":
         ego_params, ego_policy, init_ego_params = run_br_training(cfg, wandb_logger)
     elif cfg["algorithm"]["ALG"] == "liam_ego":
-        ego_params, ego_policy, init_ego_params = run_ego_liam_training(cfg, wandb_logger)
+        ego_params, ego_policy, init_ego_params = run_ego_liam_training(
+            cfg, wandb_logger
+        )
     elif cfg["algorithm"]["ALG"] == "meliba_ego":
-        ego_params, ego_policy, init_ego_params = run_ego_meliba_training(cfg, wandb_logger)
+        ego_params, ego_policy, init_ego_params = run_ego_meliba_training(
+            cfg, wandb_logger
+        )
 
     if cfg["run_heldout_eval"]:
         metric_names = get_metric_names(cfg["ENV_NAME"])
-        eval_metrics, ego_names, heldout_names = run_heldout_evaluation(cfg, ego_policy, ego_params, init_ego_params, ego_as_2d=False)
-        log_heldout_metrics(cfg, wandb_logger, eval_metrics, ego_names, heldout_names, metric_names, ego_as_2d=False)
+        eval_metrics, ego_names, heldout_names = run_heldout_evaluation(
+            cfg, ego_policy, ego_params, init_ego_params, ego_as_2d=False
+        )
+        log_heldout_metrics(
+            cfg,
+            wandb_logger,
+            eval_metrics,
+            ego_names,
+            heldout_names,
+            metric_names,
+            ego_as_2d=False,
+        )
 
     # Cleanup
     wandb_logger.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_training()

--- a/ego_agent_training/run.py
+++ b/ego_agent_training/run.py
@@ -1,14 +1,14 @@
 """Main entry point for running ego agent training algorithms against a fixed partner population."""
 
 import hydra
-from liam_ego import run_ego_training as run_ego_liam_training
-from meliba_ego import run_ego_training as run_ego_meliba_training
 from omegaconf import OmegaConf
-from ppo_ego import run_ego_training as run_ego_ppo_training
 
 from common.plot_utils import get_metric_names
 from common.wandb_visualizations import Logger
+from ego_agent_training.liam_ego import run_ego_training as run_ego_liam_training
+from ego_agent_training.meliba_ego import run_ego_training as run_ego_meliba_training
 from ego_agent_training.ppo_br import run_br_training
+from ego_agent_training.ppo_ego import run_ego_training as run_ego_ppo_training
 from evaluation.heldout_runner import log_heldout_metrics, run_heldout_evaluation
 
 

--- a/evaluation/configs/task/hanabi.yaml
+++ b/evaluation/configs/task/hanabi.yaml
@@ -1,5 +1,5 @@
 # Hanabi: evaluation task config.
-# Full 2-player Hanabi. Used by evaluation/heldout_eval.py with task=hanabi.
+# Full 2-player Hanabi. Used by evaluation/heldout_runner.py with task=hanabi.
 ENV_NAME: hanabi
 ROLLOUT_LENGTH: 128
 ENV_KWARGS:

--- a/evaluation/generate_xp_matrix.py
+++ b/evaluation/generate_xp_matrix.py
@@ -9,7 +9,7 @@ from common.tree_utils import tree_stack
 from common.plot_utils import get_metric_names
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from evaluation.heldout_evaluator import load_heldout_set, print_metrics_table, normalize_metrics
+from evaluation.heldout_core import load_heldout_set, print_metrics_table, normalize_metrics
 
 def heldout_crossplay(config, env, rng, num_episodes, heldout_agents, br_agents):
     '''Evaluate all heldout agents against each other

--- a/evaluation/generate_xp_matrix.py
+++ b/evaluation/generate_xp_matrix.py
@@ -1,70 +1,82 @@
-'''This script generates a XP matrix for the heldout set.
+"""This script generates a XP matrix for the heldout set.
 
 Run via `python evaluation/run.py -cn heldout_xp task=lbf/lbf_7x7_nolevels`.
-'''
+"""
+
 import jax
 
+from common.plot_utils import get_metric_names
 from common.run_episodes import run_episodes
 from common.tree_utils import tree_stack
-from common.plot_utils import get_metric_names
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from evaluation.heldout_core import load_heldout_set, print_metrics_table, normalize_metrics
+from evaluation.heldout_core import (
+    load_heldout_set,
+    normalize_metrics,
+    print_metrics_table,
+)
+
 
 def heldout_crossplay(config, env, rng, num_episodes, heldout_agents, br_agents):
-    '''Evaluate all heldout agents against each other
-    Args: 
+    """Evaluate all heldout agents against each other
+    Args:
         heldout_agents: a dict of (policy, params, test_mode) tuples for each heldout partner. params might be None for heuristic agents.
         br_agents: dict with same structure as heldout_agents, but for best response agents.
     Returns a pytree of shape (num_heldout_agents, num_heldout_agents, num_eval_episodes, num_agents_per_env)
-    '''
+    """
     num_agents = env.num_agents
     assert num_agents == 2, "This eval code assumes exactly 2 agents."
 
     heldout_agent_names = list(heldout_agents.keys())
     heldout_agent_list = list(heldout_agents.values())
-    br_agent_names = list(br_agents.keys())
     br_agent_list = list(br_agents.values())
-    
+
     num_heldout_agents = len(heldout_agent_list)
 
     def eval_pair_fn(rng, policy1, param1, test_mode1, policy2, param2, test_mode2):
-        return run_episodes(rng, env, 
-                            agent_0_param=param1, agent_0_policy=policy1,
-                            agent_1_param=param2, agent_1_policy=policy2,
-                            max_episode_steps=config["global_heldout_settings"]["MAX_EPISODE_STEPS"],
-                            num_eps=num_episodes, 
-                            agent_0_test_mode=test_mode1,
-                            agent_1_test_mode=test_mode2)
+        return run_episodes(
+            rng,
+            env,
+            agent_0_param=param1,
+            agent_0_policy=policy1,
+            agent_1_param=param2,
+            agent_1_policy=policy2,
+            max_episode_steps=config["global_heldout_settings"]["MAX_EPISODE_STEPS"],
+            num_eps=num_episodes,
+            agent_0_test_mode=test_mode1,
+            agent_1_test_mode=test_mode2,
+        )
 
     # Initialize results array
     all_metrics = []
-    
+
     # Split RNG for each heldout agent
     rng, sub_rng = jax.random.split(rng)
     outer_heldout_rngs = jax.random.split(sub_rng, num_heldout_agents)
-    
-    # Double for loop implementation is necessary because the heldout agents have heterogeneous policy and 
-    # param structures. 
+
+    # Double for loop implementation is necessary because the heldout agents have heterogeneous policy and
+    # param structures.
     warned_missing_row_bounds = set()
 
     for i in range(num_heldout_agents):
         heldout_agent1 = heldout_agent_list[i]
         policy1, param1, test_mode1, performance_bounds1 = heldout_agent1
         rng1 = outer_heldout_rngs[i]
-        
+
         # Split RNG for each heldout partner
         rng1, sub_rng1 = jax.random.split(rng1)
         partner_rngs = jax.random.split(sub_rng1, num_heldout_agents)
-        
+
         partner_i_metrics = []
         for j in range(num_heldout_agents):
             br_agent = br_agent_list[j]
-            policy2, param2, test_mode2, performance_bounds2 = br_agent
+            policy2, param2, test_mode2, _performance_bounds2 = br_agent
             rng2 = partner_rngs[j]
-            
+
             # Evaluate the pair
-            eval_metrics = eval_pair_fn(rng2, policy1, param1, test_mode1, policy2, param2, test_mode2)
+            eval_metrics = eval_pair_fn(
+                rng2, policy1, param1, test_mode1, policy2, param2, test_mode2
+            )
 
             if config["global_heldout_settings"]["NORMALIZE_RETURNS"]:
                 # XP row normalization: use the heldout-row agent bounds only.
@@ -79,32 +91,44 @@ def heldout_crossplay(config, env, rng, num_episodes, heldout_agents, br_agents)
 
             partner_i_metrics.append(eval_metrics)
 
-        all_metrics.append(tree_stack(partner_i_metrics))    
+        all_metrics.append(tree_stack(partner_i_metrics))
     return tree_stack(all_metrics)
 
+
 def run_heldout_xp_evaluation(config, print_metrics=False):
-    '''Run heldout evaluation'''
+    """Run heldout evaluation"""
     # Create only one environment instance
     env = make_env(config["ENV_NAME"], config["ENV_KWARGS"])
     env = LogWrapper(env)
-    
+
     rng = jax.random.PRNGKey(config["global_heldout_settings"]["EVAL_SEED"])
     rng, heldout_init_rng, br_init_rng, eval_rng = jax.random.split(rng, 4)
-    
+
     # load heldout agents
     heldout_cfg = config["heldout_set"][config["TASK_NAME"]]
-    heldout_agents = load_heldout_set(heldout_cfg, env, config["TASK_NAME"], config["ENV_KWARGS"], heldout_init_rng)
-    
+    heldout_agents = load_heldout_set(
+        heldout_cfg, env, config["TASK_NAME"], config["ENV_KWARGS"], heldout_init_rng
+    )
+
     # load best response agents
     br_cfg = config["best_response_set"][config["TASK_NAME"]]
-    br_agents = load_heldout_set(br_cfg, env, config["TASK_NAME"], config["ENV_KWARGS"], br_init_rng)
+    br_agents = load_heldout_set(
+        br_cfg, env, config["TASK_NAME"], config["ENV_KWARGS"], br_init_rng
+    )
 
     # sanity check
-    assert len(heldout_agents) == len(br_agents), "Number of heldout agents and best response agents must be the same."
+    assert len(heldout_agents) == len(br_agents), (
+        "Number of heldout agents and best response agents must be the same."
+    )
     # run evaluation
     eval_metrics = heldout_crossplay(
-        config, env, eval_rng, config["global_heldout_settings"]["NUM_EVAL_EPISODES"], 
-        heldout_agents, br_agents)
+        config,
+        env,
+        eval_rng,
+        config["global_heldout_settings"]["NUM_EVAL_EPISODES"],
+        heldout_agents,
+        br_agents,
+    )
 
     if print_metrics:
         # each leaf of eval_metrics has shape (num_heldout_agents, num_heldout_agents, num_eval_episodes, num_agents_per_env)
@@ -112,7 +136,13 @@ def run_heldout_xp_evaluation(config, print_metrics=False):
         heldout_names = list(heldout_agents.keys())
         br_names = list(br_agents.keys())
         for metric_name in metric_names:
-            print_metrics_table(eval_metrics, metric_name, heldout_names, br_names, 
-            config["global_heldout_settings"]["AGGREGATE_STAT"], 
-            config["global_heldout_settings"]["NORMALIZE_RETURNS"], save=True)
+            print_metrics_table(
+                eval_metrics,
+                metric_name,
+                heldout_names,
+                br_names,
+                config["global_heldout_settings"]["AGGREGATE_STAT"],
+                config["global_heldout_settings"]["NORMALIZE_RETURNS"],
+                save=True,
+            )
     return eval_metrics

--- a/evaluation/heldout_core.py
+++ b/evaluation/heldout_core.py
@@ -1,31 +1,30 @@
-'''This script implements evaluating ego agents against heldout agents. 
+"""This script implements evaluating ego agents against heldout agents.
 Warning: ActorCritic agents that rely on auxiliary information to compute actions are not currently supported.
-'''
+"""
+
+import os
+import time
+from functools import partial
+
+import hydra
 import jax
 import jax.numpy as jnp
 import numpy as np
 from prettytable import PrettyTable
-from functools import partial
-import time
-import os
-import hydra
 
 from common.agent_loader_from_config import (
-    initialize_rl_agent_from_config,
     initialize_heuristic_agent_from_config,
+    initialize_rl_agent_from_config,
 )
 from common.run_episodes import run_episodes
-from common.tree_utils import tree_stack
-from common.plot_utils import get_metric_names
 from common.stat_utils import compute_aggregate_stat_and_ci_per_task
-from envs import make_env
-from envs.log_wrapper import LogWrapper
+from common.tree_utils import tree_stack
 
 
 def extract_params(params, init_params, idx_labels=None):
-    '''params is a pytree of n model checkpoints, where each leaf has an unknown number 
-    of checkpoint dimensions, and the last dimension corresponds to the layer dimension. 
-    This function extracts each of the n checkpoints and returns a list of n pytrees, 
+    """params is a pytree of n model checkpoints, where each leaf has an unknown number
+    of checkpoint dimensions, and the last dimension corresponds to the layer dimension.
+    This function extracts each of the n checkpoints and returns a list of n pytrees,
     where each pytree has the same structure as init_params.
 
     Args:
@@ -37,8 +36,10 @@ def extract_params(params, init_params, idx_labels=None):
         Tuple of:
             - list of n pytrees with same structure as init_params
             - list of n index labels identifying the original location of each checkpoint
-    '''
-    assert jax.tree.structure(params) == jax.tree.structure(init_params), "Params and init_params must have the same structure."
+    """
+    assert jax.tree.structure(params) == jax.tree.structure(init_params), (
+        "Params and init_params must have the same structure."
+    )
 
     model_list = []
     flattened_idx_labels = []
@@ -48,34 +49,37 @@ def extract_params(params, init_params, idx_labels=None):
     if params_shape == init_params_shape:
         model_list = [params]
         n_models = 1
-        
+
         if idx_labels is not None:
             flattened_idx_labels = idx_labels
     # multiple models, extract each one
     else:
         # first, flatten the params so that each leaf has shape (..., init_params_shape)
-        flattened_params = jax.tree.map(lambda x, y: x.reshape((-1,) + y.shape), params, init_params)        
+        flattened_params = jax.tree.map(
+            lambda x, y: x.reshape((-1,) + y.shape), params, init_params
+        )
         # then, extract each model
         n_models = jax.tree.leaves(flattened_params)[0].shape[0]
-        
+
         # Now, flatten the idx_labels to match the flattened parameters
         if idx_labels is not None:
             flattened_idx_labels = np.array(idx_labels).reshape(n_models)
-            
+
         # Extract each model
         for i in range(n_models):
-            model_i = jax.tree.map(lambda x: x[i], flattened_params)
+            model_i = jax.tree.map(lambda x, i=i: x[i], flattened_params)
             model_list.append(model_i)
-    
+
     if idx_labels is None:
         flattened_idx_labels = [str(i) for i in range(n_models)]
-    
+
     return model_list, flattened_idx_labels
 
+
 def extract_performance_bounds(agent_config, n_models):
-    '''Flatten performance bounds dictionary into n_models dictionaries. 
-    Each leaf has the same structure as idx_list. 
-    '''
+    """Flatten performance bounds dictionary into n_models dictionaries.
+    Each leaf has the same structure as idx_list.
+    """
     performance_bounds = agent_config.get("performance_bounds", None)
     if performance_bounds is None:
         return [None for _ in range(n_models)]
@@ -84,16 +88,19 @@ def extract_performance_bounds(agent_config, n_models):
         for i in range(n_models):
             perf_i = {}
             for stat_name, bound_list in performance_bounds.items():
-                assert len(bound_list[i]) == 2, "Performance bounds must be a list of two values (upper and lower bounds)."
+                assert len(bound_list[i]) == 2, (
+                    "Performance bounds must be a list of two values (upper and lower bounds)."
+                )
                 perf_i[stat_name] = bound_list[i]
             ret_list.append(perf_i)
         return ret_list
 
+
 def load_heldout_set(heldout_config, env, task_name, env_kwargs, rng):
-    '''Load heldout evaluation agents from config.
-    Returns a dictionary of agents with keys as agent names and values as tuples of 
+    """Load heldout evaluation agents from config.
+    Returns a dictionary of agents with keys as agent names and values as tuples of
     (policy, params, test_mode).
-    '''
+    """
     heldout_agents = {}
     for agent_name, agent_config in heldout_config.items():
         # Allow env-specific configs to null out entries inherited from a
@@ -108,10 +115,14 @@ def load_heldout_set(heldout_config, env, task_name, env_kwargs, rng):
         if "path" in agent_config and agent_config.get("actor_type") != "bc_proxy":
             # ensure that each rl agent has a unique initialization rng
             rng, init_rng = jax.random.split(rng)
-            policy, params, init_params, idx_labels = initialize_rl_agent_from_config(agent_config, agent_name, env, init_rng)
+            policy, params, init_params, idx_labels = initialize_rl_agent_from_config(
+                agent_config, agent_name, env, init_rng
+            )
             # params contains multiple model checkpoints, so we need to extract each one
             params_list, idx_labels = extract_params(params, init_params, idx_labels)
-            performance_bounds_list = extract_performance_bounds(agent_config, len(params_list))
+            performance_bounds_list = extract_performance_bounds(
+                agent_config, len(params_list)
+            )
 
         # Load non-RL-based heuristic agents
         else:
@@ -119,36 +130,51 @@ def load_heldout_set(heldout_config, env, task_name, env_kwargs, rng):
             policy = initialize_heuristic_agent_from_config(
                 agent_config, agent_name, task_name, env_kwargs
             )
-        
+
         # Generate agent labels
-        if params_list is None: # heuristic agent
+        if params_list is None:  # heuristic agent
             heldout_agents[agent_name] = (policy, None, test_mode, performance_bounds)
-        else: # rl agent
+        else:  # rl agent
             for i, params_i in enumerate(params_list):
                 if idx_labels is None:
-                    agent_label = f'{agent_name} ({i})'
+                    agent_label = f"{agent_name} ({i})"
                 else:
-                    agent_label = f'{agent_name} ({idx_labels[i]})'
-                heldout_agents[agent_label] = (policy, params_i, test_mode, performance_bounds_list[i])
+                    agent_label = f"{agent_name} ({idx_labels[i]})"
+                heldout_agents[agent_label] = (
+                    policy,
+                    params_i,
+                    test_mode,
+                    performance_bounds_list[i],
+                )
     return heldout_agents
 
+
 def normalize_metrics(metrics, performance_bounds):
-    '''For the metrics in performance_bounds, normalize the metrics in eval_metrics
-    using the performance bounds.'''
+    """For the metrics in performance_bounds, normalize the metrics in eval_metrics
+    using the performance bounds."""
     for k, v in performance_bounds.items():
         lower, upper = v[0], v[1]
         metrics[k] = (metrics[k] - lower) / (upper - lower)
     return metrics
 
 
-def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params,
-                          heldout_agent_list, heldout_agent_names=None, ego_test_mode=False,
-                          num_ego_axes=1):
-    '''Evaluate all ego agents against all heldout partners.
+def eval_egos_vs_heldouts(
+    config,
+    env,
+    rng,
+    num_episodes,
+    ego_policy,
+    ego_params,
+    heldout_agent_list,
+    heldout_agent_names=None,
+    ego_test_mode=False,
+    num_ego_axes=1,
+):
+    """Evaluate all ego agents against all heldout partners.
     Ego_params must be a pytree with num_ego_axes leading ego axes: (num_ego_agents, ...)
     for num_ego_axes=1, or (num_seeds, num_oel_iters, ...) for num_ego_axes=2.
     Returns a pytree of shape (*ego_axes, num_partners, num_episodes, num_agents_per_env).
-    '''
+    """
     num_agents = env.num_agents
     assert num_agents == 2, "This eval code assumes exactly 2 agents."
     assert num_ego_axes in (1, 2), "Only 1 or 2 leading ego axes are supported."
@@ -156,19 +182,29 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
     ego_axis_sizes = jax.tree.leaves(ego_params)[0].shape[:num_ego_axes]
     # We vmap over the first ego axis and loop over the second (if present): vmapping
     # over both OOMs for long runs.
-    num_vmapped_egos = ego_axis_sizes[0]
     tot_ego_agents = int(np.prod(ego_axis_sizes))
     num_partner_total = len(heldout_agent_list)
 
-    def _eval_ego_vs_one_partner(single_ego_params, rng_for_ego, heldout_params,
-                                     single_ego_policy, heldout_policy, heldout_test_mode):
-        return run_episodes(rng_for_ego, env,
-                            agent_0_policy=single_ego_policy, agent_0_param=single_ego_params,
-                            agent_1_policy=heldout_policy, agent_1_param=heldout_params,
-                            max_episode_steps=config["global_heldout_settings"]["MAX_EPISODE_STEPS"],
-                            num_eps=num_episodes,
-                            agent_0_test_mode=ego_test_mode,
-                            agent_1_test_mode=heldout_test_mode)
+    def _eval_ego_vs_one_partner(
+        single_ego_params,
+        rng_for_ego,
+        heldout_params,
+        single_ego_policy,
+        heldout_policy,
+        heldout_test_mode,
+    ):
+        return run_episodes(
+            rng_for_ego,
+            env,
+            agent_0_policy=single_ego_policy,
+            agent_0_param=single_ego_params,
+            agent_1_policy=heldout_policy,
+            agent_1_param=heldout_params,
+            max_episode_steps=config["global_heldout_settings"]["MAX_EPISODE_STEPS"],
+            num_eps=num_episodes,
+            agent_0_test_mode=ego_test_mode,
+            agent_1_test_mode=heldout_test_mode,
+        )
 
     # Outer Python loop over heterogeneous heldout partners
     all_metrics_for_partners = []
@@ -182,41 +218,63 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
     compiled_per_policy = {}
 
     for partner_idx in range(num_partner_total):
-        heldout_policy, heldout_params, heldout_test_mode, heldout_performance_bounds = heldout_agent_list[partner_idx]
+        (
+            heldout_policy,
+            heldout_params,
+            heldout_test_mode,
+            heldout_performance_bounds,
+        ) = heldout_agent_list[partner_idx]
         ego_rngs = jax.random.split(partner_rngs[partner_idx], tot_ego_agents)
         ego_rngs = ego_rngs.reshape(ego_axis_sizes + ego_rngs.shape[1:])
 
         policy_key = (id(heldout_policy), heldout_test_mode)
         if policy_key not in compiled_per_policy:
             # Use partial to fix the policies for the function being vmapped
-            func_to_vmap = partial(_eval_ego_vs_one_partner,
-                                   single_ego_policy=ego_policy,
-                                   heldout_policy=heldout_policy,
-                                   heldout_test_mode=heldout_test_mode)
+            func_to_vmap = partial(
+                _eval_ego_vs_one_partner,
+                single_ego_policy=ego_policy,
+                heldout_policy=heldout_policy,
+                heldout_test_mode=heldout_test_mode,
+            )
             # Map over ego agents and their RNGs; heldout params are an argument.
             compiled_per_policy[policy_key] = jax.jit(
-                jax.vmap(func_to_vmap, in_axes=(0, 0, None)))
+                jax.vmap(func_to_vmap, in_axes=(0, 0, None))
+            )
         vmap_over_egos = compiled_per_policy[policy_key]
 
         if num_ego_axes == 1:
-            results_for_this_partner = vmap_over_egos(ego_params, ego_rngs, heldout_params)
+            results_for_this_partner = vmap_over_egos(
+                ego_params, ego_rngs, heldout_params
+            )
         else:
             per_iter_results = []
             for iter_idx in range(ego_axis_sizes[1]):
-                iter_params = jax.tree.map(lambda x: x[:, iter_idx], ego_params)
+                iter_params = jax.tree.map(
+                    lambda x, iter_idx=iter_idx: x[:, iter_idx], ego_params
+                )
                 per_iter_results.append(
-                    vmap_over_egos(iter_params, ego_rngs[:, iter_idx], heldout_params))
+                    vmap_over_egos(iter_params, ego_rngs[:, iter_idx], heldout_params)
+                )
             # (num_oel_iters, num_seeds, ...) -> (num_seeds, num_oel_iters, ...)
             results_for_this_partner = jax.tree.map(
-                lambda x: x.swapaxes(0, 1), tree_stack(per_iter_results))
+                lambda x: x.swapaxes(0, 1), tree_stack(per_iter_results)
+            )
 
         # results_for_this_partner shape: (*ego_axes, num_episodes, ...)
         if config["global_heldout_settings"]["NORMALIZE_RETURNS"]:
             if heldout_performance_bounds is not None:
-                results_for_this_partner = normalize_metrics(results_for_this_partner, heldout_performance_bounds)
+                results_for_this_partner = normalize_metrics(
+                    results_for_this_partner, heldout_performance_bounds
+                )
             else:
-                agent_name = heldout_agent_names[partner_idx] if heldout_agent_names is not None else f"partner_{partner_idx}"
-                print(f"Warning: no performance bounds provided for {agent_name}. Skipping normalization.")
+                agent_name = (
+                    heldout_agent_names[partner_idx]
+                    if heldout_agent_names is not None
+                    else f"partner_{partner_idx}"
+                )
+                print(
+                    f"Warning: no performance bounds provided for {agent_name}. Skipping normalization."
+                )
         all_metrics_for_partners.append(results_for_this_partner)
 
     end_time = time.time()
@@ -224,40 +282,61 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
 
     # (num_partners, *ego_axes, ...) -> (*ego_axes, num_partners, ...)
     final_metrics = tree_stack(all_metrics_for_partners)
-    final_metrics = jax.tree.map(lambda x: jnp.moveaxis(x, 0, num_ego_axes), final_metrics)
+    final_metrics = jax.tree.map(
+        lambda x: jnp.moveaxis(x, 0, num_ego_axes), final_metrics
+    )
 
     return final_metrics
 
-def print_metrics_table(eval_metrics, metric_name, ego_names, heldout_names,
-                        aggregate_stat: str, normalized_metrics: bool,
-                        save: bool = False, save_heatmap: bool = False):
-    '''Generate a table of the aggregate stat and CI of the metric for each ego agent and heldout agent.'''
+
+def print_metrics_table(
+    eval_metrics,
+    metric_name,
+    ego_names,
+    heldout_names,
+    aggregate_stat: str,
+    normalized_metrics: bool,
+    save: bool = False,
+    save_heatmap: bool = False,
+):
+    """Generate a table of the aggregate stat and CI of the metric for each ego agent and heldout agent."""
     # eval_metrics[metric_name] shape (num_ego_agents, num_heldout_agents, num_eval_episodes, num_agents_per_env)
     # we first take the mean over the num_agents_per_env dimension
-    eval_metric_data = np.array(eval_metrics[metric_name]).mean(axis=-1) # shape (num_ego_agents, num_heldout_agents, num_eval_episodes, 2)
+    eval_metric_data = np.array(eval_metrics[metric_name]).mean(
+        axis=-1
+    )  # shape (num_ego_agents, num_heldout_agents, num_eval_episodes, 2)
     table = PrettyTable()
     table.field_names = ["---", *heldout_names]
     tidy_rows = []
 
     for i, ego_name in enumerate(ego_names):
-        data = eval_metric_data[i].transpose(1, 0) # shape (num_eval_episodes, num_heldout_agents)
-        point_est_all, interval_ests_all = compute_aggregate_stat_and_ci_per_task(data, aggregate_stat, return_interval_est=True)
+        data = eval_metric_data[i].transpose(
+            1, 0
+        )  # shape (num_eval_episodes, num_heldout_agents)
+        point_est_all, interval_ests_all = compute_aggregate_stat_and_ci_per_task(
+            data, aggregate_stat, return_interval_est=True
+        )
         lower_ci = interval_ests_all[:, 0]
         upper_ci = interval_ests_all[:, 1]
-        row = [ego_name] + [f"{point_est_all[j]:.2f} ({lower_ci[j]:.2f}, {upper_ci[j]:.2f})" for j in range(len(heldout_names))]
+        row = [ego_name] + [
+            f"{point_est_all[j]:.2f} ({lower_ci[j]:.2f}, {upper_ci[j]:.2f})"
+            for j in range(len(heldout_names))
+        ]
         table.add_row(row)
         for j, heldout_name in enumerate(heldout_names):
-            tidy_rows.append({
-                "row_agent": ego_name,
-                "col_agent": heldout_name,
-                "metric_name": metric_name,
-                "aggregate_stat": aggregate_stat,
-                "normalized": normalized_metrics,
-                "mean": float(point_est_all[j]),
-                "ci_lower": float(lower_ci[j]),
-                "ci_upper": float(upper_ci[j]),
-            })
-    
+            tidy_rows.append(
+                {
+                    "row_agent": ego_name,
+                    "col_agent": heldout_name,
+                    "metric_name": metric_name,
+                    "aggregate_stat": aggregate_stat,
+                    "normalized": normalized_metrics,
+                    "mean": float(point_est_all[j]),
+                    "ci_lower": float(lower_ci[j]),
+                    "ci_upper": float(upper_ci[j]),
+                }
+            )
+
     print(f"\n{metric_name} ({aggregate_stat} ± CI):")
     if normalized_metrics:
         print("Metrics are normalized to [lower_bound, upper_bound].")
@@ -267,18 +346,25 @@ def print_metrics_table(eval_metrics, metric_name, ego_names, heldout_names,
         output_dir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
         # if not os.path.exists(output_dir):
         #     os.makedirs(output_dir)
-        
+
         # Sanitize metric_name for use in filename
         safe_metric_name = "".join(c if c.isalnum() else "_" for c in metric_name)
-        
-        csv_filename = os.path.join(output_dir, f"{safe_metric_name}_{aggregate_stat}_normalized={normalized_metrics}.csv")
-        with open(csv_filename, 'w', newline='') as f_output:
+
+        csv_filename = os.path.join(
+            output_dir,
+            f"{safe_metric_name}_{aggregate_stat}_normalized={normalized_metrics}.csv",
+        )
+        with open(csv_filename, "w", newline="") as f_output:
             f_output.write(table.get_csv_string())
         print(f"Table saved to {csv_filename}")
 
-        tidy_csv_filename = os.path.join(output_dir, f"{safe_metric_name}_{aggregate_stat}_normalized={normalized_metrics}_tidy.csv")
+        tidy_csv_filename = os.path.join(
+            output_dir,
+            f"{safe_metric_name}_{aggregate_stat}_normalized={normalized_metrics}_tidy.csv",
+        )
         import csv
-        with open(tidy_csv_filename, 'w', newline='') as tidy_file:
+
+        with open(tidy_csv_filename, "w", newline="") as tidy_file:
             writer = csv.DictWriter(
                 tidy_file,
                 fieldnames=[
@@ -299,10 +385,13 @@ def print_metrics_table(eval_metrics, metric_name, ego_names, heldout_names,
         if save_heatmap:
             try:
                 from pathlib import Path
+
                 from evaluation.plot_xp_csv_heatmap import generate_heatmap_from_csv
 
                 heatmap_title = f"XP Matrix: {metric_name} ({aggregate_stat})"
-                png_path = generate_heatmap_from_csv(Path(csv_filename), title=heatmap_title)
+                png_path = generate_heatmap_from_csv(
+                    Path(csv_filename), title=heatmap_title
+                )
                 print(f"Heatmap saved to {png_path}")
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 - heatmap rendering is best-effort
                 print(f"Warning: failed to generate heatmap for {csv_filename}: {exc}")

--- a/evaluation/heldout_core.py
+++ b/evaluation/heldout_core.py
@@ -2,6 +2,7 @@
 Warning: ActorCritic agents that rely on auxiliary information to compute actions are not currently supported.
 '''
 import jax
+import jax.numpy as jnp
 import numpy as np
 from prettytable import PrettyTable
 from functools import partial
@@ -141,14 +142,22 @@ def normalize_metrics(metrics, performance_bounds):
 
 
 def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params,
-                          heldout_agent_list, heldout_agent_names=None, ego_test_mode=False):
-    '''Evaluate all ego agents against all heldout partners using vmap over egos.
-    Ego_params must be a pytree of shape (num_ego_agents, ...)
+                          heldout_agent_list, heldout_agent_names=None, ego_test_mode=False,
+                          num_ego_axes=1):
+    '''Evaluate all ego agents against all heldout partners.
+    Ego_params must be a pytree with num_ego_axes leading ego axes: (num_ego_agents, ...)
+    for num_ego_axes=1, or (num_seeds, num_oel_iters, ...) for num_ego_axes=2.
+    Returns a pytree of shape (*ego_axes, num_partners, num_episodes, num_agents_per_env).
     '''
     num_agents = env.num_agents
     assert num_agents == 2, "This eval code assumes exactly 2 agents."
+    assert num_ego_axes in (1, 2), "Only 1 or 2 leading ego axes are supported."
 
-    num_ego_agents = jax.tree.leaves(ego_params)[0].shape[0]
+    ego_axis_sizes = jax.tree.leaves(ego_params)[0].shape[:num_ego_axes]
+    # We vmap over the first ego axis and loop over the second (if present): vmapping
+    # over both OOMs for long runs.
+    num_vmapped_egos = ego_axis_sizes[0]
+    tot_ego_agents = int(np.prod(ego_axis_sizes))
     num_partner_total = len(heldout_agent_list)
 
     def _eval_ego_vs_one_partner(single_ego_params, rng_for_ego, heldout_params,
@@ -157,21 +166,25 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
                             agent_0_policy=single_ego_policy, agent_0_param=single_ego_params,
                             agent_1_policy=heldout_policy, agent_1_param=heldout_params,
                             max_episode_steps=config["global_heldout_settings"]["MAX_EPISODE_STEPS"],
-                            num_eps=num_episodes, 
+                            num_eps=num_episodes,
                             agent_0_test_mode=ego_test_mode,
                             agent_1_test_mode=heldout_test_mode)
 
     # Outer Python loop over heterogeneous heldout partners
     all_metrics_for_partners = []
-    rng, sub_rng = jax.random.split(rng)
-    partner_rngs = jax.random.split(sub_rng, num_partner_total)
+    if num_ego_axes == 1:
+        # Preserves the RNG stream this path has always used, so 1d eval numbers stay
+        # comparable with previously published runs.
+        _, rng = jax.random.split(rng)
+    partner_rngs = jax.random.split(rng, num_partner_total)
     start_time = time.time()
     # Compilation dominates this loop, so cache one compiled fn per heldout policy.
     compiled_per_policy = {}
 
     for partner_idx in range(num_partner_total):
         heldout_policy, heldout_params, heldout_test_mode, heldout_performance_bounds = heldout_agent_list[partner_idx]
-        ego_rngs = jax.random.split(partner_rngs[partner_idx], num_ego_agents)
+        ego_rngs = jax.random.split(partner_rngs[partner_idx], tot_ego_agents)
+        ego_rngs = ego_rngs.reshape(ego_axis_sizes + ego_rngs.shape[1:])
 
         policy_key = (id(heldout_policy), heldout_test_mode)
         if policy_key not in compiled_per_policy:
@@ -183,11 +196,21 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
             # Map over ego agents and their RNGs; heldout params are an argument.
             compiled_per_policy[policy_key] = jax.jit(
                 jax.vmap(func_to_vmap, in_axes=(0, 0, None)))
+        vmap_over_egos = compiled_per_policy[policy_key]
 
-        results_for_this_partner = compiled_per_policy[policy_key](
-            ego_params, ego_rngs, heldout_params)
+        if num_ego_axes == 1:
+            results_for_this_partner = vmap_over_egos(ego_params, ego_rngs, heldout_params)
+        else:
+            per_iter_results = []
+            for iter_idx in range(ego_axis_sizes[1]):
+                iter_params = jax.tree.map(lambda x: x[:, iter_idx], ego_params)
+                per_iter_results.append(
+                    vmap_over_egos(iter_params, ego_rngs[:, iter_idx], heldout_params))
+            # (num_oel_iters, num_seeds, ...) -> (num_seeds, num_oel_iters, ...)
+            results_for_this_partner = jax.tree.map(
+                lambda x: x.swapaxes(0, 1), tree_stack(per_iter_results))
 
-        # results_for_this_partner shape: (num_ego_agents, num_episodes, ...)
+        # results_for_this_partner shape: (*ego_axes, num_episodes, ...)
         if config["global_heldout_settings"]["NORMALIZE_RETURNS"]:
             if heldout_performance_bounds is not None:
                 results_for_this_partner = normalize_metrics(results_for_this_partner, heldout_performance_bounds)
@@ -199,51 +222,11 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
     end_time = time.time()
     print(f"Time taken for vmap evaluation loop: {end_time - start_time:.2f} seconds")
 
-    # Result shape: (num_partners, num_egos, num_episodes, ...)
+    # (num_partners, *ego_axes, ...) -> (*ego_axes, num_partners, ...)
     final_metrics = tree_stack(all_metrics_for_partners)
-    # Transpose to (num_egos, num_partners, num_episodes, ...)
-    final_metrics = jax.tree.map(lambda x: x.transpose(1, 0, 2, 3), final_metrics)
+    final_metrics = jax.tree.map(lambda x: jnp.moveaxis(x, 0, num_ego_axes), final_metrics)
 
     return final_metrics
-
-def run_heldout_evaluation(config, print_metrics=False):
-    '''Run heldout evaluation'''
-    # Create only one environment instance
-    env = make_env(config["ENV_NAME"], config["ENV_KWARGS"])
-    env = LogWrapper(env)
-    
-    rng = jax.random.PRNGKey(config["global_heldout_settings"]["EVAL_SEED"])
-    rng, ego_init_rng, heldout_init_rng, eval_rng = jax.random.split(rng, 4)
-    
-    # load ego agents
-    ego_agent_config = dict(config["ego_agent"])
-    ego_test_mode = ego_agent_config.get("test_mode", False)
-    ego_policy, ego_params, init_ego_params, ego_idx_labels = initialize_rl_agent_from_config(ego_agent_config, "ego", env, ego_init_rng)
-    # flatten ego params and idx labels
-    ego_idx_labels = np.array(ego_idx_labels).reshape(-1) # flatten the list of ego agent labels 
-    flattened_ego_params = jax.tree.map(lambda x, y: x.reshape((-1,) + y.shape), ego_params, init_ego_params)        
-    
-    # load heldout agents
-    heldout_cfg = config["heldout_set"][config["TASK_NAME"]]
-    heldout_agents = load_heldout_set(heldout_cfg, env, config["TASK_NAME"], config["ENV_KWARGS"], heldout_init_rng)
-    heldout_agent_names = list(heldout_agents.keys())
-    heldout_agent_list = list(heldout_agents.values())
-
-    # run evaluation
-    eval_metrics = eval_egos_vs_heldouts(
-        config, env, eval_rng, config["global_heldout_settings"]["NUM_EVAL_EPISODES"],
-        ego_policy, flattened_ego_params, heldout_agent_list, heldout_agent_names, ego_test_mode)
-
-    if print_metrics:
-        # each leaf of eval_metrics has shape (num_ego_agents, num_heldout_agents, num_eval_episodes, num_agents_per_env)
-        metric_names = get_metric_names(config["ENV_NAME"])
-        aggregate_stat = config["global_heldout_settings"]["AGGREGATE_STAT"]
-        ego_names = [f"ego ({label})" for label in ego_idx_labels]
-        heldout_names = list(heldout_agents.keys())
-        for metric_name in metric_names:
-            print_metrics_table(eval_metrics, metric_name, ego_names, heldout_names, 
-                aggregate_stat, config["global_heldout_settings"]["NORMALIZE_RETURNS"])
-    return eval_metrics
 
 def print_metrics_table(eval_metrics, metric_name, ego_names, heldout_names,
                         aggregate_stat: str, normalized_metrics: bool,

--- a/evaluation/heldout_eval.py
+++ b/evaluation/heldout_eval.py
@@ -31,8 +31,8 @@ def eval_2d_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_par
     tot_ego_agents = num_ego_seeds * num_ego_iters
     num_partner_total = len(heldout_agent_list)
 
-    def _eval_ego_vs_one_partner(rng_for_ego, single_ego_params, single_ego_policy,
-                                 heldout_params, heldout_policy, heldout_test_mode):
+    def _eval_ego_vs_one_partner(rng_for_ego, single_ego_params, heldout_params,
+                                 single_ego_policy, heldout_policy, heldout_test_mode):
         return run_episodes(rng_for_ego, env,
                             agent_0_policy=single_ego_policy, agent_0_param=single_ego_params,
                             agent_1_policy=heldout_policy, agent_1_param=heldout_params,
@@ -45,25 +45,32 @@ def eval_2d_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_par
     all_metrics_for_partners = []
     partner_rngs = jax.random.split(rng, num_partner_total)
     start_time = time.time()
+    # One compiled fn per distinct heldout policy: compilation dominates this loop, so
+    # partners sharing a policy (e.g. members of one population) must reuse it.
+    compiled_per_policy = {}
 
     for partner_idx in range(num_partner_total):
         heldout_policy, heldout_params, heldout_test_mode, heldout_performance_bounds = heldout_agent_list[partner_idx]
         ego_rngs = jax.random.split(partner_rngs[partner_idx], tot_ego_agents)
         ego_rngs = ego_rngs.reshape(num_ego_seeds, num_ego_iters, 2)
 
-        # Use partial to fix the heldout agent for the function being vmapped
-        func_to_vmap = partial(_eval_ego_vs_one_partner,
-                               single_ego_policy=ego_policy,
-                               heldout_params=heldout_params,
-                               heldout_policy=heldout_policy,
-                               heldout_test_mode=heldout_test_mode)
+        policy_key = (id(heldout_policy), heldout_test_mode)
+        if policy_key not in compiled_per_policy:
+            # Use partial to fix the policies for the function being vmapped
+            func_to_vmap = partial(_eval_ego_vs_one_partner,
+                                   single_ego_policy=ego_policy,
+                                   heldout_policy=heldout_policy,
+                                   heldout_test_mode=heldout_test_mode)
+            # vmap over seeds only, looping over iters: vmapping over both OOMs for long
+            # runs. Heldout params are an argument (in_axes=None), not a baked-in constant.
+            compiled_per_policy[policy_key] = jax.jit(
+                jax.vmap(func_to_vmap, in_axes=(0, 0, None)))
 
-        # vmap over seeds only, looping over iters: vmapping over both OOMs for long runs.
-        vmap_over_seeds = jax.jit(jax.vmap(func_to_vmap, in_axes=(0, 0)))
+        vmap_over_seeds = compiled_per_policy[policy_key]
         per_iter_results = []
         for iter_idx in range(num_ego_iters):
             iter_params = jax.tree.map(lambda x: x[:, iter_idx], ego_params)
-            per_iter_results.append(vmap_over_seeds(ego_rngs[:, iter_idx], iter_params))
+            per_iter_results.append(vmap_over_seeds(ego_rngs[:, iter_idx], iter_params, heldout_params))
         # (num_oel_iters, num_seeds, ...) -> (num_seeds, num_oel_iters, ...)
         results_for_this_partner = jax.tree.map(
             lambda x: x.swapaxes(0, 1), tree_stack(per_iter_results))

--- a/evaluation/heldout_eval.py
+++ b/evaluation/heldout_eval.py
@@ -45,8 +45,7 @@ def eval_2d_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_par
     all_metrics_for_partners = []
     partner_rngs = jax.random.split(rng, num_partner_total)
     start_time = time.time()
-    # One compiled fn per distinct heldout policy: compilation dominates this loop, so
-    # partners sharing a policy (e.g. members of one population) must reuse it.
+    # Compilation dominates this loop, so cache one compiled fn per heldout policy.
     compiled_per_policy = {}
 
     for partner_idx in range(num_partner_total):
@@ -61,8 +60,7 @@ def eval_2d_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_par
                                    single_ego_policy=ego_policy,
                                    heldout_policy=heldout_policy,
                                    heldout_test_mode=heldout_test_mode)
-            # vmap over seeds only, looping over iters: vmapping over both OOMs for long
-            # runs. Heldout params are an argument (in_axes=None), not a baked-in constant.
+            # vmap over seeds only, looping over iters: vmapping over both OOMs for long runs.
             compiled_per_policy[policy_key] = jax.jit(
                 jax.vmap(func_to_vmap, in_axes=(0, 0, None)))
 

--- a/evaluation/heldout_evaluator.py
+++ b/evaluation/heldout_evaluator.py
@@ -2,6 +2,7 @@
 Warning: ActorCritic agents that rely on auxiliary information to compute actions are not currently supported.
 '''
 import jax
+import jax.numpy as jnp
 import numpy as np
 from prettytable import PrettyTable
 from functools import partial
@@ -150,6 +151,8 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
 
     num_ego_agents = jax.tree.leaves(ego_params)[0].shape[0]
     num_partner_total = len(heldout_agent_list)
+    # vmapping over all egos at once can OOM, so vmap over chunks of egos
+    ego_chunk_size = min(config["global_heldout_settings"].get("EGO_CHUNK_SIZE", 8), num_ego_agents)
 
     def _eval_ego_vs_one_partner(single_ego_policy, single_ego_params, rng_for_ego,
                                      heldout_policy, heldout_params, heldout_test_mode):
@@ -177,11 +180,18 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
                                heldout_params=heldout_params,
                                heldout_test_mode=heldout_test_mode)
 
-        # vmap over the stacked ego agents and their RNGs
-        results_for_this_partner = jax.vmap(
+        vmap_over_egos = jax.jit(jax.vmap(
             func_to_vmap,
-            in_axes=(None, 0, 0) # Map over axis 0 of ego_policies, ego_params, ego_rngs
-        )(ego_policy, ego_params, ego_rngs)
+            in_axes=(None, 0, 0) # Map over axis 0 of ego_params, ego_rngs
+        ))
+        per_chunk_results = []
+        for chunk_start in range(0, num_ego_agents, ego_chunk_size):
+            chunk_end = min(chunk_start + ego_chunk_size, num_ego_agents)
+            chunk_params = jax.tree.map(lambda x: x[chunk_start:chunk_end], ego_params)
+            per_chunk_results.append(
+                vmap_over_egos(ego_policy, chunk_params, ego_rngs[chunk_start:chunk_end]))
+        results_for_this_partner = jax.tree.map(
+            lambda *xs: jnp.concatenate(xs, axis=0), *per_chunk_results)
 
         # results_for_this_partner shape: (num_ego_agents, num_episodes, ...)
         if config["global_heldout_settings"]["NORMALIZE_RETURNS"]:

--- a/evaluation/heldout_evaluator.py
+++ b/evaluation/heldout_evaluator.py
@@ -2,7 +2,6 @@
 Warning: ActorCritic agents that rely on auxiliary information to compute actions are not currently supported.
 '''
 import jax
-import jax.numpy as jnp
 import numpy as np
 from prettytable import PrettyTable
 from functools import partial
@@ -151,8 +150,6 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
 
     num_ego_agents = jax.tree.leaves(ego_params)[0].shape[0]
     num_partner_total = len(heldout_agent_list)
-    # vmapping over all egos at once can OOM, so vmap over chunks of egos
-    ego_chunk_size = min(config["global_heldout_settings"].get("EGO_CHUNK_SIZE", 8), num_ego_agents)
 
     def _eval_ego_vs_one_partner(single_ego_policy, single_ego_params, rng_for_ego,
                                      heldout_policy, heldout_params, heldout_test_mode):
@@ -180,18 +177,11 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
                                heldout_params=heldout_params,
                                heldout_test_mode=heldout_test_mode)
 
-        vmap_over_egos = jax.jit(jax.vmap(
+        # vmap over the stacked ego agents and their RNGs
+        results_for_this_partner = jax.vmap(
             func_to_vmap,
-            in_axes=(None, 0, 0) # Map over axis 0 of ego_params, ego_rngs
-        ))
-        per_chunk_results = []
-        for chunk_start in range(0, num_ego_agents, ego_chunk_size):
-            chunk_end = min(chunk_start + ego_chunk_size, num_ego_agents)
-            chunk_params = jax.tree.map(lambda x: x[chunk_start:chunk_end], ego_params)
-            per_chunk_results.append(
-                vmap_over_egos(ego_policy, chunk_params, ego_rngs[chunk_start:chunk_end]))
-        results_for_this_partner = jax.tree.map(
-            lambda *xs: jnp.concatenate(xs, axis=0), *per_chunk_results)
+            in_axes=(None, 0, 0) # Map over axis 0 of ego_policies, ego_params, ego_rngs
+        )(ego_policy, ego_params, ego_rngs)
 
         # results_for_this_partner shape: (num_ego_agents, num_episodes, ...)
         if config["global_heldout_settings"]["NORMALIZE_RETURNS"]:

--- a/evaluation/heldout_evaluator.py
+++ b/evaluation/heldout_evaluator.py
@@ -151,8 +151,8 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
     num_ego_agents = jax.tree.leaves(ego_params)[0].shape[0]
     num_partner_total = len(heldout_agent_list)
 
-    def _eval_ego_vs_one_partner(single_ego_policy, single_ego_params, rng_for_ego,
-                                     heldout_policy, heldout_params, heldout_test_mode):
+    def _eval_ego_vs_one_partner(single_ego_params, rng_for_ego, heldout_params,
+                                     single_ego_policy, heldout_policy, heldout_test_mode):
         return run_episodes(rng_for_ego, env,
                             agent_0_policy=single_ego_policy, agent_0_param=single_ego_params,
                             agent_1_policy=heldout_policy, agent_1_param=heldout_params,
@@ -166,22 +166,28 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
     rng, sub_rng = jax.random.split(rng)
     partner_rngs = jax.random.split(sub_rng, num_partner_total)
     start_time = time.time()
+    # One compiled fn per distinct heldout policy: compilation dominates this loop, so
+    # partners sharing a policy (e.g. members of one population) must reuse it.
+    compiled_per_policy = {}
 
     for partner_idx in range(num_partner_total):
         heldout_policy, heldout_params, heldout_test_mode, heldout_performance_bounds = heldout_agent_list[partner_idx]
         ego_rngs = jax.random.split(partner_rngs[partner_idx], num_ego_agents)
 
-        # Use partial to fix the heldout agent for the function being vmapped
-        func_to_vmap = partial(_eval_ego_vs_one_partner,
-                               heldout_policy=heldout_policy,
-                               heldout_params=heldout_params,
-                               heldout_test_mode=heldout_test_mode)
+        policy_key = (id(heldout_policy), heldout_test_mode)
+        if policy_key not in compiled_per_policy:
+            # Use partial to fix the policies for the function being vmapped
+            func_to_vmap = partial(_eval_ego_vs_one_partner,
+                                   single_ego_policy=ego_policy,
+                                   heldout_policy=heldout_policy,
+                                   heldout_test_mode=heldout_test_mode)
+            # vmap over the stacked ego agents and their RNGs; heldout params are an
+            # argument (in_axes=None) rather than a baked-in constant.
+            compiled_per_policy[policy_key] = jax.jit(
+                jax.vmap(func_to_vmap, in_axes=(0, 0, None)))
 
-        # vmap over the stacked ego agents and their RNGs
-        results_for_this_partner = jax.vmap(
-            func_to_vmap,
-            in_axes=(None, 0, 0) # Map over axis 0 of ego_policies, ego_params, ego_rngs
-        )(ego_policy, ego_params, ego_rngs)
+        results_for_this_partner = compiled_per_policy[policy_key](
+            ego_params, ego_rngs, heldout_params)
 
         # results_for_this_partner shape: (num_ego_agents, num_episodes, ...)
         if config["global_heldout_settings"]["NORMALIZE_RETURNS"]:

--- a/evaluation/heldout_evaluator.py
+++ b/evaluation/heldout_evaluator.py
@@ -166,8 +166,7 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
     rng, sub_rng = jax.random.split(rng)
     partner_rngs = jax.random.split(sub_rng, num_partner_total)
     start_time = time.time()
-    # One compiled fn per distinct heldout policy: compilation dominates this loop, so
-    # partners sharing a policy (e.g. members of one population) must reuse it.
+    # Compilation dominates this loop, so cache one compiled fn per heldout policy.
     compiled_per_policy = {}
 
     for partner_idx in range(num_partner_total):
@@ -181,8 +180,7 @@ def eval_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params
                                    single_ego_policy=ego_policy,
                                    heldout_policy=heldout_policy,
                                    heldout_test_mode=heldout_test_mode)
-            # vmap over the stacked ego agents and their RNGs; heldout params are an
-            # argument (in_axes=None) rather than a baked-in constant.
+            # Map over ego agents and their RNGs; heldout params are an argument.
             compiled_per_policy[policy_key] = jax.jit(
                 jax.vmap(func_to_vmap, in_axes=(0, 0, None)))
 

--- a/evaluation/heldout_runner.py
+++ b/evaluation/heldout_runner.py
@@ -1,93 +1,31 @@
-''''Implementation of heldout evaluation helper functions used by learners.'''
+'''Entry points for heldout evaluation, plus metric logging/reporting.
+
+Two entry points, differing in where the ego agent comes from:
+  - run_heldout_evaluation: ego policy/params passed in by a learner.
+  - run_heldout_evaluation_from_config: ego agent loaded from config["ego_agent"].
+The evaluation itself lives in evaluation/heldout_core.py.
+'''
 import logging
-import time
-from functools import partial
 import shutil
 
 import jax
 import numpy as np
 import hydra
 
+from common.agent_loader_from_config import initialize_rl_agent_from_config
+from common.plot_utils import get_metric_names
 from common.save_load_utils import save_train_run
-from common.run_episodes import run_episodes
-from common.tree_utils import tree_stack
 from common.stat_utils import compute_aggregate_stat_and_ci, compute_aggregate_stat_and_ci_per_task, get_aggregate_stat_fn
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from evaluation.heldout_evaluator import load_heldout_set, normalize_metrics, eval_egos_vs_heldouts as eval_1d_egos_vs_heldouts
+from evaluation.heldout_core import (
+    load_heldout_set,
+    eval_egos_vs_heldouts,
+    print_metrics_table,
+)
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
-
-def eval_2d_egos_vs_heldouts(config, env, rng, num_episodes, ego_policy, ego_params,
-                          heldout_agent_list, ego_test_mode=False):
-    '''Evaluate all ego agents against all heldout partners using vmap over egos.
-    Ego_params must be a pytree of shape (num_seeds, num_oel_iters, ...)
-    '''
-    num_agents = env.num_agents
-    assert num_agents == 2, "This eval code assumes exactly 2 agents."
-
-    num_ego_seeds, num_ego_iters = jax.tree.leaves(ego_params)[0].shape[:2]
-    tot_ego_agents = num_ego_seeds * num_ego_iters
-    num_partner_total = len(heldout_agent_list)
-
-    def _eval_ego_vs_one_partner(rng_for_ego, single_ego_params, heldout_params,
-                                 single_ego_policy, heldout_policy, heldout_test_mode):
-        return run_episodes(rng_for_ego, env,
-                            agent_0_policy=single_ego_policy, agent_0_param=single_ego_params,
-                            agent_1_policy=heldout_policy, agent_1_param=heldout_params,
-                            max_episode_steps=config["global_heldout_settings"]["MAX_EPISODE_STEPS"],
-                            num_eps=num_episodes,
-                            agent_0_test_mode=ego_test_mode,
-                            agent_1_test_mode=heldout_test_mode)
-
-    # Outer Python loop over heterogeneous heldout partners
-    all_metrics_for_partners = []
-    partner_rngs = jax.random.split(rng, num_partner_total)
-    start_time = time.time()
-    # Compilation dominates this loop, so cache one compiled fn per heldout policy.
-    compiled_per_policy = {}
-
-    for partner_idx in range(num_partner_total):
-        heldout_policy, heldout_params, heldout_test_mode, heldout_performance_bounds = heldout_agent_list[partner_idx]
-        ego_rngs = jax.random.split(partner_rngs[partner_idx], tot_ego_agents)
-        ego_rngs = ego_rngs.reshape(num_ego_seeds, num_ego_iters, 2)
-
-        policy_key = (id(heldout_policy), heldout_test_mode)
-        if policy_key not in compiled_per_policy:
-            # Use partial to fix the policies for the function being vmapped
-            func_to_vmap = partial(_eval_ego_vs_one_partner,
-                                   single_ego_policy=ego_policy,
-                                   heldout_policy=heldout_policy,
-                                   heldout_test_mode=heldout_test_mode)
-            # vmap over seeds only, looping over iters: vmapping over both OOMs for long runs.
-            compiled_per_policy[policy_key] = jax.jit(
-                jax.vmap(func_to_vmap, in_axes=(0, 0, None)))
-
-        vmap_over_seeds = compiled_per_policy[policy_key]
-        per_iter_results = []
-        for iter_idx in range(num_ego_iters):
-            iter_params = jax.tree.map(lambda x: x[:, iter_idx], ego_params)
-            per_iter_results.append(vmap_over_seeds(ego_rngs[:, iter_idx], iter_params, heldout_params))
-        # (num_oel_iters, num_seeds, ...) -> (num_seeds, num_oel_iters, ...)
-        results_for_this_partner = jax.tree.map(
-            lambda x: x.swapaxes(0, 1), tree_stack(per_iter_results))
-        # results_for_this_partner shape: (num_seeds, num_oel_iters, num_episodes, ...)
-        if config["global_heldout_settings"]["NORMALIZE_RETURNS"]:
-            if heldout_performance_bounds is not None:
-                results_for_this_partner = normalize_metrics(results_for_this_partner, heldout_performance_bounds)
-            else:
-                print(f"Warning: no performance bounds provided for {heldout_agent_list[partner_idx]}. Skipping normalization.")
-        all_metrics_for_partners.append(results_for_this_partner)
-
-    end_time = time.time()
-    print(f"Time taken for vmap evaluation loop: {end_time - start_time:.2f} seconds")
-
-    # Result shape: (num_partners, num_seeds, num_oel_iters, num_episodes, ...)
-    final_metrics = tree_stack(all_metrics_for_partners)
-    # Transpose to (num_seeds, num_oel_iters, num_partners, num_episodes, ...)
-    final_metrics = jax.tree.map(lambda x: x.transpose(1, 2, 0, 3, 4), final_metrics)
-    return final_metrics
 
 def run_heldout_evaluation(config, ego_policy, ego_params, init_ego_params,
                            ego_as_2d: bool, ego_test_mode=False):
@@ -124,12 +62,10 @@ def run_heldout_evaluation(config, ego_policy, ego_params, init_ego_params,
     heldout_names = list(heldout_agents.keys())
 
     # run evaluation
-    if ego_as_2d:
-        eval_metrics = eval_2d_egos_vs_heldouts(config, env, eval_rng, config["global_heldout_settings"]["NUM_EVAL_EPISODES"],
-                                            ego_policy, ego_params, heldout_agent_list, ego_test_mode)
-    else:
-        eval_metrics = eval_1d_egos_vs_heldouts(config, env, eval_rng, config["global_heldout_settings"]["NUM_EVAL_EPISODES"],
-                                            ego_policy, ego_params, heldout_agent_list, ego_test_mode)
+    eval_metrics = eval_egos_vs_heldouts(
+        config, env, eval_rng, config["global_heldout_settings"]["NUM_EVAL_EPISODES"],
+        ego_policy, ego_params, heldout_agent_list, heldout_names,
+        ego_test_mode, num_ego_axes=2 if ego_as_2d else 1)
 
     return eval_metrics, ego_names, heldout_names
 
@@ -243,3 +179,42 @@ def heldout_metrics_2d(config, logger, eval_metrics,
         col_strs.insert(0, f"{point_est_all:.3f} ({lower_ci:.3f}, {upper_ci:.3f})")
         table_data.append(col_strs)
     return np.array(table_data)
+
+def run_heldout_evaluation_from_config(config, print_metrics=False):
+    '''Run heldout evaluation, loading the ego agent from config["ego_agent"].'''
+    # Create only one environment instance
+    env = make_env(config["ENV_NAME"], config["ENV_KWARGS"])
+    env = LogWrapper(env)
+    
+    rng = jax.random.PRNGKey(config["global_heldout_settings"]["EVAL_SEED"])
+    rng, ego_init_rng, heldout_init_rng, eval_rng = jax.random.split(rng, 4)
+    
+    # load ego agents
+    ego_agent_config = dict(config["ego_agent"])
+    ego_test_mode = ego_agent_config.get("test_mode", False)
+    ego_policy, ego_params, init_ego_params, ego_idx_labels = initialize_rl_agent_from_config(ego_agent_config, "ego", env, ego_init_rng)
+    # flatten ego params and idx labels
+    ego_idx_labels = np.array(ego_idx_labels).reshape(-1) # flatten the list of ego agent labels 
+    flattened_ego_params = jax.tree.map(lambda x, y: x.reshape((-1,) + y.shape), ego_params, init_ego_params)        
+    
+    # load heldout agents
+    heldout_cfg = config["heldout_set"][config["TASK_NAME"]]
+    heldout_agents = load_heldout_set(heldout_cfg, env, config["TASK_NAME"], config["ENV_KWARGS"], heldout_init_rng)
+    heldout_agent_names = list(heldout_agents.keys())
+    heldout_agent_list = list(heldout_agents.values())
+
+    # run evaluation
+    eval_metrics = eval_egos_vs_heldouts(
+        config, env, eval_rng, config["global_heldout_settings"]["NUM_EVAL_EPISODES"],
+        ego_policy, flattened_ego_params, heldout_agent_list, heldout_agent_names, ego_test_mode)
+
+    if print_metrics:
+        # each leaf of eval_metrics has shape (num_ego_agents, num_heldout_agents, num_eval_episodes, num_agents_per_env)
+        metric_names = get_metric_names(config["ENV_NAME"])
+        aggregate_stat = config["global_heldout_settings"]["AGGREGATE_STAT"]
+        ego_names = [f"ego ({label})" for label in ego_idx_labels]
+        heldout_names = list(heldout_agents.keys())
+        for metric_name in metric_names:
+            print_metrics_table(eval_metrics, metric_name, ego_names, heldout_names, 
+                aggregate_stat, config["global_heldout_settings"]["NORMALIZE_RETURNS"])
+    return eval_metrics

--- a/evaluation/heldout_runner.py
+++ b/evaluation/heldout_runner.py
@@ -1,35 +1,47 @@
-'''Entry points for heldout evaluation, plus metric logging/reporting.
+"""Entry points for heldout evaluation, plus metric logging/reporting.
 
 Two entry points, differing in where the ego agent comes from:
   - run_heldout_evaluation: ego policy/params passed in by a learner.
   - run_heldout_evaluation_from_config: ego agent loaded from config["ego_agent"].
 The evaluation itself lives in evaluation/heldout_core.py.
-'''
+"""
+
 import logging
 import shutil
 
+import hydra
 import jax
 import numpy as np
-import hydra
 
 from common.agent_loader_from_config import initialize_rl_agent_from_config
 from common.plot_utils import get_metric_names
 from common.save_load_utils import save_train_run
-from common.stat_utils import compute_aggregate_stat_and_ci, compute_aggregate_stat_and_ci_per_task, get_aggregate_stat_fn
+from common.stat_utils import (
+    compute_aggregate_stat_and_ci,
+    compute_aggregate_stat_and_ci_per_task,
+    get_aggregate_stat_fn,
+)
 from envs import make_env
 from envs.log_wrapper import LogWrapper
 from evaluation.heldout_core import (
-    load_heldout_set,
     eval_egos_vs_heldouts,
+    load_heldout_set,
     print_metrics_table,
 )
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-def run_heldout_evaluation(config, ego_policy, ego_params, init_ego_params,
-                           ego_as_2d: bool, ego_test_mode=False):
-    '''Run heldout evaluation given an ego policy, ego params, and init_ego_params.
+
+def run_heldout_evaluation(
+    config,
+    ego_policy,
+    ego_params,
+    init_ego_params,
+    ego_as_2d: bool,
+    ego_test_mode=False,
+):
+    """Run heldout evaluation given an ego policy, ego params, and init_ego_params.
     Ego_params can be a pytree of shape (num_seeds, num_oel_iters, ...) or (num_seeds, ...).
     Args:
         config: Configuration dictionary
@@ -38,7 +50,7 @@ def run_heldout_evaluation(config, ego_policy, ego_params, init_ego_params,
         init_ego_params: Initial parameters for the ego agent
         ego_as_2d: Whether to treat the ego agent params as a 2D or 1D array of ego agents
         ego_test_mode: Whether the ego agent should run in test mode (default: False)
-    '''
+    """
     log.info("Running heldout evaluation...")
     env = make_env(config["ENV_NAME"], config["ENV_KWARGS"])
     env = LogWrapper(env)
@@ -48,39 +60,68 @@ def run_heldout_evaluation(config, ego_policy, ego_params, init_ego_params,
 
     if ego_as_2d:
         num_seeds, num_oel_iters = jax.tree.leaves(ego_params)[0].shape[:2]
-        ego_names = [f"ego (seed={i}, iter={j})" for i in range(num_seeds) for j in range(num_oel_iters)]
+        ego_names = [
+            f"ego (seed={i}, iter={j})"
+            for i in range(num_seeds)
+            for j in range(num_oel_iters)
+        ]
     else:
         # flatten ego params
-        ego_params = jax.tree.map(lambda x, y: x.reshape((-1,) + y.shape), ego_params, init_ego_params)
+        ego_params = jax.tree.map(
+            lambda x, y: x.reshape((-1,) + y.shape), ego_params, init_ego_params
+        )
         num_ego_agents = jax.tree.leaves(ego_params)[0].shape[0]
         ego_names = [f"ego ({i})" for i in range(num_ego_agents)]
 
     # load heldout agents
     heldout_cfg = config["heldout_set"][config["TASK_NAME"]]
-    heldout_agents = load_heldout_set(heldout_cfg, env, config["TASK_NAME"], config["ENV_KWARGS"], heldout_init_rng)
+    heldout_agents = load_heldout_set(
+        heldout_cfg, env, config["TASK_NAME"], config["ENV_KWARGS"], heldout_init_rng
+    )
     heldout_agent_list = list(heldout_agents.values())
     heldout_names = list(heldout_agents.keys())
 
     # run evaluation
     eval_metrics = eval_egos_vs_heldouts(
-        config, env, eval_rng, config["global_heldout_settings"]["NUM_EVAL_EPISODES"],
-        ego_policy, ego_params, heldout_agent_list, heldout_names,
-        ego_test_mode, num_ego_axes=2 if ego_as_2d else 1)
+        config,
+        env,
+        eval_rng,
+        config["global_heldout_settings"]["NUM_EVAL_EPISODES"],
+        ego_policy,
+        ego_params,
+        heldout_agent_list,
+        heldout_names,
+        ego_test_mode,
+        num_ego_axes=2 if ego_as_2d else 1,
+    )
 
     return eval_metrics, ego_names, heldout_names
 
-def log_heldout_metrics(config, logger, eval_metrics,
-        ego_names, heldout_names, metric_names: tuple,
-        ego_as_2d: bool):
-    '''Log heldout evaluation metrics.'''
+
+def log_heldout_metrics(
+    config,
+    logger,
+    eval_metrics,
+    ego_names,
+    heldout_names,
+    metric_names: tuple,
+    ego_as_2d: bool,
+):
+    """Log heldout evaluation metrics."""
     if ego_as_2d:
-        table_data = heldout_metrics_2d(config, logger, eval_metrics, ego_names, heldout_names, metric_names)
+        table_data = heldout_metrics_2d(
+            config, logger, eval_metrics, ego_names, heldout_names, metric_names
+        )
     else:
-        table_data = heldout_metrics_1d(config, logger, eval_metrics, ego_names, heldout_names, metric_names)
+        table_data = heldout_metrics_1d(
+            config, logger, eval_metrics, ego_names, heldout_names, metric_names
+        )
 
     # table_data shape (num_metrics, num_heldout_agents)
     # Add metric name column to the table data
-    metric_names_array = np.array(metric_names).reshape(-1, 1)  # Convert to column vector
+    metric_names_array = np.array(metric_names).reshape(
+        -1, 1
+    )  # Convert to column vector
 
     # Add algo name column to the table data
     algo_name = config["algorithm"]["ALG"]
@@ -91,28 +132,41 @@ def log_heldout_metrics(config, logger, eval_metrics,
 
     # Additionally log each metric separately for parameter sweep analysis
     for i in range(table_data_with_names.shape[0]):
-        logger.log_item(f"HeldoutEval/FinalEgoVsHeldout/{table_data_with_names[i, 1]}/mean", float(table_data_with_names[i, 2].split()[0]))
+        logger.log_item(
+            f"HeldoutEval/FinalEgoVsHeldout/{table_data_with_names[i, 1]}/mean",
+            float(table_data_with_names[i, 2].split()[0]),
+        )
 
     aggregate_stat = config["global_heldout_settings"]["AGGREGATE_STAT"]
-    logger.log_xp_matrix(f"HeldoutEval/FinalEgoVsHeldout-{aggregate_stat.capitalize()}-CI", table_data_with_names,
-                         columns=["Algorithm", "Metric", f"{aggregate_stat.capitalize()} (all)"] + list(heldout_names), commit=True)
+    logger.log_xp_matrix(
+        f"HeldoutEval/FinalEgoVsHeldout-{aggregate_stat.capitalize()}-CI",
+        table_data_with_names,
+        columns=["Algorithm", "Metric", f"{aggregate_stat.capitalize()} (all)"]
+        + list(heldout_names),
+        commit=True,
+    )
 
     # Saving artifacts
     savedir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
-    out_savepath = save_train_run(eval_metrics, savedir, savename="heldout_eval_metrics")
+    out_savepath = save_train_run(
+        eval_metrics, savedir, savename="heldout_eval_metrics"
+    )
     if config["logger"]["log_eval_out"]:
-        logger.log_artifact(name="heldout_eval_metrics", path=out_savepath, type_name="eval_metrics")
+        logger.log_artifact(
+            name="heldout_eval_metrics", path=out_savepath, type_name="eval_metrics"
+        )
 
     # Cleanup locally logged out file
     if not config["local_logger"]["save_eval_out"]:
         shutil.rmtree(out_savepath)
 
-def heldout_metrics_1d(config, logger, eval_metrics,
-                       ego_names, heldout_names, metric_names: tuple):
-    '''Treat the first dimension of eval_metrics as (num_seeds, ...).
+
+def heldout_metrics_1d(
+    config, logger, eval_metrics, ego_names, heldout_names, metric_names: tuple
+):
+    """Treat the first dimension of eval_metrics as (num_seeds, ...).
     Returns the data for a table where the rows are the metrics and the columns are the heldout agents.
-    '''
-    num_seeds, num_heldout_agents, num_eval_episodes, _ = eval_metrics[metric_names[0]].shape
+    """
     table_data = []
     aggregate_stat = config["global_heldout_settings"]["AGGREGATE_STAT"]
 
@@ -120,17 +174,28 @@ def heldout_metrics_1d(config, logger, eval_metrics,
         # shape of eval_metrics[metric_name] is (num_seeds, num_heldout_agents, num_eval_episodes, num_agents_per_game)
         # average out the episode and agents-per-game dims so that seeds are the
         # bootstrap replication unit and heldout agents are the tasks
-        data = eval_metrics[metric_name].mean(axis=(-1, -2)) # final shape (num_seeds, num_heldout_agents)
+        data = eval_metrics[metric_name].mean(
+            axis=(-1, -2)
+        )  # final shape (num_seeds, num_heldout_agents)
         data = np.array(data)
         # compute per-heldout-agent aggregate stat+CIs
-        point_est_per_task, interval_ests_per_task = compute_aggregate_stat_and_ci_per_task(data, aggregate_stat, return_interval_est=True)
+        point_est_per_task, interval_ests_per_task = (
+            compute_aggregate_stat_and_ci_per_task(
+                data, aggregate_stat, return_interval_est=True
+            )
+        )
         lower_ci = interval_ests_per_task[:, 0]
         upper_ci = interval_ests_per_task[:, 1]
 
-        col_strs = [f"{point_est_per_task[i]:.3f} ({lower_ci[i]:.3f}, {upper_ci[i]:.3f})" for i in range(len(point_est_per_task))]
+        col_strs = [
+            f"{point_est_per_task[i]:.3f} ({lower_ci[i]:.3f}, {upper_ci[i]:.3f})"
+            for i in range(len(point_est_per_task))
+        ]
 
         # compute aggregate stat+CI over all heldout agents
-        point_est_all, interval_ests_all = compute_aggregate_stat_and_ci(data, aggregate_stat, return_interval_est=True)
+        point_est_all, interval_ests_all = compute_aggregate_stat_and_ci(
+            data, aggregate_stat, return_interval_est=True
+        )
         lower_ci = interval_ests_all[0]
         upper_ci = interval_ests_all[1]
 
@@ -139,14 +204,15 @@ def heldout_metrics_1d(config, logger, eval_metrics,
         table_data.append(col_strs)
     return np.array(table_data)
 
-def heldout_metrics_2d(config, logger, eval_metrics,
-        ego_names, heldout_names, metric_names: tuple):
-    '''Treat the first two dimensions of eval_metrics as (seeds, iters, ...) dimensions.
+
+def heldout_metrics_2d(
+    config, logger, eval_metrics, ego_names, heldout_names, metric_names: tuple
+):
+    """Treat the first two dimensions of eval_metrics as (seeds, iters, ...) dimensions.
     Logs a curve for each metric over the iters dimension.
     Returns the data for a table where the rows are the metrics and the columns are the heldout agents.
-    '''
-    num_seeds, num_oel_iter, num_heldout_agents, \
-        num_eval_episodes, num_agents_per_game = eval_metrics[metric_names[0]].shape
+    """
+    num_oel_iter = eval_metrics[metric_names[0]].shape[1]
 
     table_data = []
     aggregate_stat = config["global_heldout_settings"]["AGGREGATE_STAT"]
@@ -157,7 +223,9 @@ def heldout_metrics_2d(config, logger, eval_metrics,
         for i in range(num_oel_iter):
             # average out the episode and agents-per-game dims so that seeds are the
             # bootstrap replication unit and heldout agents are the tasks
-            data = eval_metrics[metric_name][:, i].mean(axis=(-1, -2)) # final shape (num_seeds, num_heldout_agents)
+            data = eval_metrics[metric_name][:, i].mean(
+                axis=(-1, -2)
+            )  # final shape (num_seeds, num_heldout_agents)
             data = np.array(data)
             point_est = aggregate_stat_fn(data)
             # log curve aggregated over all heldout agents
@@ -165,14 +233,23 @@ def heldout_metrics_2d(config, logger, eval_metrics,
 
         # now compute per-heldout-agent aggregate stat+CIs corresponding to the LAST ego iter
         last_iter_data = data
-        point_est_per_task, interval_ests_per_task = compute_aggregate_stat_and_ci_per_task(last_iter_data, aggregate_stat, return_interval_est=True)
+        point_est_per_task, interval_ests_per_task = (
+            compute_aggregate_stat_and_ci_per_task(
+                last_iter_data, aggregate_stat, return_interval_est=True
+            )
+        )
         lower_ci = interval_ests_per_task[:, 0]
         upper_ci = interval_ests_per_task[:, 1]
 
-        col_strs = [f"{point_est_per_task[i]:.3f} ({lower_ci[i]:.3f}, {upper_ci[i]:.3f})" for i in range(len(point_est_per_task))]
+        col_strs = [
+            f"{point_est_per_task[i]:.3f} ({lower_ci[i]:.3f}, {upper_ci[i]:.3f})"
+            for i in range(len(point_est_per_task))
+        ]
 
         # compute aggregate stat+CI over all heldout agents
-        point_est_all, interval_ests_all = compute_aggregate_stat_and_ci(last_iter_data, aggregate_stat, return_interval_est=True)
+        point_est_all, interval_ests_all = compute_aggregate_stat_and_ci(
+            last_iter_data, aggregate_stat, return_interval_est=True
+        )
         lower_ci = interval_ests_all[0]
         upper_ci = interval_ests_all[1]
 
@@ -180,33 +257,50 @@ def heldout_metrics_2d(config, logger, eval_metrics,
         table_data.append(col_strs)
     return np.array(table_data)
 
+
 def run_heldout_evaluation_from_config(config, print_metrics=False):
-    '''Run heldout evaluation, loading the ego agent from config["ego_agent"].'''
+    """Run heldout evaluation, loading the ego agent from config["ego_agent"]."""
     # Create only one environment instance
     env = make_env(config["ENV_NAME"], config["ENV_KWARGS"])
     env = LogWrapper(env)
-    
+
     rng = jax.random.PRNGKey(config["global_heldout_settings"]["EVAL_SEED"])
     rng, ego_init_rng, heldout_init_rng, eval_rng = jax.random.split(rng, 4)
-    
+
     # load ego agents
     ego_agent_config = dict(config["ego_agent"])
     ego_test_mode = ego_agent_config.get("test_mode", False)
-    ego_policy, ego_params, init_ego_params, ego_idx_labels = initialize_rl_agent_from_config(ego_agent_config, "ego", env, ego_init_rng)
+    ego_policy, ego_params, init_ego_params, ego_idx_labels = (
+        initialize_rl_agent_from_config(ego_agent_config, "ego", env, ego_init_rng)
+    )
     # flatten ego params and idx labels
-    ego_idx_labels = np.array(ego_idx_labels).reshape(-1) # flatten the list of ego agent labels 
-    flattened_ego_params = jax.tree.map(lambda x, y: x.reshape((-1,) + y.shape), ego_params, init_ego_params)        
-    
+    ego_idx_labels = np.array(ego_idx_labels).reshape(
+        -1
+    )  # flatten the list of ego agent labels
+    flattened_ego_params = jax.tree.map(
+        lambda x, y: x.reshape((-1,) + y.shape), ego_params, init_ego_params
+    )
+
     # load heldout agents
     heldout_cfg = config["heldout_set"][config["TASK_NAME"]]
-    heldout_agents = load_heldout_set(heldout_cfg, env, config["TASK_NAME"], config["ENV_KWARGS"], heldout_init_rng)
+    heldout_agents = load_heldout_set(
+        heldout_cfg, env, config["TASK_NAME"], config["ENV_KWARGS"], heldout_init_rng
+    )
     heldout_agent_names = list(heldout_agents.keys())
     heldout_agent_list = list(heldout_agents.values())
 
     # run evaluation
     eval_metrics = eval_egos_vs_heldouts(
-        config, env, eval_rng, config["global_heldout_settings"]["NUM_EVAL_EPISODES"],
-        ego_policy, flattened_ego_params, heldout_agent_list, heldout_agent_names, ego_test_mode)
+        config,
+        env,
+        eval_rng,
+        config["global_heldout_settings"]["NUM_EVAL_EPISODES"],
+        ego_policy,
+        flattened_ego_params,
+        heldout_agent_list,
+        heldout_agent_names,
+        ego_test_mode,
+    )
 
     if print_metrics:
         # each leaf of eval_metrics has shape (num_ego_agents, num_heldout_agents, num_eval_episodes, num_agents_per_env)
@@ -215,6 +309,12 @@ def run_heldout_evaluation_from_config(config, print_metrics=False):
         ego_names = [f"ego ({label})" for label in ego_idx_labels]
         heldout_names = list(heldout_agents.keys())
         for metric_name in metric_names:
-            print_metrics_table(eval_metrics, metric_name, ego_names, heldout_names, 
-                aggregate_stat, config["global_heldout_settings"]["NORMALIZE_RETURNS"])
+            print_metrics_table(
+                eval_metrics,
+                metric_name,
+                ego_names,
+                heldout_names,
+                aggregate_stat,
+                config["global_heldout_settings"]["NORMALIZE_RETURNS"],
+            )
     return eval_metrics

--- a/evaluation/run.py
+++ b/evaluation/run.py
@@ -1,9 +1,10 @@
-import hydra
-from omegaconf import OmegaConf
 import logging
 
-from evaluation.heldout_runner import run_heldout_evaluation_from_config
+import hydra
+from omegaconf import OmegaConf
+
 from evaluation.generate_xp_matrix import run_heldout_xp_evaluation
+from evaluation.heldout_runner import run_heldout_evaluation_from_config
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -11,10 +12,10 @@ logging.basicConfig(level=logging.INFO)
 
 @hydra.main(version_base=None, config_path="configs", config_name="heldout_xp")
 def run_evaluation(cfg):
-    '''Run evaluation. 
+    """Run evaluation.
     All evaluators assume that the path to the ego agent is provided at config["ego_agent"]["path"]
     and that all information necessary to properly initialize the ego agent is provided at config["ego_agent"]
-    '''
+    """
     print(OmegaConf.to_yaml(cfg, resolve=True))
 
     if "heldout_ego" in cfg["name"] or "validation_ego" in cfg["name"]:
@@ -26,5 +27,6 @@ def run_evaluation(cfg):
     else:
         raise ValueError(f"Evaluator {cfg['name']} not found.")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_evaluation()

--- a/evaluation/run.py
+++ b/evaluation/run.py
@@ -2,7 +2,7 @@ import hydra
 from omegaconf import OmegaConf
 import logging
 
-from heldout_evaluator import run_heldout_evaluation
+from evaluation.heldout_runner import run_heldout_evaluation_from_config
 from evaluation.generate_xp_matrix import run_heldout_xp_evaluation
 
 log = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ def run_evaluation(cfg):
     print(OmegaConf.to_yaml(cfg, resolve=True))
 
     if "heldout_ego" in cfg["name"] or "validation_ego" in cfg["name"]:
-        run_heldout_evaluation(cfg, print_metrics=True)
+        run_heldout_evaluation_from_config(cfg, print_metrics=True)
 
     elif "heldout_xp" in cfg["name"]:
         run_heldout_xp_evaluation(cfg, print_metrics=True)

--- a/human_data_collecting/app.py
+++ b/human_data_collecting/app.py
@@ -25,7 +25,7 @@ from agents.lbf import SequentialFruitAgent
 from agents.lbf import GreedyHeuristicAgent
 from agents.lbf import EntitledAgent
 from common.agent_loader_from_config import initialize_rl_agent_from_config
-from evaluation.heldout_evaluator import extract_params
+from evaluation.heldout_core import extract_params
 
 app = Flask(__name__)
 app.secret_key = os.environ.get('FLASK_SECRET_KEY', os.urandom(32).hex())

--- a/human_data_collecting/app.py
+++ b/human_data_collecting/app.py
@@ -2,33 +2,33 @@
 Flask web application for human interaction with the Level-Based Foraging (LBF) environment.
 Human player plays against a heuristic LBF agent.
 """
-import os
-import sys
+
+import asyncio
 import json
-import time
+import os
 import random
-from flask import Flask, render_template, jsonify, request, session
-from flask_cors import CORS
+import sys
+import threading
+import time
+import uuid
+from asyncio import run_coroutine_threadsafe
+
 import jax
 import jax.numpy as jnp
 import numpy as np
-import asyncio
-import uuid
-import threading
-from asyncio import run_coroutine_threadsafe
+from flask import Flask, jsonify, render_template, request, session
+from flask_cors import CORS
 
 # Add parent directory to path to import project modules
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from envs import make_env
-from agents.lbf import SequentialFruitAgent
-from agents.lbf import GreedyHeuristicAgent
-from agents.lbf import EntitledAgent
+from agents.lbf import EntitledAgent, GreedyHeuristicAgent, SequentialFruitAgent
 from common.agent_loader_from_config import initialize_rl_agent_from_config
+from envs import make_env
 from evaluation.heldout_core import extract_params
 
 app = Flask(__name__)
-app.secret_key = os.environ.get('FLASK_SECRET_KEY', os.urandom(32).hex())
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", os.urandom(32).hex())
 CORS(app)
 
 # Global game state storage (in production, use Redis or similar)
@@ -37,6 +37,7 @@ game_sessions_lock = threading.Lock()
 
 
 # -- RL POLICY AGENT SUPPORT --
+
 
 class RLPolicyAgentWrapper:
     """Wraps an AgentPolicy + params to match the heuristic BaseAgent interface
@@ -90,7 +91,9 @@ _RL_AGENT_CONFIGS = {
             "name": "ippo_mlp_s2c0",
             "path": "human_data/teammates/ippo-lbf-7/saved_train_run",
             "actor_type": "mlp",
-            "idx_list": [[2, 0]],  # seed 2, checkpoint 0 — needs "checkpoints" key (default)
+            "idx_list": [
+                [2, 0]
+            ],  # seed 2, checkpoint 0 — needs "checkpoints" key (default)
             "test_mode": False,
         },
         # {
@@ -167,12 +170,17 @@ def _load_rl_agents_for_variant(variant_key):
             RL_AGENTS[variant_key] = []
             return
 
-        cpu = jax.devices('cpu')[0]
+        cpu = jax.devices("cpu")[0]
         num_food = 3 if grid_size == 7 else 6
-        env = make_env(env_name="lbf", env_kwargs={
-            "grid_size": grid_size, "num_agents": 2, "num_food": num_food,
-            "different_levels": different_levels,
-        })
+        env = make_env(
+            env_name="lbf",
+            env_kwargs={
+                "grid_size": grid_size,
+                "num_agents": 2,
+                "num_food": num_food,
+                "different_levels": different_levels,
+            },
+        )
 
         root_logger = logging.getLogger()
         prev_level = root_logger.level
@@ -187,23 +195,29 @@ def _load_rl_agents_for_variant(variant_key):
 
                 _rl_load_rng, init_rng = jax.random.split(_rl_load_rng)
                 cfg["custom_loader"] = {"name": "partial_load"}
-                policy, params, init_params, idx_labels = initialize_rl_agent_from_config(
-                    cfg, name, env, init_rng
+                policy, params, init_params, idx_labels = (
+                    initialize_rl_agent_from_config(cfg, name, env, init_rng)
                 )
                 params = jax.tree.map(lambda x: jax.device_put(x, cpu), params)
-                params_list, idx_labels = extract_params(params, init_params, idx_labels)
+                params_list, idx_labels = extract_params(
+                    params, init_params, idx_labels
+                )
                 del init_params
 
                 for i, p in enumerate(params_list):
                     label = f"{name}({idx_labels[i]})" if len(params_list) > 1 else name
                     param_bytes = sum(x.nbytes for x in jax.tree.leaves(p))
-                    print(f"  Agent '{label}': {param_bytes / 1024:.1f} KB ({len(jax.tree.leaves(p))} arrays)")
+                    print(
+                        f"  Agent '{label}': {param_bytes / 1024:.1f} KB ({len(jax.tree.leaves(p))} arrays)"
+                    )
                     agents.append(RLPolicyAgentWrapper(policy, p, test_mode, label))
         finally:
             root_logger.setLevel(prev_level)
 
         RL_AGENTS[variant_key] = agents
-        print(f"Loaded {len(agents)} RL policy agents for {grid_size}x{grid_size} (different_levels={different_levels})")
+        print(
+            f"Loaded {len(agents)} RL policy agents for {grid_size}x{grid_size} (different_levels={different_levels})"
+        )
 
 
 def load_rl_agents():
@@ -213,6 +227,7 @@ def load_rl_agents():
     _load_rl_agents_for_variant((12, True))
     _load_rl_agents_for_variant((12, False))
 
+
 # Action constants
 NOOP = 0
 UP = 1
@@ -221,11 +236,21 @@ LEFT = 3
 RIGHT = 4
 LOAD = 5
 
+
 class GameSession:
     """Manages a single game session with environment state and agent state."""
 
-    def __init__(self, session_id, max_steps=50, env_kwargs: dict = None, is_warmup: bool = False, data_source: str = "",
-                 prolific_pid=None, study_id=None, prolific_session_id=None):
+    def __init__(
+        self,
+        session_id,
+        max_steps=50,
+        env_kwargs: dict | None = None,
+        is_warmup: bool = False,
+        data_source: str = "",
+        prolific_pid=None,
+        study_id=None,
+        prolific_session_id=None,
+    ):
         self.is_warmup = is_warmup
         self.data_source = data_source
         self.prolific_pid = prolific_pid
@@ -235,7 +260,9 @@ class GameSession:
         self.max_steps = max_steps
         self.env_kwargs = env_kwargs or {}
         self.grid_size = self.env_kwargs.get("grid_size", 7)
-        self.num_fruits = self.env_kwargs.get("num_food", 3 if self.grid_size == 7 else 6)
+        self.num_fruits = self.env_kwargs.get(
+            "num_food", 3 if self.grid_size == 7 else 6
+        )
         self.different_levels = self.env_kwargs.get("different_levels", False)
 
         # Choose agent first
@@ -243,16 +270,18 @@ class GameSession:
 
         # Initialize environment
         env_args = dict(self.env_kwargs)
-        env_args.update({
-            "time_limit": max_steps,
-            "num_agents": 2,
-            "highlight_agent_idx": 0,
-        })
+        env_args.update(
+            {
+                "time_limit": max_steps,
+                "num_agents": 2,
+                "highlight_agent_idx": 0,
+            }
+        )
         self.env = make_env(env_name="lbf", env_kwargs=env_args)
-        
+
         # Initialize JAX random key
         self.rng = jax.random.PRNGKey(np.random.randint(0, 1000000))
-        
+
         # Game state
         self.obs = None
         self.state = None
@@ -262,13 +291,13 @@ class GameSession:
         self.step_count = 0
         self.ai_agent_state = None
         self.episode_history = []  # Store episode trajectory
-        
+
         # Initialize the game
         self.reset()
-        
+
         # Pre-compile JAX functions with a warmup step
         self._warmup_jit_compilation()
-    
+
     def _choose_agent(self):
         # Build a flat list of all possible agent factories, then pick uniformly
         candidates = []
@@ -282,20 +311,28 @@ class GameSession:
 
         # SequentialFruitAgent — one per ordering strategy
         for strategy in SequentialFruitAgent.VALID_ORDERING_STRATEGIES:
-            candidates.append(lambda s=strategy: SequentialFruitAgent(
-                grid_size=self.grid_size,
-                num_fruits=self.num_fruits,
-                ordering_strategy=s,
-            ))
+            candidates.append(
+                lambda s=strategy: SequentialFruitAgent(
+                    grid_size=self.grid_size,
+                    num_fruits=self.num_fruits,
+                    ordering_strategy=s,
+                )
+            )
 
         # GreedyHeuristicAgent — one per heuristic
-        heuristics = GreedyHeuristicAgent.VALID_HEURISTICS_LEVELS if self.different_levels else GreedyHeuristicAgent.VALID_HEURISTICS
+        heuristics = (
+            GreedyHeuristicAgent.VALID_HEURISTICS_LEVELS
+            if self.different_levels
+            else GreedyHeuristicAgent.VALID_HEURISTICS
+        )
         for heuristic in heuristics:
-            candidates.append(lambda h=heuristic: GreedyHeuristicAgent(
-                grid_size=self.grid_size,
-                num_fruits=self.num_fruits,
-                heuristic=h,
-            ))
+            candidates.append(
+                lambda h=heuristic: GreedyHeuristicAgent(
+                    grid_size=self.grid_size,
+                    num_fruits=self.num_fruits,
+                    heuristic=h,
+                )
+            )
 
         # EntitledAgent — weighted 1.5x relative to any other single candidate
         entitled_factory = lambda: EntitledAgent(
@@ -313,63 +350,58 @@ class GameSession:
         This ensures the first actual game step is fast.
         """
         # print(f"🔥 Warming up JIT compilation for session {self.session_id[:8]}...")
-        warmup_start = time.time()
-        
+
         # Save current state
         saved_obs = self.obs
         saved_state = self.state
         saved_ai_agent_state = self.ai_agent_state
         saved_rng = self.rng
-        
+
         # Do a few warmup steps to trigger compilation
         for _ in range(3):
             # Get AI agent action (triggers agent compilation)
             self.rng, ai_rng = jax.random.split(self.rng)
             ai_action, self.ai_agent_state = self.ai_agent.get_action(
-                self.obs["agent_1"], 
-                self.state, 
-                self.ai_agent_state, 
-                ai_rng
+                self.obs["agent_1"], self.state, self.ai_agent_state, ai_rng
             )
-            
+
             # Prepare actions
             actions = {
                 "agent_0": jnp.array(0, dtype=jnp.int32),  # NOOP
-                "agent_1": ai_action
+                "agent_1": ai_action,
             }
-            
+
             # Step environment (triggers env.step compilation)
             self.rng, step_key = jax.random.split(self.rng)
-            self.obs, self.state, self.rewards, done_dict, info = self.env.step(
+            self.obs, self.state, self.rewards, done_dict, _info = self.env.step(
                 step_key, self.state, actions
             )
-            
+
             # If done, reset for next warmup iteration
             if done_dict["__all__"]:
                 self.rng, reset_key = jax.random.split(self.rng)
                 self.obs, self.state = self.env.reset(reset_key)
                 self.ai_agent_state = self.ai_agent.init_agent_state(1)
-        
+
         # Block until all JAX operations complete
         jax.block_until_ready(self.obs)
-        
+
         # Restore original state
         self.obs = saved_obs
         self.state = saved_state
         self.ai_agent_state = saved_ai_agent_state
         self.rng = saved_rng
-        
-        warmup_time = time.time() - warmup_start
+
         # print(f"✅ JIT compilation complete ({warmup_time:.2f}s)")
-    
+
     def reset(self):
         """Reset the game environment."""
         self.rng, subkey = jax.random.split(self.rng)
         self.obs, self.state = self.env.reset(subkey)
-        
+
         # Initialize AI agent state
         self.ai_agent_state = self.ai_agent.init_agent_state(1)  # Agent 1 is AI
-        
+
         self.done = False
         self.rewards = {"agent_0": 0.0, "agent_1": 0.0}
         self.total_rewards = {"agent_0": 0.0, "agent_1": 0.0}
@@ -381,68 +413,67 @@ class GameSession:
         self.episode_history = []
 
         return self.get_state_dict()
-    
+
     def step(self, human_action):
         """Execute one step with human action and AI agent action."""
         if self.done:
             # TODO: Record endtime
             return self.get_state_dict()
-        
+
         # Get AI agent action
         self.rng, ai_rng = jax.random.split(self.rng)
         ai_action, self.ai_agent_state = self.ai_agent.get_action(
-            self.obs["agent_1"], 
-            self.state, 
-            self.ai_agent_state, 
-            ai_rng
+            self.obs["agent_1"], self.state, self.ai_agent_state, ai_rng
         )
-        
+
         # Combine actions
         actions = {
             "agent_0": jnp.array(human_action, dtype=jnp.int32),
-            "agent_1": ai_action
+            "agent_1": ai_action,
         }
-        
+
         # Step environment
         self.rng, step_key = jax.random.split(self.rng)
-        self.obs, self.state, self.rewards, done_dict, info = self.env.step(
+        self.obs, self.state, self.rewards, done_dict, _info = self.env.step(
             step_key, self.state, actions
         )
-        
+
         # Block until all JAX operations are complete before proceeding
         # This ensures responsive gameplay without lag
         jax.block_until_ready(self.obs)
-        
+
         # Update state
         self.done = done_dict["__all__"]
         self.step_count += 1
-        
+
         # Update total rewards
         for agent in self.env.agents:
             self.total_rewards[agent] += float(self.rewards[agent])
-        
+
         # Store in history (with elapsed time since start)
         now = time.time()
-        elapsed = now - self.start_time if hasattr(self, 'start_time') else None
-        self.episode_history.append({
-            "step": self.step_count,
-            "human_action": int(human_action),
-            "ai_action": int(ai_action),
-            "rewards": {k: float(v) for k, v in self.rewards.items()},
-            "state": self._serialize_state(),
-            # include wall-clock timestamp and elapsed seconds
-            "timestamp": now,
-            "elapsed": elapsed
-        })
-        
+        elapsed = now - self.start_time if hasattr(self, "start_time") else None
+        self.episode_history.append(
+            {
+                "step": self.step_count,
+                "human_action": int(human_action),
+                "ai_action": int(ai_action),
+                "rewards": {k: float(v) for k, v in self.rewards.items()},
+                "state": self._serialize_state(),
+                # include wall-clock timestamp and elapsed seconds
+                "timestamp": now,
+                "elapsed": elapsed,
+            }
+        )
+
         # Auto-save when episode is done
         if self.done:
             # record end time before saving
             self.end_time = time.time()
             self.save_episode()
-        
+
         return self.get_state_dict()
-    
+
     def _serialize_state(self):
         """Serialize environment state for storage."""
         # Extract key state information
@@ -452,16 +483,16 @@ class GameSession:
             "food_positions": self.state.env_state.food_items.position.tolist(),
             "food_levels": self.state.env_state.food_items.level.tolist(),
             "food_eaten": self.state.env_state.food_items.eaten.tolist(),
-            "step_count": int(self.step_count)
+            "step_count": int(self.step_count),
         }
-    
+
     def get_state_dict(self):
         """Get current game state as a dictionary for JSON serialization."""
         state_data = self._serialize_state()
-        
+
         # Add available actions for human player
         avail_actions = self.state.avail_actions["agent_0"].tolist()
-        
+
         return {
             "done": bool(self.done),
             "step_count": int(self.step_count),
@@ -472,18 +503,18 @@ class GameSession:
             "state": state_data,
             "grid_size": self.grid_size,
             "num_fruits": self.num_fruits,
-            "different_levels": self.different_levels
+            "different_levels": self.different_levels,
         }
-    
+
     def save_episode(self, player_name="Anonymous"):
         """Save episode data to file."""
         if not self.episode_history:
             return None
-        
+
         timestamp = time.strftime("%Y%m%d_%H%M%S")
-        
+
         # make sure end_time is set if game is being saved after completion
-        if getattr(self, 'end_time', None) is None and self.done:
+        if getattr(self, "end_time", None) is None and self.done:
             self.end_time = time.time()
 
         episode_data = {
@@ -502,25 +533,34 @@ class GameSession:
             # include game start/end timing information
             "start_time": getattr(self, "start_time", None),
             "end_time": getattr(self, "end_time", None),
-            "duration": (self.end_time - self.start_time) if (self.start_time and self.end_time) else None,
-            "trajectory": self.episode_history
+            "duration": (self.end_time - self.start_time)
+            if (self.start_time and self.end_time)
+            else None,
+            "trajectory": self.episode_history,
         }
-        
+
         # Create data directory if it doesn't exist
         # Warmup games go to a separate folder; data_source adds a suffix (e.g. "_prolific")
         suffix = f"_{self.data_source}" if self.data_source else ""
-        folder_name = f"collected_data_warmup{suffix}" if self.is_warmup else f"collected_data{suffix}"
+        folder_name = (
+            f"collected_data_warmup{suffix}"
+            if self.is_warmup
+            else f"collected_data{suffix}"
+        )
         data_dir = os.path.join(os.path.dirname(__file__), folder_name)
         os.makedirs(data_dir, exist_ok=True)
-        
+
         # Save to file with timestamp for uniqueness
-        filename = f"episode_{timestamp}_{self.session_id[:8]}_{self.step_count}steps.json"
+        filename = (
+            f"episode_{timestamp}_{self.session_id[:8]}_{self.step_count}steps.json"
+        )
         filepath = os.path.join(data_dir, filename)
-        
-        with open(filepath, 'w') as f:
+
+        with open(filepath, "w") as f:
             json.dump(episode_data, f, indent=2)
-        
+
         return filepath
+
 
 # Number of warmup games at the start of each session
 NUM_WARMUP_GAMES = 2
@@ -529,8 +569,18 @@ NUM_REAL_GAMES = 8
 
 class MultiGameSession:
     """Manages a sequence of GameSession instances played sequentially with lazy loading."""
-    def __init__(self, session_id, game_configs, first_game=None, num_warmup=NUM_WARMUP_GAMES, data_source="",
-                 prolific_pid=None, study_id=None, prolific_session_id=None):
+
+    def __init__(
+        self,
+        session_id,
+        game_configs,
+        first_game=None,
+        num_warmup=NUM_WARMUP_GAMES,
+        data_source="",
+        prolific_pid=None,
+        study_id=None,
+        prolific_session_id=None,
+    ):
         self.session_id = session_id
         self.config_list = game_configs  # All configs (used for lazy creation)
         self.games = [None] * len(game_configs)  # Placeholder for all games
@@ -547,7 +597,7 @@ class MultiGameSession:
         if first_game:
             self.games[0] = first_game
             first_game.session_id = session_id
-            first_game.is_warmup = (0 < num_warmup)
+            first_game.is_warmup = 0 < num_warmup
             first_game.data_source = data_source
             first_game.prolific_pid = prolific_pid
             first_game.study_id = study_id
@@ -561,7 +611,7 @@ class MultiGameSession:
         cfg = self.config_list[idx]
         game = get_or_create_game(cfg)
         game.session_id = self.session_id
-        game.is_warmup = (idx < self.num_warmup)
+        game.is_warmup = idx < self.num_warmup
         game.data_source = self.data_source
         game.prolific_pid = self.prolific_pid
         game.study_id = self.study_id
@@ -585,29 +635,29 @@ class MultiGameSession:
             # Ensure next game is loaded before returning its state
             self._ensure_game_loaded(self.current_idx)
             result = self.get_state_dict()
-            result['game_just_advanced'] = True
-            result['prev_game_index'] = prev_idx
+            result["game_just_advanced"] = True
+            result["prev_game_index"] = prev_idx
             return result
         # If all games are done, mark session complete
         if cur.done and self.current_idx >= len(self.games) - 1:
             self.session_complete = True
         result = self.get_state_dict()
-        result['game_just_advanced'] = False
+        result["game_just_advanced"] = False
         return result
 
     def get_state_dict(self):
         state = self._current().get_state_dict()
         # add multi-game metadata
-        state['multi'] = True
-        state['current_game_index'] = self.current_idx
-        state['total_games'] = len(self.games)
-        state['num_warmup'] = self.num_warmup
-        state['is_warmup'] = self.current_idx < self.num_warmup
-        state['session_complete'] = self.session_complete
-        state['game_configs'] = self.config_list
+        state["multi"] = True
+        state["current_game_index"] = self.current_idx
+        state["total_games"] = len(self.games)
+        state["num_warmup"] = self.num_warmup
+        state["is_warmup"] = self.current_idx < self.num_warmup
+        state["session_complete"] = self.session_complete
+        state["game_configs"] = self.config_list
         return state
 
-    def save_all(self, player_name='Anonymous'):
+    def save_all(self, player_name="Anonymous"):
         paths = []
         for game in self.games:
             if game is not None:
@@ -632,9 +682,11 @@ BASE_ENV_CONFIGS = [
     {"grid_size": 12, "num_food": 6, "different_levels": True},
 ]
 
+
 def _config_key(env_kwargs):
     """Hashable key for an env_kwargs dict."""
     return (env_kwargs.get("grid_size", 7), env_kwargs.get("different_levels", False))
+
 
 def generate_session_configs(num_warmup=NUM_WARMUP_GAMES, num_real=NUM_REAL_GAMES):
     """Generate the full list of game configs (env_kwargs dicts) for a session.
@@ -647,7 +699,11 @@ def generate_session_configs(num_warmup=NUM_WARMUP_GAMES, num_real=NUM_REAL_GAME
     warmup = [random.choice(BASE_ENV_CONFIGS).copy() for _ in range(num_warmup)]
 
     # Real games: 2 copies of each base config, shuffled
-    real = [cfg.copy() for cfg in BASE_ENV_CONFIGS for _ in range(num_real // len(BASE_ENV_CONFIGS))]
+    real = [
+        cfg.copy()
+        for cfg in BASE_ENV_CONFIGS
+        for _ in range(num_real // len(BASE_ENV_CONFIGS))
+    ]
     # If num_real isn't perfectly divisible, pad with random picks
     while len(real) < num_real:
         real.append(random.choice(BASE_ENV_CONFIGS).copy())
@@ -655,11 +711,12 @@ def generate_session_configs(num_warmup=NUM_WARMUP_GAMES, num_real=NUM_REAL_GAME
 
     return warmup + real
 
+
 def get_or_create_game(env_kwargs):
     """Get a prewarmed game or create one on-demand."""
     key = _config_key(env_kwargs)
     with PREWARMING_LOCK:
-        if key in PREWARMED_GAMES_POOL and PREWARMED_GAMES_POOL[key]:
+        if PREWARMED_GAMES_POOL.get(key):
             game = PREWARMED_GAMES_POOL[key].pop(0)
             # When returning a prewarmed game, reset to ensure start/end times are for the actual human episode
             game.reset()
@@ -668,7 +725,9 @@ def get_or_create_game(env_kwargs):
     # Fallback: create on-demand
     return GameSession(str(uuid.uuid4()), 50, env_kwargs=env_kwargs)
 
+
 SESSION_TTL = 30 * 60  # 30 minutes
+
 
 async def prewarm_games():
     """Continuously prewarm games in background, keeping a pool of each config type."""
@@ -677,8 +736,12 @@ async def prewarm_games():
             # Clean up stale game sessions
             now = time.time()
             with game_sessions_lock:
-                stale = [sid for sid, gs in game_sessions.items()
-                         if hasattr(gs, 'last_activity') and now - gs.last_activity > SESSION_TTL]
+                stale = [
+                    sid
+                    for sid, gs in game_sessions.items()
+                    if hasattr(gs, "last_activity")
+                    and now - gs.last_activity > SESSION_TTL
+                ]
                 for sid in stale:
                     del game_sessions[sid]
             if stale:
@@ -703,37 +766,44 @@ async def prewarm_games():
                         del gs  # Pool was replenished by another thread
 
             await asyncio.sleep(1)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - prewarm loop must not die
             print(f"Error prewarming: {e}")
             await asyncio.sleep(1)
 
 
-@app.route('/')
+@app.route("/")
 def index():
     """Serve the main game page."""
-    return render_template('index.html', data_source='')
+    return render_template("index.html", data_source="")
 
 
-@app.route('/prolific')
+@app.route("/prolific")
 def prolific_index():
     """Serve the game page for Prolific participants (data saved to prolific-specific folders)."""
     import base64
+
     _completion_url = "https://app.prolific.com/submissions/complete?cc=C13XLNJ0"
     _encoded = base64.b64encode(_completion_url.encode()).decode()
-    return render_template('index.html', data_source='prolific', prolific_completion=_encoded)
+    return render_template(
+        "index.html", data_source="prolific", prolific_completion=_encoded
+    )
 
 
-@app.route('/api/new_game', methods=['POST'])
+@app.route("/api/new_game", methods=["POST"])
 def new_game():
     """Start a new game session with 2 warmup + 8 real games. Only first game is loaded upfront."""
     data = request.get_json() or {}
     # Sanitize data_source to prevent path traversal — only allow alphanumeric and hyphens
-    raw_source = data.get('data_source', '')
-    data_source = raw_source if raw_source.isalnum() or all(c.isalnum() or c == '-' for c in raw_source) else ''
+    raw_source = data.get("data_source", "")
+    data_source = (
+        raw_source
+        if raw_source.isalnum() or all(c.isalnum() or c == "-" for c in raw_source)
+        else ""
+    )
 
-    prolific_pid = data.get('prolific_pid') or None
-    study_id = data.get('study_id') or None
-    prolific_session_id = data.get('prolific_session_id') or None
+    prolific_pid = data.get("prolific_pid") or None
+    study_id = data.get("study_id") or None
+    prolific_session_id = data.get("prolific_session_id") or None
 
     session_id = str(uuid.uuid4())
 
@@ -745,30 +815,34 @@ def new_game():
     first_game = get_or_create_game(first_cfg)
 
     # Create MultiGameSession with lazy loading for remaining games
-    multi = MultiGameSession(session_id, conf_list, first_game=first_game, num_warmup=NUM_WARMUP_GAMES,
-                             data_source=data_source, prolific_pid=prolific_pid,
-                             study_id=study_id, prolific_session_id=prolific_session_id)
+    multi = MultiGameSession(
+        session_id,
+        conf_list,
+        first_game=first_game,
+        num_warmup=NUM_WARMUP_GAMES,
+        data_source=data_source,
+        prolific_pid=prolific_pid,
+        study_id=study_id,
+        prolific_session_id=prolific_session_id,
+    )
     with game_sessions_lock:
         game_sessions[session_id] = multi
 
     # Store session ID in Flask session
-    session['session_id'] = session_id
+    session["session_id"] = session_id
 
-    return jsonify({
-        "success": True,
-        "session_id": session_id,
-        "state": multi.get_state_dict()
-    })
+    return jsonify(
+        {"success": True, "session_id": session_id, "state": multi.get_state_dict()}
+    )
 
 
-
-@app.route('/api/step', methods=['POST'])
+@app.route("/api/step", methods=["POST"])
 def step():
     """Execute a step with the human player's action."""
     data = request.get_json()
-    session_id = session.get('session_id')
-    action = data.get('action')
-    
+    session_id = session.get("session_id")
+    action = data.get("action")
+
     if action is None or not isinstance(action, int) or action < 0 or action > 5:
         return jsonify({"success": False, "error": "Invalid action"}), 400
 
@@ -777,48 +851,57 @@ def step():
             return jsonify({"success": False, "error": "No active game session"}), 400
         game = game_sessions[session_id]
     # capture reference to underlying current game before stepping (so we can report last actions)
-    pre_game = game._current() if hasattr(game, '_current') else game
+    pre_game = game._current() if hasattr(game, "_current") else game
     state = game.step(action)
     # last actions come from the pre-step game
     last_step = pre_game.episode_history[-1] if pre_game.episode_history else None
-    
-    return jsonify({
-        "success": True,
-        "state": state,
-        "human_action": last_step["human_action"] if last_step else None,
-        "ai_action": last_step["ai_action"] if last_step else None
-    })
+
+    return jsonify(
+        {
+            "success": True,
+            "state": state,
+            "human_action": last_step["human_action"] if last_step else None,
+            "ai_action": last_step["ai_action"] if last_step else None,
+        }
+    )
 
 
-@app.route('/api/save_episode', methods=['POST'])
+@app.route("/api/save_episode", methods=["POST"])
 def save_episode():
     """Save the current episode data."""
     data = request.get_json()
-    session_id = session.get('session_id')
-    player_name = data.get('player_name', 'Anonymous')
-    
+    session_id = session.get("session_id")
+    player_name = data.get("player_name", "Anonymous")
+
     with game_sessions_lock:
         if not session_id or session_id not in game_sessions:
             return jsonify({"success": False, "error": "No active game session"}), 400
         game = game_sessions.pop(session_id)
 
     # If this is a multi-game session, save all games
-    if hasattr(game, 'save_all'):
+    if hasattr(game, "save_all"):
         paths = game.save_all(player_name)
         if paths:
             names = [os.path.basename(p) for p in paths]
-            return jsonify({"success": True, "message": f"Saved episodes: {', '.join(names)}"})
+            return jsonify(
+                {"success": True, "message": f"Saved episodes: {', '.join(names)}"}
+            )
         else:
             return jsonify({"success": False, "error": "No episode data to save"}), 400
     else:
         filepath = game.save_episode(player_name)
         if filepath:
-            return jsonify({"success": True, "message": f"Episode saved to {os.path.basename(filepath)}"})
+            return jsonify(
+                {
+                    "success": True,
+                    "message": f"Episode saved to {os.path.basename(filepath)}",
+                }
+            )
         else:
             return jsonify({"success": False, "error": "No episode data to save"}), 400
 
 
-@app.route('/api/controls', methods=['GET'])
+@app.route("/api/controls", methods=["GET"])
 def get_controls():
     """Return the control scheme for the game."""
     controls = {
@@ -828,7 +911,7 @@ def get_controls():
             "a": {"action": LEFT, "name": "Move Left"},
             "d": {"action": RIGHT, "name": "Move Right"},
             "space": {"action": LOAD, "name": "Load/Collect Food"},
-            "q": {"action": NOOP, "name": "No Operation (Wait)"}
+            "q": {"action": NOOP, "name": "No Operation (Wait)"},
         },
         "actions": {
             NOOP: "No Operation (Wait)",
@@ -836,20 +919,24 @@ def get_controls():
             DOWN: "Move Down",
             LEFT: "Move Left",
             RIGHT: "Move Right",
-            LOAD: "Load/Collect Food"
-        }
+            LOAD: "Load/Collect Food",
+        },
     }
     return jsonify(controls)
 
 
 BACKGROUND_LOOP = asyncio.new_event_loop()
+
+
 def start_background_loop(loop):
     asyncio.set_event_loop(loop)
     loop.run_forever()
 
-if __name__ == '__main__':
-    
-    threading.Thread(target=start_background_loop, args=(BACKGROUND_LOOP,), daemon=True).start()
+
+if __name__ == "__main__":
+    threading.Thread(
+        target=start_background_loop, args=(BACKGROUND_LOOP,), daemon=True
+    ).start()
 
     # Load RL policy agents from checkpoints (once at startup)
     print("[Startup] Loading RL policy agents...")
@@ -859,4 +946,4 @@ if __name__ == '__main__':
     print("[Startup] Starting background prewarming loop...")
     run_coroutine_threadsafe(prewarm_games(), BACKGROUND_LOOP)
 
-    app.run(debug=False, host='0.0.0.0', port=8998)
+    app.run(debug=False, host="0.0.0.0", port=8998)

--- a/marl/run.py
+++ b/marl/run.py
@@ -1,9 +1,10 @@
-'''Main entry point for running MARL algorithms.'''
+"""Main entry point for running MARL algorithms."""
+
 import hydra
 from omegaconf import OmegaConf
 
 from common.wandb_visualizations import Logger
-from ippo import run_ippo
+from marl.ippo import run_ippo
 
 
 @hydra.main(version_base=None, config_path="configs", config_name="base_config_marl")
@@ -15,8 +16,9 @@ def main(config):
         run_ippo(config, wandb_logger)
     else:
         raise NotImplementedError(f"Algorithm {config['ALG']} not implemented.")
-        
+
     wandb_logger.close()
+
 
 if __name__ == "__main__":
     main()

--- a/open_ended_training/run.py
+++ b/open_ended_training/run.py
@@ -2,7 +2,7 @@
 import hydra
 from omegaconf import OmegaConf
 
-from evaluation.heldout_eval import run_heldout_evaluation, log_heldout_metrics
+from evaluation.heldout_runner import run_heldout_evaluation, log_heldout_metrics
 from common.plot_utils import get_metric_names
 from common.wandb_visualizations import Logger
 from open_ended_training.rotate import run_rotate

--- a/open_ended_training/run.py
+++ b/open_ended_training/run.py
@@ -1,15 +1,17 @@
-'''Main entry point for running open-ended training algorithms.'''
+"""Main entry point for running open-ended training algorithms."""
+
 import hydra
 from omegaconf import OmegaConf
+from open_ended_minimax import run_minimax
 
-from evaluation.heldout_runner import run_heldout_evaluation, log_heldout_metrics
 from common.plot_utils import get_metric_names
 from common.wandb_visualizations import Logger
-from open_ended_training.rotate import run_rotate
+from evaluation.heldout_runner import log_heldout_metrics, run_heldout_evaluation
 from open_ended_training.cole import run_cole
-from open_ended_minimax import run_minimax
 from open_ended_training.paired import run_paired
+from open_ended_training.rotate import run_rotate
 from open_ended_training.trajedi import run_trajedi
+
 
 @hydra.main(version_base=None, config_path="configs", config_name="base_config_oel")
 def run_training(cfg):
@@ -31,15 +33,22 @@ def run_training(cfg):
 
     if cfg["run_heldout_eval"]:
         metric_names = get_metric_names(cfg["task"]["ENV_NAME"])
-        ego_as_2d = False if cfg.algorithm["ALG"] in ["cole", "paired", "trajedi"] else True
+        ego_as_2d = cfg.algorithm["ALG"] not in ["cole", "paired", "trajedi"]
         eval_metrics, ego_names, heldout_names = run_heldout_evaluation(
             cfg, ego_policy, final_ego_params, init_ego_params, ego_as_2d=ego_as_2d
         )
         log_heldout_metrics(
-            cfg, wandb_logger, eval_metrics, ego_names, heldout_names, metric_names, ego_as_2d=ego_as_2d
+            cfg,
+            wandb_logger,
+            eval_metrics,
+            ego_names,
+            heldout_names,
+            metric_names,
+            ego_as_2d=ego_as_2d,
         )
 
     wandb_logger.close()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_training()

--- a/open_ended_training/run.py
+++ b/open_ended_training/run.py
@@ -2,12 +2,12 @@
 
 import hydra
 from omegaconf import OmegaConf
-from open_ended_minimax import run_minimax
 
 from common.plot_utils import get_metric_names
 from common.wandb_visualizations import Logger
 from evaluation.heldout_runner import log_heldout_metrics, run_heldout_evaluation
 from open_ended_training.cole import run_cole
+from open_ended_training.open_ended_minimax import run_minimax
 from open_ended_training.paired import run_paired
 from open_ended_training.rotate import run_rotate
 from open_ended_training.trajedi import run_trajedi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,9 @@ markers = [
 
 [tool.ruff]
 target-version = "py311"
+
+[tool.ruff.lint.per-file-ignores]
+# N999 derives a module name from the checkout directory, which we do not
+# control: CI clones into a directory named "jax-aht", and the hyphen is not
+# a valid identifier.
+"**/__init__.py" = ["N999"]

--- a/teammate_generation/run.py
+++ b/teammate_generation/run.py
@@ -2,7 +2,7 @@
 import hydra
 from omegaconf import OmegaConf
 
-from evaluation.heldout_eval import run_heldout_evaluation, log_heldout_metrics
+from evaluation.heldout_runner import run_heldout_evaluation, log_heldout_metrics
 from common.plot_utils import get_metric_names
 from common.wandb_visualizations import Logger
 from teammate_generation.BRDiv import run_brdiv

--- a/teammate_generation/run.py
+++ b/teammate_generation/run.py
@@ -1,18 +1,21 @@
-'''Main entry point for running teammate generation algorithms.'''
+"""Main entry point for running teammate generation algorithms."""
+
 import hydra
 from omegaconf import OmegaConf
 
-from evaluation.heldout_runner import run_heldout_evaluation, log_heldout_metrics
 from common.plot_utils import get_metric_names
 from common.wandb_visualizations import Logger
+from evaluation.heldout_runner import log_heldout_metrics, run_heldout_evaluation
 from teammate_generation.BRDiv import run_brdiv
-from teammate_generation.LBRDiv import run_lbrdiv
 from teammate_generation.CoMeDi import run_comedi
 from teammate_generation.fcp import run_fcp
+from teammate_generation.LBRDiv import run_lbrdiv
 from teammate_generation.train_ego import train_ego_agent
 
 
-@hydra.main(version_base=None, config_path="configs", config_name="base_config_teammate")
+@hydra.main(
+    version_base=None, config_path="configs", config_name="base_config_teammate"
+)
 def run_training(cfg):
     print(OmegaConf.to_yaml(cfg, resolve=True))
     wandb_logger = Logger(cfg)
@@ -29,15 +32,28 @@ def run_training(cfg):
         partner_params, partner_population = run_comedi(cfg, wandb_logger)
     else:
         raise NotImplementedError("Selected method not implemented.")
-    
+
     metric_names = get_metric_names(cfg["task"]["ENV_NAME"])
     if cfg["train_ego"]:
-        ego_params, ego_policy, init_ego_params = train_ego_agent(cfg, wandb_logger, partner_params, partner_population)
-    
+        ego_params, ego_policy, init_ego_params = train_ego_agent(
+            cfg, wandb_logger, partner_params, partner_population
+        )
+
     if cfg["run_heldout_eval"]:
-        eval_metrics, ego_names, heldout_names = run_heldout_evaluation(cfg, ego_policy, ego_params, init_ego_params, ego_as_2d=False)
-        log_heldout_metrics(cfg, wandb_logger, eval_metrics, ego_names, heldout_names, metric_names, ego_as_2d=False)
+        eval_metrics, ego_names, heldout_names = run_heldout_evaluation(
+            cfg, ego_policy, ego_params, init_ego_params, ego_as_2d=False
+        )
+        log_heldout_metrics(
+            cfg,
+            wandb_logger,
+            eval_metrics,
+            ego_names,
+            heldout_names,
+            metric_names,
+            ego_as_2d=False,
+        )
     wandb_logger.close()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_training()

--- a/tests/test_heldout_loading.py
+++ b/tests/test_heldout_loading.py
@@ -10,7 +10,7 @@ import yaml
 
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from evaluation.heldout_evaluator import load_heldout_set
+from evaluation.heldout_core import load_heldout_set
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 HELDOUT_CONFIG = REPO_ROOT / "evaluation/configs/global_heldout_settings.yaml"


### PR DESCRIPTION
Heldout params were closed over as jit constants, so every partner triggered its own ~16s XLA compile even when partners shared a policy. `run_episodes`/`run_n_agent_episodes` also built a fresh `jax.jit` object per call, giving each an empty cache. Both now take params as arguments and memoize the compiled function on the static key.

Measured on LBF 7x7, 24 heldout agents (15 distinct policies), 3 egos, 64 episodes:

| path | before | after |
|---|---|---|
| 1d heldout eval | 422s (17.6s/partner) | 262s |
| 2d heldout eval (2 seeds x 2 iters) | ~422s | 305s |
| XP matrix (6 agents, 36 pairs) | ~633s | 189s |

Verified 1d output matches a from-scratch pairwise reference exactly, including a partner in the middle of a shared-policy group; n-agent runner checked standalone and under a jit trace as ROTATE calls it.