### PR TITLE
Fix one-step done misalignment in recurrent PPO replay

### DIFF
--- a/agents/meliba_agent.py
+++ b/agents/meliba_agent.py
@@ -1,17 +1,19 @@
 import functools
 import warnings
+from functools import partial
 
+import distrax
+import flax.linen as nn
 import jax
 import jax.numpy as jnp
-import numpy as np
-import flax.linen as nn
-import distrax
-
-from functools import partial
 
 from agents.agent_interface import AgentPolicy
 from agents.rnn_actor_critic import ScannedRNN
-from ego_agent_training.meliba_utils import DecoderScannedRNN, transform_timestep_to_k_batch, fill_to_first_true
+from ego_agent_training.meliba_utils import (
+    DecoderScannedRNN,
+    transform_timestep_to_k_batch,
+)
+
 
 def sample_gaussian(mu, logvar, prng_key):
     """
@@ -30,6 +32,7 @@ def sample_gaussian(mu, logvar, prng_key):
     eps = jax.random.normal(prng_key, std.shape)
     return (eps * std) + mu
 
+
 class FeatureExtractor(nn.Module):
     """
     Used for extrating features for states/actions/rewards
@@ -38,6 +41,7 @@ class FeatureExtractor(nn.Module):
         output_size: int, size of the output features
         activation_function: callable, activation function to use (default: None)
     """
+
     output_size: int
     activation_function: callable = None
 
@@ -58,7 +62,10 @@ class FeatureExtractor(nn.Module):
                 features = self.activation_function(features)
             return features
         else:
-            return jnp.zeros(0, )
+            return jnp.zeros(
+                0,
+            )
+
 
 class VariationalEncoderRNNNetwork(nn.Module):
     """
@@ -73,6 +80,7 @@ class VariationalEncoderRNNNetwork(nn.Module):
         layer_after_rnn: int, dimension of the layer after the RNN
         latent_dim: int, dimension of the latent space
     """
+
     state_embed_dim: int
     action_embed_dim: int
     reward_embed_dim: int
@@ -143,9 +151,19 @@ class VariationalEncoderRNNNetwork(nn.Module):
         # Latent space for the mental state
         latent_mean_t = nn.Dense(self.latent_dim)(embedding)
         latent_logvar_t = nn.Dense(self.latent_dim)(embedding)
-        latent_sample_t = sample_gaussian(latent_mean_t, latent_logvar_t, mental_state_key)
+        latent_sample_t = sample_gaussian(
+            latent_mean_t, latent_logvar_t, mental_state_key
+        )
 
-        return hidden, (latent_sample, latent_mean, latent_logvar, latent_sample_t, latent_mean_t, latent_logvar_t)
+        return hidden, (
+            latent_sample,
+            latent_mean,
+            latent_logvar,
+            latent_sample_t,
+            latent_mean_t,
+            latent_logvar_t,
+        )
+
 
 class DecoderRNNNetwork(nn.Module):
     """
@@ -159,6 +177,7 @@ class DecoderRNNNetwork(nn.Module):
         num_elbo_subsamples: int, number of start indices subsampled for the
             reconstruction term (0 = use all H-1 starts)
     """
+
     state_embed_dim: int
     agent_character_embed_dim: int
     hidden_dim: int
@@ -190,7 +209,18 @@ class DecoderRNNNetwork(nn.Module):
             recon_loss: jnp.array, reconstruction loss (negative log likelihood of partner actions)
         """
         # Shapes are (time, batch, dim), except partner_actions and dones which are (time, batch)
-        state, latent_mean, latent_logvar, latent_mean_t, latent_logvar_t, agent_character, mental_state, partner_actions, dones, prng_key = x
+        (
+            state,
+            latent_mean,
+            latent_logvar,
+            latent_mean_t,
+            latent_logvar_t,
+            agent_character,
+            mental_state,
+            partner_actions,
+            dones,
+            prng_key,
+        ) = x
 
         # Compute KL divergence
         latent_mean_all = jnp.concatenate((latent_mean, latent_mean_t), axis=-1)
@@ -198,27 +228,40 @@ class DecoderRNNNetwork(nn.Module):
 
         gauss_dim = latent_mean_all.shape[-1]
         # add the gaussian prior
-        all_means = jnp.concatenate((jnp.zeros((1, *latent_mean_all.shape[1:])), latent_mean_all))
-        all_logvars = jnp.concatenate((jnp.zeros((1, *latent_logvar_all.shape[1:])), latent_logvar_all))
+        all_means = jnp.concatenate(
+            (jnp.zeros((1, *latent_mean_all.shape[1:])), latent_mean_all)
+        )
+        all_logvars = jnp.concatenate(
+            (jnp.zeros((1, *latent_logvar_all.shape[1:])), latent_logvar_all)
+        )
         # https://arxiv.org/pdf/1811.09975.pdf
         # KL(N(mu,E)||N(m,S)) = 0.5 * (log(|S|/|E|) - K + tr(S^-1 E) + (m-mu)^T S^-1 (m-mu)))
         mu = all_means[1:]
         m = all_means[:-1]
         logE = all_logvars[1:]
         logS = all_logvars[:-1]
-        kl_loss = 0.5 * (jnp.sum(logS, axis=-1) - jnp.sum(logE, axis=-1) - gauss_dim + jnp.sum(
-            1 / jnp.exp(logS) * jnp.exp(logE), axis=-1) + ((m - mu) / jnp.exp(logS) * (m - mu)).sum(axis=-1))
+        kl_loss = 0.5 * (
+            jnp.sum(logS, axis=-1)
+            - jnp.sum(logE, axis=-1)
+            - gauss_dim
+            + jnp.sum(1 / jnp.exp(logS) * jnp.exp(logE), axis=-1)
+            + ((m - mu) / jnp.exp(logS) * (m - mu)).sum(axis=-1)
+        )
         # Sum over time, mean over batch so DECODER_KL_WEIGHT is invariant to minibatch size
         kl_loss = kl_loss.sum(axis=0).mean()
 
         # MeLIBA decoder
         # Embed inputs
         state_embed = FeatureExtractor(self.state_embed_dim, nn.relu)(state)
-        agent_character_embed = FeatureExtractor(self.agent_character_embed_dim, nn.relu)(agent_character)
+        agent_character_embed = FeatureExtractor(
+            self.agent_character_embed_dim, nn.relu
+        )(agent_character)
 
         # Contruct state_agent_embedding
         # Combine state_embed and agent_character_embed
-        state_agent_embed = jnp.concatenate((state_embed, agent_character_embed), axis=-1)
+        state_agent_embed = jnp.concatenate(
+            (state_embed, agent_character_embed), axis=-1
+        )
         state_agent_embed = nn.Dense(self.hidden_dim)(state_agent_embed)
 
         # Construct initial hidden states for the RNN
@@ -233,21 +276,28 @@ class DecoderRNNNetwork(nn.Module):
         if self.num_elbo_subsamples > 0 and self.num_elbo_subsamples < H_time - 1:
             stratum_width = (H_time - 1) / self.num_elbo_subsamples
             strata = jnp.arange(self.num_elbo_subsamples) * stratum_width
-            offsets = jax.random.uniform(
-                prng_key, (batch_size, self.num_elbo_subsamples)) * stratum_width
+            offsets = (
+                jax.random.uniform(prng_key, (batch_size, self.num_elbo_subsamples))
+                * stratum_width
+            )
             start_indices = jnp.floor(strata + offsets).astype(jnp.int32)
             recon_scale = (H_time - 1) / self.num_elbo_subsamples
         else:
             if self.num_elbo_subsamples > 0 and H_time > 1:
                 warnings.warn(
                     f"num_elbo_subsamples={self.num_elbo_subsamples} >= H-1={H_time - 1}; "
-                    "falling back to the exact O(H^2) reconstruction over all starts.")
-            start_indices = jnp.broadcast_to(jnp.arange(H_time - 1), (batch_size, H_time - 1))
+                    "falling back to the exact O(H^2) reconstruction over all starts."
+                )
+            start_indices = jnp.broadcast_to(
+                jnp.arange(H_time - 1), (batch_size, H_time - 1)
+            )
             recon_scale = 1.0
 
         # The batch dimension is the second dimension, we want to vmap over that.
         # The batch refers to the different env instances.
-        def handle_batch(state_agent_embed, hidden, dones, partner_actions, start_indices):
+        def handle_batch(
+            state_agent_embed, hidden, dones, partner_actions, start_indices
+        ):
             """
             vmap over the batch dimension.
 
@@ -265,10 +315,24 @@ class DecoderRNNNetwork(nn.Module):
                 actions summed over start indices
             """
             # Construct k trajectories
-            k_state_agent_embed, valid_mask = transform_timestep_to_k_batch(state_agent_embed, pad_value=0.0, return_mask=True, start_indices=start_indices)
-            k_hidden = transform_timestep_to_k_batch(hidden, pad_value=0.0, return_mask=False, start_indices=start_indices)
-            k_dones = transform_timestep_to_k_batch(dones, pad_value=0.0, return_mask=False, start_indices=start_indices)
-            k_partner_actions = transform_timestep_to_k_batch(partner_actions, pad_value=0.0, return_mask=False, start_indices=start_indices)
+            k_state_agent_embed, valid_mask = transform_timestep_to_k_batch(
+                state_agent_embed,
+                pad_value=0.0,
+                return_mask=True,
+                start_indices=start_indices,
+            )
+            k_hidden = transform_timestep_to_k_batch(
+                hidden, pad_value=0.0, return_mask=False, start_indices=start_indices
+            )
+            k_dones = transform_timestep_to_k_batch(
+                dones, pad_value=0.0, return_mask=False, start_indices=start_indices
+            )
+            k_partner_actions = transform_timestep_to_k_batch(
+                partner_actions,
+                pad_value=0.0,
+                return_mask=False,
+                start_indices=start_indices,
+            )
             k_partner_actions = jnp.squeeze(k_partner_actions, axis=-1)
 
             # Mask to only consider elements belonging to the window's first episode.
@@ -300,7 +364,9 @@ class DecoderRNNNetwork(nn.Module):
                 Returns:
                     out: jnp.array, shape (time, output_dim), logits for partner actions"""
                 rnn_in = (jnp.expand_dims(state_agent_embed, axis=1), hidden, dones)
-                _, embedding = DecoderScannedRNN()(jnp.expand_dims(hidden[0], axis=0), rnn_in)
+                _, embedding = DecoderScannedRNN()(
+                    jnp.expand_dims(hidden[0], axis=0), rnn_in
+                )
 
                 # Squeeze the batch dimension
                 out = nn.Dense(self.output_dim)(embedding)
@@ -329,15 +395,32 @@ class DecoderRNNNetwork(nn.Module):
             return log_prob_sum
 
         vmap_handle_batch = jax.vmap(handle_batch, (1, 1, 1, 1, 0), 1)
-        recon_loss = vmap_handle_batch(state_agent_embed, hidden, jnp.expand_dims(dones, axis=-1), jnp.expand_dims(partner_actions, axis=-1), start_indices)
+        recon_loss = vmap_handle_batch(
+            state_agent_embed,
+            hidden,
+            jnp.expand_dims(dones, axis=-1),
+            jnp.expand_dims(partner_actions, axis=-1),
+            start_indices,
+        )
 
         return kl_loss, recon_loss
 
-class VariationalEncoderRNN():
+
+class VariationalEncoderRNN:
     """Model wrapper for EncoderRNNNetwork."""
 
-    def __init__(self, state_dim, action_dim, state_embed_dim, action_embed_dim, reward_embed_dim,
-                 rnn_hidden_dim, layers_before_rnn, layers_after_rnn, latent_dim):
+    def __init__(
+        self,
+        state_dim,
+        action_dim,
+        state_embed_dim,
+        action_embed_dim,
+        reward_embed_dim,
+        rnn_hidden_dim,
+        layers_before_rnn,
+        layers_after_rnn,
+        latent_dim,
+    ):
         """
         Args:
             state_dim: int, dimension of the state space
@@ -350,15 +433,21 @@ class VariationalEncoderRNN():
             layers_after_rnn: jnp.array, dimensions of the layers after LSTM
             latent_dim: int, dimension of the latent space
         """
-        self.model = VariationalEncoderRNNNetwork(state_embed_dim, action_embed_dim, reward_embed_dim,
-                                                  layers_before_rnn, layers_after_rnn, latent_dim)
+        self.model = VariationalEncoderRNNNetwork(
+            state_embed_dim,
+            action_embed_dim,
+            reward_embed_dim,
+            layers_before_rnn,
+            layers_after_rnn,
+            latent_dim,
+        )
         self.state_dim = state_dim
         self.action_dim = action_dim
         self.rnn_hidden_dim = rnn_hidden_dim
 
     def init_hstate(self, batch_size=1, aux_info=None):
         """Initialize hidden state for the encoder RNN."""
-        hstate =  ScannedRNN.initialize_carry(batch_size, self.rnn_hidden_dim)
+        hstate = ScannedRNN.initialize_carry(batch_size, self.rnn_hidden_dim)
         hstate = hstate.reshape(1, batch_size, self.rnn_hidden_dim)
         return hstate
 
@@ -390,23 +479,58 @@ class VariationalEncoderRNN():
         """Embed observations using the encoder model."""
         batch_size = state.shape[1]
 
-        new_hstate, (latent_sample, latent_mean, latent_logvar, latent_sample_t, latent_mean_t, latent_logvar_t) = self.model.apply(
-            params, hstate.squeeze(0), (state, act, reward, done, sample_key))
+        (
+            new_hstate,
+            (
+                latent_sample,
+                latent_mean,
+                latent_logvar,
+                latent_sample_t,
+                latent_mean_t,
+                latent_logvar_t,
+            ),
+        ) = self.model.apply(
+            params, hstate.squeeze(0), (state, act, reward, done, sample_key)
+        )
 
-        return latent_sample, latent_mean, latent_logvar, latent_sample_t, latent_mean_t, latent_logvar_t, new_hstate.reshape(1, batch_size, -1)
+        return (
+            latent_sample,
+            latent_mean,
+            latent_logvar,
+            latent_sample_t,
+            latent_mean_t,
+            latent_logvar_t,
+            new_hstate.reshape(1, batch_size, -1),
+        )
 
-class Decoder():
+
+class Decoder:
     """Model wrapper for DecoderNetwork."""
 
-    def __init__(self, state_dim, state_embed_dim, agent_character_embed_dim, latent_mean_dim, latent_logvar_dim,
-                 latent_mean_t_dim, latent_logvar_t_dim, agent_character_dim, mental_state_dim, partner_action_dim,
-                 hidden_dim, loss_coeff, kl_weight, num_elbo_subsamples=0):
+    def __init__(
+        self,
+        state_dim,
+        state_embed_dim,
+        agent_character_embed_dim,
+        latent_mean_dim,
+        latent_logvar_dim,
+        latent_mean_t_dim,
+        latent_logvar_t_dim,
+        agent_character_dim,
+        mental_state_dim,
+        partner_action_dim,
+        hidden_dim,
+        loss_coeff,
+        kl_weight,
+        num_elbo_subsamples=0,
+    ):
         self.model = DecoderRNNNetwork(
             state_embed_dim=state_embed_dim,
             agent_character_embed_dim=agent_character_embed_dim,
             hidden_dim=hidden_dim,
             output_dim=partner_action_dim,
-            num_elbo_subsamples=num_elbo_subsamples)
+            num_elbo_subsamples=num_elbo_subsamples,
+        )
 
         self.state_dim = state_dim
         self.state_embed_dim = state_embed_dim
@@ -437,24 +561,56 @@ class Decoder():
         dummy_partner_actions = jnp.zeros((1, batch_size))
         dummy_done = jnp.zeros((1, batch_size))
 
-        dummy_x = (dummy_state, dummy_latent_mean, dummy_latent_logvar, dummy_latent_mean_t,
-                   dummy_latent_logvar_t, dummy_agent_character, dummy_mental_state,
-                   dummy_partner_actions, dummy_done, jax.random.PRNGKey(0))
+        dummy_x = (
+            dummy_state,
+            dummy_latent_mean,
+            dummy_latent_logvar,
+            dummy_latent_mean_t,
+            dummy_latent_logvar_t,
+            dummy_agent_character,
+            dummy_mental_state,
+            dummy_partner_actions,
+            dummy_done,
+            jax.random.PRNGKey(0),
+        )
 
         # Initialize model
         return self.model.init(prng, dummy_x)
 
     @functools.partial(jax.jit, static_argnums=(0,))
-    def compute_losses(self, params, state, latent_mean, latent_logvar, latent_mean_t, latent_logvar_t,
-                       agent_character, mental_state, partner_action, done, rng):
-
+    def compute_losses(
+        self,
+        params,
+        state,
+        latent_mean,
+        latent_logvar,
+        latent_mean_t,
+        latent_logvar_t,
+        agent_character,
+        mental_state,
+        partner_action,
+        done,
+        rng,
+    ):
         """Evaluate the decoder model with given parameters and inputs."""
-        kl_loss, recon_loss = self.model.apply(params, (state, latent_mean, latent_logvar,
-                                                           latent_mean_t, latent_logvar_t,
-                                                           agent_character, mental_state,
-                                                           partner_action, done, rng))
+        kl_loss, recon_loss = self.model.apply(
+            params,
+            (
+                state,
+                latent_mean,
+                latent_logvar,
+                latent_mean_t,
+                latent_logvar_t,
+                agent_character,
+                mental_state,
+                partner_action,
+                done,
+                rng,
+            ),
+        )
 
         return kl_loss, recon_loss.mean()
+
 
 def initialize_meliba_encoder_decoder(config, env, rng):
     """Initialize the Encoder and Decoder models with the given config.
@@ -472,14 +628,15 @@ def initialize_meliba_encoder_decoder(config, env, rng):
     # TODO: Should be the state instead of obs
     encoder = VariationalEncoderRNN(
         state_dim=env.observation_space(env.agents[0]).shape[0],
-        action_dim=env.action_space(env.agents[0]).n + env.action_space(env.agents[1]).n,
+        action_dim=env.action_space(env.agents[0]).n
+        + env.action_space(env.agents[1]).n,
         state_embed_dim=config.get("ENCODER_STATE_EMBED_DIM", 64),
         action_embed_dim=config.get("ENCODER_ACTION_EMBED_DIM", 64),
         reward_embed_dim=config.get("ENCODER_REWARD_EMBED_DIM", 64),
         rnn_hidden_dim=config.get("ENCODER_RNN_HIDDEN_DIM", 64),
         layers_before_rnn=config.get("ENCODER_LAYERS_BEFORE_RNN", 64),
         layers_after_rnn=config.get("ENCODER_LAYERS_AFTER_RNN", 64),
-        latent_dim=config.get("ENCODER_LATENT_DIM", 64)
+        latent_dim=config.get("ENCODER_LATENT_DIM", 64),
     )
 
     # TODO: Should be the state instead of obs
@@ -497,14 +654,19 @@ def initialize_meliba_encoder_decoder(config, env, rng):
         hidden_dim=config.get("DECODER_HIDDEN_DIM", 64),
         loss_coeff=config.get("DECODER_LOSS_COEFF", 1.0),
         kl_weight=config.get("DECODER_KL_WEIGHT", 0.05),
-        num_elbo_subsamples=int(config.get("DECODER_NUM_ELBO_SAMPLES", 0))
+        num_elbo_subsamples=int(config.get("DECODER_NUM_ELBO_SAMPLES", 0)),
     )
 
-    rng, init_rng_encoder, init_rng_decoder  = jax.random.split(rng, 3)
+    rng, init_rng_encoder, init_rng_decoder = jax.random.split(rng, 3)
     init_params_encoder = encoder.init_params(init_rng_encoder)
     init_params_decoder = decoder.init_params(init_rng_decoder)
 
-    return encoder, decoder, {'encoder': init_params_encoder, 'decoder': init_params_decoder}
+    return (
+        encoder,
+        decoder,
+        {"encoder": init_params_encoder, "decoder": init_params_decoder},
+    )
+
 
 class MeLIBAPolicy(AgentPolicy):
     """MeLIBA inference policy that uses an encoder and decoder to model partner behavior."""
@@ -533,8 +695,12 @@ class MeLIBAPolicy(AgentPolicy):
         Returns:
             hstate: tuple of (encoder_hstate, policy_hstate)
         """
-        encoder_hstate = self.encoder.init_hstate(batch_size=batch_size, aux_info=aux_info)
-        policy_hstate = self.policy.init_hstate(batch_size=batch_size, aux_info=aux_info)
+        encoder_hstate = self.encoder.init_hstate(
+            batch_size=batch_size, aux_info=aux_info
+        )
+        policy_hstate = self.policy.init_hstate(
+            batch_size=batch_size, aux_info=aux_info
+        )
         return (encoder_hstate, policy_hstate)
 
     def init_params(self, rng):
@@ -547,15 +713,31 @@ class MeLIBAPolicy(AgentPolicy):
         Returns:
             params: dict, containing encoder and policy parameters
         """
-        rng, init_rng_encoder, init_rng_decoder, init_rng_policy  = jax.random.split(rng, 4)
+        rng, init_rng_encoder, init_rng_decoder, init_rng_policy = jax.random.split(
+            rng, 4
+        )
         encoder_params = self.encoder.init_params(init_rng_encoder)
         decoder_params = self.decoder.init_params(init_rng_decoder)
         policy_params = self.policy.init_params(init_rng_policy)
-        return {'encoder': encoder_params, 'decoder': decoder_params, 'policy': policy_params}
+        return {
+            "encoder": encoder_params,
+            "decoder": decoder_params,
+            "policy": policy_params,
+        }
 
     @partial(jax.jit, static_argnums=(0,))
-    def get_action(self, params, obs, done, avail_actions, hstate, rng,
-                   aux_obs=None, env_state=None, test_mode=False):
+    def get_action(
+        self,
+        params,
+        obs,
+        done,
+        avail_actions,
+        hstate,
+        rng,
+        aux_obs=None,
+        env_state=None,
+        test_mode=False,
+    ):
         """
         Get actions for the MeLIBA policy.
 
@@ -580,35 +762,55 @@ class MeLIBAPolicy(AgentPolicy):
         """
         _, joint_act, reward = aux_obs
 
-        rng, policy_rng, sample_key  = jax.random.split(rng, 3)
+        rng, policy_rng, sample_key = jax.random.split(rng, 3)
 
-        _, latent_mean, latent_logvar, _, latent_mean_t, latent_logvar_t, new_encoder_hstate = self.encoder.compute_embedding(
-            params=params['encoder'],
-            hstate=hstate[0], # Encoder hidden state
+        (
+            _,
+            latent_mean,
+            latent_logvar,
+            _,
+            latent_mean_t,
+            latent_logvar_t,
+            new_encoder_hstate,
+        ) = self.encoder.compute_embedding(
+            params=params["encoder"],
+            hstate=hstate[0],  # Encoder hidden state
             state=obs,
             act=joint_act,
             reward=reward,
             done=done,
-            sample_key=sample_key
+            sample_key=sample_key,
         )
 
         action, new_policy_hstate = self.policy.get_action(
-            params=params['policy'],
-            obs=jnp.concatenate((obs, latent_mean, latent_logvar, latent_mean_t, latent_logvar_t), axis=-1),
+            params=params["policy"],
+            obs=jnp.concatenate(
+                (obs, latent_mean, latent_logvar, latent_mean_t, latent_logvar_t),
+                axis=-1,
+            ),
             done=done,
             avail_actions=avail_actions,
-            hstate=hstate[1], # Policy hidden state
+            hstate=hstate[1],  # Policy hidden state
             rng=policy_rng,
             aux_obs=aux_obs,
             env_state=env_state,
-            test_mode=test_mode
+            test_mode=test_mode,
         )
 
         return action, (new_encoder_hstate, new_policy_hstate)
 
     @partial(jax.jit, static_argnums=(0,))
-    def get_action_value_policy(self, params, obs, done, avail_actions, hstate, rng,
-                                aux_obs=None, env_state=None):
+    def get_action_value_policy(
+        self,
+        params,
+        obs,
+        done,
+        avail_actions,
+        hstate,
+        rng,
+        aux_obs=None,
+        env_state=None,
+    ):
         """
         Get actions, values, and policy for the MeLIBA policy.
 
@@ -634,34 +836,55 @@ class MeLIBAPolicy(AgentPolicy):
         """
         _, joint_act, reward = aux_obs
 
-        rng, policy_rng, sample_key  = jax.random.split(rng, 3)
+        rng, policy_rng, sample_key = jax.random.split(rng, 3)
 
-        _, latent_mean, latent_logvar, _, latent_mean_t, latent_logvar_t, new_encoder_hstate = self.encoder.compute_embedding(
-            params=params['encoder'],
-            hstate=hstate[0], # Encoder hidden state
+        (
+            _,
+            latent_mean,
+            latent_logvar,
+            _,
+            latent_mean_t,
+            latent_logvar_t,
+            new_encoder_hstate,
+        ) = self.encoder.compute_embedding(
+            params=params["encoder"],
+            hstate=hstate[0],  # Encoder hidden state
             state=obs,
             act=joint_act,
             reward=reward,
             done=done,
-            sample_key=sample_key
+            sample_key=sample_key,
         )
 
         action, val, pi, new_policy_hstate = self.policy.get_action_value_policy(
-            params=params['policy'],
-            obs=jnp.concatenate((obs, latent_mean, latent_logvar, latent_mean_t, latent_logvar_t), axis=-1),
+            params=params["policy"],
+            obs=jnp.concatenate(
+                (obs, latent_mean, latent_logvar, latent_mean_t, latent_logvar_t),
+                axis=-1,
+            ),
             done=done,
             avail_actions=avail_actions,
-            hstate=hstate[1], # Policy hidden state
+            hstate=hstate[1],  # Policy hidden state
             rng=policy_rng,
             aux_obs=aux_obs,
-            env_state=env_state
+            env_state=env_state,
         )
 
         return action, val, pi, (new_encoder_hstate, new_policy_hstate)
 
     @partial(jax.jit, static_argnums=(0,))
-    def compute_decoder_losses(self, params, obs, done, avail_actions, hstate, rng,
-                               partner_action, aux_obs=None, env_state=None):
+    def compute_decoder_losses(
+        self,
+        params,
+        obs,
+        done,
+        avail_actions,
+        hstate,
+        rng,
+        partner_action,
+        aux_obs=None,
+        env_state=None,
+    ):
         """
         Get actions, values, policy, and decoder reconstructions for the MeLIBA policy.
 
@@ -692,30 +915,54 @@ class MeLIBAPolicy(AgentPolicy):
 
         rng, policy_rng, sample_key, decoder_rng = jax.random.split(rng, 4)
 
-        latent_sample, latent_mean, latent_logvar, latent_sample_t, latent_mean_t, latent_logvar_t, new_encoder_hstate = self.encoder.compute_embedding(
-            params=params['encoder'],
-            hstate=hstate[0], # Encoder hidden state
+        (
+            latent_sample,
+            latent_mean,
+            latent_logvar,
+            latent_sample_t,
+            latent_mean_t,
+            latent_logvar_t,
+            new_encoder_hstate,
+        ) = self.encoder.compute_embedding(
+            params=params["encoder"],
+            hstate=hstate[0],  # Encoder hidden state
             state=obs,
             act=joint_act,
             reward=jnp.expand_dims(reward, axis=-1),
             done=done,
-            sample_key=sample_key
+            sample_key=sample_key,
         )
 
         action, val, pi, new_policy_hstate = self.policy.get_action_value_policy(
-            params=params['policy'],
-            obs=jnp.concatenate((obs, jax.lax.stop_gradient(jnp.concatenate((latent_mean, latent_logvar, latent_mean_t, latent_logvar_t), axis=-1))), axis=-1),
+            params=params["policy"],
+            obs=jnp.concatenate(
+                (
+                    obs,
+                    jax.lax.stop_gradient(
+                        jnp.concatenate(
+                            (
+                                latent_mean,
+                                latent_logvar,
+                                latent_mean_t,
+                                latent_logvar_t,
+                            ),
+                            axis=-1,
+                        )
+                    ),
+                ),
+                axis=-1,
+            ),
             done=done,
             avail_actions=avail_actions,
-            hstate=hstate[1], # Policy hidden state
+            hstate=hstate[1],  # Policy hidden state
             rng=policy_rng,
             aux_obs=aux_obs,
-            env_state=env_state
+            env_state=env_state,
         )
 
         # Reconstruction Loss
         kl_loss, recon_loss = self.decoder.compute_losses(
-            params=params['decoder'],
+            params=params["decoder"],
             state=obs,
             latent_mean=latent_mean,
             latent_logvar=latent_logvar,
@@ -725,7 +972,14 @@ class MeLIBAPolicy(AgentPolicy):
             mental_state=latent_sample_t,
             partner_action=partner_action,
             done=done,
-            rng=decoder_rng
+            rng=decoder_rng,
         )
 
-        return action, val, pi, kl_loss, recon_loss, (new_encoder_hstate, new_policy_hstate)
+        return (
+            action,
+            val,
+            pi,
+            kl_loss,
+            recon_loss,
+            (new_encoder_hstate, new_policy_hstate),
+        )

--- a/agents/meliba_agent.py
+++ b/agents/meliba_agent.py
@@ -271,8 +271,16 @@ class DecoderRNNNetwork(nn.Module):
             k_partner_actions = transform_timestep_to_k_batch(partner_actions, pad_value=0.0, return_mask=False, start_indices=start_indices)
             k_partner_actions = jnp.squeeze(k_partner_actions, axis=-1)
 
-            # Mask to only consider elements before the first done
-            episode_mask = fill_to_first_true(jnp.squeeze(k_dones, axis=-1))
+            # Mask to only consider elements belonging to the window's first episode.
+            # `dones` carries pre-step (prev) dones: a True at position j marks a reset
+            # *before* step j, i.e. step j starts a new episode. A True at position 0
+            # marks a reset into the window's first step, not a boundary within the
+            # window, so ignore it; steps strictly before the first later True belong
+            # to the same episode (this includes the terminal step, matching the old
+            # post-step-done masking).
+            k_dones_sq = jnp.squeeze(k_dones, axis=-1)
+            boundaries = k_dones_sq.at[:, 0].set(0)
+            episode_mask = jnp.cumsum(boundaries, axis=1) == 0
 
             def handle_k_trajectories(state_agent_embed, hidden, dones):
                 """

--- a/ego_agent_training/liam_ego.py
+++ b/ego_agent_training/liam_ego.py
@@ -207,6 +207,7 @@ def train_liam_ego_agent(config, env, train_rng,
                     prev_action_onehot=act_onehot["agent_0"],
                     partner_obs=prev_obs["agent_1"],
                     partner_action_onehot=env_act_onehot["agent_1"],
+                    prev_done=prev_done["agent_0"],
                 )
                 new_runner_state = (train_state, encoder_decoder_train_state, env_state_next, obs_next, done_next, env_act_onehot,
                                     new_ego_hstate, new_partner_hstate, updated_partner_indices, rng)
@@ -248,7 +249,7 @@ def train_liam_ego_agent(config, env, train_rng,
                                 "decoder": encoder_decoder_params["decoder"],
                                 "policy": params},
                         obs=traj_batch.obs,
-                        done=traj_batch.done,
+                        done=traj_batch.prev_done,
                         avail_actions=traj_batch.avail_actions,
                         hstate=init_ego_hstate,
                         rng=jax.random.PRNGKey(0), # only used for action sampling, which is unused here

--- a/ego_agent_training/liam_ego.py
+++ b/ego_agent_training/liam_ego.py
@@ -1,4 +1,4 @@
-'''
+"""
 Script for training a LIAM ego agent against a population of homogeneous partner agents.
 
 
@@ -16,39 +16,45 @@ python ego_agent_training/run.py algorithm=liam_ego/lbf/lbf_7x7_nolevels task=lb
 Suggested debug command:
 
 python ego_agent_training/run.py algorithm=liam_ego/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels logger.mode=disabled label=debug algorithm.TOTAL_TIMESTEPS=1e5
-'''
+"""
+
+import logging
 import shutil
 import time
-import logging
 
+import hydra
 import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
-import hydra
 from flax.training.train_state import TrainState
 
 from agents.initialize_agents import initialize_liam_agent
 from agents.population_interface import AgentPopulation
+from common.agent_loader_from_config import initialize_rl_agent_from_config
+from common.plot_utils import get_metric_names, get_stats
 from common.run_episodes import run_episodes
-from common.plot_utils import get_stats, get_metric_names
 from common.save_load_utils import save_train_run
+from ego_agent_training.liam_utils import Transition
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from common.agent_loader_from_config import initialize_rl_agent_from_config
 from marl.ppo_utils import _create_minibatches, unbatchify
-from ego_agent_training.liam_utils import Transition
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-def train_liam_ego_agent(config, env, train_rng,
-                        ego_policy, init_ego_params, n_ego_train_seeds,
-                        partner_population: AgentPopulation,
-                        partner_params
-                        ):
-    '''
+def train_liam_ego_agent(
+    config,
+    env,
+    train_rng,
+    ego_policy,
+    init_ego_params,
+    n_ego_train_seeds,
+    partner_population: AgentPopulation,
+    partner_params,
+):
+    """
     Train LIAM ego agent using the given partner checkpoints and initial ego parameters.
 
     Args:
@@ -61,7 +67,7 @@ def train_liam_ego_agent(config, env, train_rng,
         init_encoder_decoder_params: dict, initial parameters for the encoder and decoder
         partner_population: AgentPopulation, population of partner agents
         partner_params: pytree of parameters for the population of agents of shape (pop_size, ...).
-    '''
+    """
     # Get partner parameters from the population
     num_total_partners = partner_population.pop_size
 
@@ -69,21 +75,35 @@ def train_liam_ego_agent(config, env, train_rng,
     # Build the LIAM training function
     # ------------------------------
     def make_liam_train(config):
-        '''agent 0 is the ego agent while agent 1 is the confederate'''
+        """agent 0 is the ego agent while agent 1 is the confederate"""
         num_agents = env.num_agents
         assert num_agents == 2, "This snippet assumes exactly 2 agents."
 
         config["NUM_ACTORS"] = env.num_agents * config["NUM_ENVS"]
-        config["NUM_UNCONTROLLED_ACTORS"] = config["NUM_ENVS"] # assumption: we control 1 agent
-        config["NUM_CONTROLLED_ACTORS"] = config["NUM_ENVS"] # assumption: we control 1 agent
-        config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // config["ROLLOUT_LENGTH"] // config["NUM_ENVS"]
+        config["NUM_UNCONTROLLED_ACTORS"] = config[
+            "NUM_ENVS"
+        ]  # assumption: we control 1 agent
+        config["NUM_CONTROLLED_ACTORS"] = config[
+            "NUM_ENVS"
+        ]  # assumption: we control 1 agent
+        config["NUM_UPDATES"] = (
+            config["TOTAL_TIMESTEPS"] // config["ROLLOUT_LENGTH"] // config["NUM_ENVS"]
+        )
 
         config["NUM_ACTIONS"] = env.action_space(env.agents[0]).n
-        assert config["NUM_CONTROLLED_ACTORS"] % config["NUM_MINIBATCHES"] == 0, "NUM_CONTROLLED_ACTORS must be divisible by NUM_MINIBATCHES"
-        assert config["NUM_CONTROLLED_ACTORS"] >= config["NUM_MINIBATCHES"], "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        assert config["NUM_CONTROLLED_ACTORS"] % config["NUM_MINIBATCHES"] == 0, (
+            "NUM_CONTROLLED_ACTORS must be divisible by NUM_MINIBATCHES"
+        )
+        assert config["NUM_CONTROLLED_ACTORS"] >= config["NUM_MINIBATCHES"], (
+            "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        )
 
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng):
@@ -100,7 +120,7 @@ def train_liam_ego_agent(config, env, train_rng,
 
             train_state = TrainState.create(
                 apply_fn=ego_policy.policy.network.apply,
-                params=init_ego_params['policy'],
+                params=init_ego_params["policy"],
                 tx=tx,
             )
 
@@ -111,13 +131,18 @@ def train_liam_ego_agent(config, env, train_rng,
 
             encoder_decoder_train_state = TrainState.create(
                 apply_fn=ego_policy.encoder.model.apply,
-                params={'encoder': init_ego_params['encoder'], 'decoder': init_ego_params['decoder']},
+                params={
+                    "encoder": init_ego_params["encoder"],
+                    "decoder": init_ego_params["decoder"],
+                },
                 tx=encoder_decoder_tx,
             )
 
             #  Init ego and partner hstates
             init_ego_hstate = ego_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
-            init_partner_hstate = partner_population.init_hstate(config["NUM_UNCONTROLLED_ACTORS"])
+            init_partner_hstate = partner_population.init_hstate(
+                config["NUM_UNCONTROLLED_ACTORS"]
+            )
 
             def _env_step(runner_state, unused):
                 """
@@ -126,39 +151,64 @@ def train_liam_ego_agent(config, env, train_rng,
                 2. Step environment using sampled actions
                 3. Return state, reward, ...
                 """
-                train_state, encoder_decoder_train_state, env_state, prev_obs, prev_done, act_onehot, ego_hstate, partner_hstate, partner_indices, rng = runner_state
+                (
+                    train_state,
+                    encoder_decoder_train_state,
+                    env_state,
+                    prev_obs,
+                    prev_done,
+                    act_onehot,
+                    ego_hstate,
+                    partner_hstate,
+                    partner_indices,
+                    rng,
+                ) = runner_state
                 rng, actor_rng, partner_rng, step_rng = jax.random.split(rng, 4)
 
-                 # Get available actions for agent 0 from environment state
+                # Get available actions for agent 0 from environment state
                 avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)
                 avail_actions = jax.lax.stop_gradient(avail_actions)
                 avail_actions_0 = avail_actions["agent_0"].astype(jnp.float32)
                 avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
                 # Conditionally resample partners based on prev_done["__all__"]
-                needs_resample = prev_done["__all__"] # shape (NUM_ENVS,) bool
-                sampled_indices_all = partner_population.sample_agent_indices(config["NUM_CONTROLLED_ACTORS"], partner_rng)
+                needs_resample = prev_done["__all__"]  # shape (NUM_ENVS,) bool
+                sampled_indices_all = partner_population.sample_agent_indices(
+                    config["NUM_CONTROLLED_ACTORS"], partner_rng
+                )
 
                 # Determine final indices based on whether resampling was needed for each env
                 updated_partner_indices = jnp.where(
-                    needs_resample,         # Mask shape (NUM_ENVS,)
-                    sampled_indices_all,    # Use newly sampled index if True
-                    partner_indices         # Else, keep index from previous step
+                    needs_resample,  # Mask shape (NUM_ENVS,)
+                    sampled_indices_all,  # Use newly sampled index if True
+                    partner_indices,  # Else, keep index from previous step
                 )
                 # Note that we do not need to reset the hidden states for both the ego and partner agents
                 # as the recurrent states are automatically reset when done is True, and the partner indices are only reset when done is True.
 
                 # Agent_0 (ego) action, value, log_prob
                 act_0, val_0, pi_0, new_ego_hstate = ego_policy.get_action_value_policy(
-                    params={"encoder": encoder_decoder_train_state.params["encoder"],
-                            "decoder": encoder_decoder_train_state.params["decoder"],
-                            "policy": train_state.params},
-                    obs=prev_obs["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=prev_done["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
+                    params={
+                        "encoder": encoder_decoder_train_state.params["encoder"],
+                        "decoder": encoder_decoder_train_state.params["decoder"],
+                        "policy": train_state.params,
+                    },
+                    obs=prev_obs["agent_0"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"], -1
+                    ),
+                    done=prev_done["agent_0"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"]
+                    ),
                     avail_actions=avail_actions_0,
                     hstate=ego_hstate,
                     rng=actor_rng,
-                    aux_obs=(act_onehot["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1), None, None)
+                    aux_obs=(
+                        act_onehot["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"], -1
+                        ),
+                        None,
+                        None,
+                    ),
                 )
                 logp_0 = pi_0.log_prob(act_0)
 
@@ -171,26 +221,35 @@ def train_liam_ego_agent(config, env, train_rng,
                     partner_params,
                     updated_partner_indices,
                     prev_obs["agent_1"].reshape(config["NUM_CONTROLLED_ACTORS"], 1, -1),
-                    prev_done["agent_1"].reshape(config["NUM_CONTROLLED_ACTORS"], 1, -1),
+                    prev_done["agent_1"].reshape(
+                        config["NUM_CONTROLLED_ACTORS"], 1, -1
+                    ),
                     avail_actions_1,
                     partner_hstate,
                     partner_rng,
                     env_state=env_state,
-                    aux_obs=None
+                    aux_obs=None,
                 )
                 act_1 = act_1.squeeze()
 
                 # Combine actions into the env format
-                combined_actions = jnp.concatenate([act_0, act_1], axis=0)  # shape (2*num_envs,)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                combined_actions = jnp.concatenate(
+                    [act_0, act_1], axis=0
+                )  # shape (2*num_envs,)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
-                env_act_onehot = {k: jax.nn.one_hot(v.flatten(), env.action_space(env.agents[i]).n) for i, (k, v) in enumerate(env_act.items())}
+                env_act_onehot = {
+                    k: jax.nn.one_hot(v.flatten(), env.action_space(env.agents[i]).n)
+                    for i, (k, v) in enumerate(env_act.items())
+                }
 
                 # Step env
                 step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done_next, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state, env_act
-                )
+                obs_next, env_state_next, reward, done_next, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 # note that num_actors = num_envs * num_agents
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
 
@@ -209,8 +268,18 @@ def train_liam_ego_agent(config, env, train_rng,
                     partner_action_onehot=env_act_onehot["agent_1"],
                     prev_done=prev_done["agent_0"],
                 )
-                new_runner_state = (train_state, encoder_decoder_train_state, env_state_next, obs_next, done_next, env_act_onehot,
-                                    new_ego_hstate, new_partner_hstate, updated_partner_indices, rng)
+                new_runner_state = (
+                    train_state,
+                    encoder_decoder_train_state,
+                    env_state_next,
+                    obs_next,
+                    done_next,
+                    env_act_onehot,
+                    new_ego_hstate,
+                    new_partner_hstate,
+                    updated_partner_indices,
+                    rng,
+                )
                 return new_runner_state, transition
 
             def _calculate_gae(traj_batch, last_val):
@@ -241,91 +310,167 @@ def train_liam_ego_agent(config, env, train_rng,
             def _update_minbatch(init_state, batch_info):
                 train_state, encoder_decoder_train_state = init_state
                 init_ego_hstate, traj_batch, advantages, returns = batch_info
-                def _loss_fn(params, encoder_decoder_params, init_ego_hstate, traj_batch, gae, target_v):
+
+                def _loss_fn(
+                    params,
+                    encoder_decoder_params,
+                    init_ego_hstate,
+                    traj_batch,
+                    gae,
+                    target_v,
+                ):
 
                     # LIAM reconstruction losses
-                    _, value, pi, recon_loss1, recon_loss2, _ = ego_policy.compute_decoder_losses(
-                        params={"encoder": encoder_decoder_params["encoder"],
+                    _, value, pi, recon_loss1, recon_loss2, _ = (
+                        ego_policy.compute_decoder_losses(
+                            params={
+                                "encoder": encoder_decoder_params["encoder"],
                                 "decoder": encoder_decoder_params["decoder"],
-                                "policy": params},
-                        obs=traj_batch.obs,
-                        done=traj_batch.prev_done,
-                        avail_actions=traj_batch.avail_actions,
-                        hstate=init_ego_hstate,
-                        rng=jax.random.PRNGKey(0), # only used for action sampling, which is unused here
-                        aux_obs=(traj_batch.prev_action_onehot, None, None),
-                        modelled_agent_obs=traj_batch.partner_obs,
-                        modelled_agent_act=traj_batch.partner_action_onehot
+                                "policy": params,
+                            },
+                            obs=traj_batch.obs,
+                            done=traj_batch.prev_done,
+                            avail_actions=traj_batch.avail_actions,
+                            hstate=init_ego_hstate,
+                            rng=jax.random.PRNGKey(
+                                0
+                            ),  # only used for action sampling, which is unused here
+                            aux_obs=(traj_batch.prev_action_onehot, None, None),
+                            modelled_agent_obs=traj_batch.partner_obs,
+                            modelled_agent_act=traj_batch.partner_action_onehot,
+                        )
                     )
                     log_prob = pi.log_prob(traj_batch.action)
-                    recon_loss = (recon_loss1 + recon_loss2)
+                    recon_loss = recon_loss1 + recon_loss2
 
                     # Value loss
                     value_pred_clipped = traj_batch.value + (
                         value - traj_batch.value
-                        ).clip(
-                        -config["CLIP_EPS"], config["CLIP_EPS"])
+                    ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                     value_losses = jnp.square(value - target_v)
                     value_losses_clipped = jnp.square(value_pred_clipped - target_v)
-                    value_loss = (
-                        jnp.maximum(value_losses, value_losses_clipped).mean()
-                    )
+                    value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
 
                     # Policy gradient loss
                     ratio = jnp.exp(log_prob - traj_batch.log_prob)
                     gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                     pg_loss_1 = ratio * gae_norm
-                    pg_loss_2 = jnp.clip(
-                        ratio,
-                        1.0 - config["CLIP_EPS"],
-                        1.0 + config["CLIP_EPS"]) * gae_norm
+                    pg_loss_2 = (
+                        jnp.clip(
+                            ratio, 1.0 - config["CLIP_EPS"], 1.0 + config["CLIP_EPS"]
+                        )
+                        * gae_norm
+                    )
                     pg_loss = -jnp.mean(jnp.minimum(pg_loss_1, pg_loss_2))
 
                     # Entropy
                     entropy = jnp.mean(pi.entropy())
 
-                    total_loss = pg_loss + config["VF_COEF"] * value_loss - config["ENT_COEF"] * entropy + config["RECON_COEF"] * recon_loss
+                    total_loss = (
+                        pg_loss
+                        + config["VF_COEF"] * value_loss
+                        - config["ENT_COEF"] * entropy
+                        + config["RECON_COEF"] * recon_loss
+                    )
                     return total_loss, (value_loss, pg_loss, entropy, recon_loss)
 
-                grad_fn = jax.value_and_grad(_loss_fn, argnums=(0,1), has_aux=True)
+                grad_fn = jax.value_and_grad(_loss_fn, argnums=(0, 1), has_aux=True)
                 (loss_val, aux_vals), (grads, encoder_decoder_grads) = grad_fn(
-                    train_state.params, encoder_decoder_train_state.params, init_ego_hstate, traj_batch, advantages, returns)
+                    train_state.params,
+                    encoder_decoder_train_state.params,
+                    init_ego_hstate,
+                    traj_batch,
+                    advantages,
+                    returns,
+                )
                 # Phase A ablation knob. When FREEZE_ENCODER_DECODER=true the
                 # encoder-decoder weights stay at their random init and the
                 # policy keeps consuming that fixed embedding, which isolates
                 # encoder learning from the extra capacity / random-feature
                 # contribution of adding the encoder-decoder in the first place.
                 if config.get("FREEZE_ENCODER_DECODER", False):
-                    encoder_decoder_grads = jax.tree.map(jnp.zeros_like, encoder_decoder_grads)
+                    encoder_decoder_grads = jax.tree.map(
+                        jnp.zeros_like, encoder_decoder_grads
+                    )
                 train_state = train_state.apply_gradients(grads=grads)
-                encoder_decoder_train_state = encoder_decoder_train_state.apply_gradients(grads=encoder_decoder_grads)
+                encoder_decoder_train_state = (
+                    encoder_decoder_train_state.apply_gradients(
+                        grads=encoder_decoder_grads
+                    )
+                )
 
                 # compute average grad norm
-                grad_l2_norms = jax.tree.map(lambda g: jnp.linalg.norm(g.astype(jnp.float32)), grads)
+                grad_l2_norms = jax.tree.map(
+                    lambda g: jnp.linalg.norm(g.astype(jnp.float32)), grads
+                )
                 sum_of_grad_norms = jax.tree.reduce(lambda x, y: x + y, grad_l2_norms)
                 n_elements = len(jax.tree.leaves(grad_l2_norms))
                 avg_grad_norm = sum_of_grad_norms / n_elements
 
-                encoder_grad_l2_norms = jax.tree.map(lambda g: jnp.linalg.norm(g.astype(jnp.float32)), encoder_decoder_grads["encoder"])
-                encoder_sum_of_grad_norms = jax.tree.reduce(lambda x, y: x + y, encoder_grad_l2_norms)
+                encoder_grad_l2_norms = jax.tree.map(
+                    lambda g: jnp.linalg.norm(g.astype(jnp.float32)),
+                    encoder_decoder_grads["encoder"],
+                )
+                encoder_sum_of_grad_norms = jax.tree.reduce(
+                    lambda x, y: x + y, encoder_grad_l2_norms
+                )
                 encoder_n_elements = len(jax.tree.leaves(encoder_grad_l2_norms))
                 encoder_avg_grad_norm = encoder_sum_of_grad_norms / encoder_n_elements
 
-                decoder_grad_l2_norms = jax.tree.map(lambda g: jnp.linalg.norm(g.astype(jnp.float32)), encoder_decoder_grads["decoder"])
-                decoder_sum_of_grad_norms = jax.tree.reduce(lambda x, y: x + y, decoder_grad_l2_norms)
+                decoder_grad_l2_norms = jax.tree.map(
+                    lambda g: jnp.linalg.norm(g.astype(jnp.float32)),
+                    encoder_decoder_grads["decoder"],
+                )
+                decoder_sum_of_grad_norms = jax.tree.reduce(
+                    lambda x, y: x + y, decoder_grad_l2_norms
+                )
                 decoder_n_elements = len(jax.tree.leaves(decoder_grad_l2_norms))
                 decoder_avg_grad_norm = decoder_sum_of_grad_norms / decoder_n_elements
 
-                return (train_state, encoder_decoder_train_state), (loss_val, aux_vals, avg_grad_norm, encoder_avg_grad_norm, decoder_avg_grad_norm)
+                return (train_state, encoder_decoder_train_state), (
+                    loss_val,
+                    aux_vals,
+                    avg_grad_norm,
+                    encoder_avg_grad_norm,
+                    decoder_avg_grad_norm,
+                )
 
             def _update_epoch(update_state, unused):
-                train_state, encoder_decoder_train_state, init_ego_hstate, traj_batch, advantages, targets, rng = update_state
+                (
+                    train_state,
+                    encoder_decoder_train_state,
+                    init_ego_hstate,
+                    traj_batch,
+                    advantages,
+                    targets,
+                    rng,
+                ) = update_state
                 rng, perm_rng = jax.random.split(rng)
-                minibatches = _create_minibatches(traj_batch, advantages, targets, init_ego_hstate, config["NUM_CONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng)
-                (train_state, encoder_decoder_train_state), losses_and_grads = jax.lax.scan(
-                    _update_minbatch, (train_state, encoder_decoder_train_state), minibatches
+                minibatches = _create_minibatches(
+                    traj_batch,
+                    advantages,
+                    targets,
+                    init_ego_hstate,
+                    config["NUM_CONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng,
                 )
-                update_state = (train_state, encoder_decoder_train_state, init_ego_hstate, traj_batch, advantages, targets, rng)
+                (train_state, encoder_decoder_train_state), losses_and_grads = (
+                    jax.lax.scan(
+                        _update_minbatch,
+                        (train_state, encoder_decoder_train_state),
+                        minibatches,
+                    )
+                )
+                update_state = (
+                    train_state,
+                    encoder_decoder_train_state,
+                    init_ego_hstate,
+                    traj_batch,
+                    advantages,
+                    targets,
+                    rng,
+                )
                 return update_state, losses_and_grads
 
             def _update_step(update_runner_state, unused):
@@ -334,37 +479,84 @@ def train_liam_ego_agent(config, env, train_rng,
                 2. Compute advantage
                 3. LIAM updates
                 """
-                (train_state, encoder_decoder_train_state, rng, update_steps) = update_runner_state
+                (train_state, encoder_decoder_train_state, rng, update_steps) = (
+                    update_runner_state
+                )
 
                 # Init envs & partner indices
                 rng, reset_rng, p_rng = jax.random.split(rng, 3)
                 reset_rngs = jax.random.split(reset_rng, config["NUM_ENVS"])
                 init_obs, init_env_state = jax.vmap(env.reset, in_axes=(0,))(reset_rngs)
-                init_done = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
-                new_partner_indices = partner_population.sample_agent_indices(config["NUM_UNCONTROLLED_ACTORS"], p_rng)
-                init_act_onehot = {k: jnp.zeros((config["NUM_ENVS"], env.action_space(env.agents[i]).n)) for i, k in enumerate(env.agents)}
+                init_done = {
+                    k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                    for k in env.agents + ["__all__"]
+                }
+                new_partner_indices = partner_population.sample_agent_indices(
+                    config["NUM_UNCONTROLLED_ACTORS"], p_rng
+                )
+                init_act_onehot = {
+                    k: jnp.zeros(
+                        (config["NUM_ENVS"], env.action_space(env.agents[i]).n)
+                    )
+                    for i, k in enumerate(env.agents)
+                }
 
                 # 1) rollout
-                runner_state = (train_state, encoder_decoder_train_state, init_env_state, init_obs, init_done, init_act_onehot, init_ego_hstate, init_partner_hstate, new_partner_indices, rng)
+                runner_state = (
+                    train_state,
+                    encoder_decoder_train_state,
+                    init_env_state,
+                    init_obs,
+                    init_done,
+                    init_act_onehot,
+                    init_ego_hstate,
+                    init_partner_hstate,
+                    new_partner_indices,
+                    rng,
+                )
                 runner_state, traj_batch = jax.lax.scan(
-                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"])
-                (train_state, encoder_decoder_train_state, env_state, obs, done, act_onehot, ego_hstate, partner_hstate, partner_indices, rng) = runner_state
+                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    train_state,
+                    encoder_decoder_train_state,
+                    env_state,
+                    obs,
+                    done,
+                    act_onehot,
+                    ego_hstate,
+                    _partner_hstate,
+                    _partner_indices,
+                    rng,
+                ) = runner_state
 
                 # 2) advantage
                 # Get available actions for agent 0 from environment state
-                avail_actions_0 = jax.vmap(env.get_avail_actions)(env_state.env_state)["agent_0"].astype(jnp.float32)
+                avail_actions_0 = jax.vmap(env.get_avail_actions)(env_state.env_state)[
+                    "agent_0"
+                ].astype(jnp.float32)
 
                 # Get final value estimate for completed trajectory
                 _, last_val, _, _ = ego_policy.get_action_value_policy(
-                    params={"encoder": encoder_decoder_train_state.params["encoder"],
-                            "decoder": encoder_decoder_train_state.params["decoder"],
-                            "policy": train_state.params},
+                    params={
+                        "encoder": encoder_decoder_train_state.params["encoder"],
+                        "decoder": encoder_decoder_train_state.params["decoder"],
+                        "policy": train_state.params,
+                    },
                     obs=obs["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
                     done=done["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
                     avail_actions=jax.lax.stop_gradient(avail_actions_0),
                     hstate=ego_hstate,
-                    rng=jax.random.PRNGKey(0),  # Dummy key since we're just extracting the value
-                    aux_obs=(act_onehot["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1), None, None)
+                    rng=jax.random.PRNGKey(
+                        0
+                    ),  # Dummy key since we're just extracting the value
+                    aux_obs=(
+                        act_onehot["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"], -1
+                        ),
+                        None,
+                        None,
+                    ),
                 )
                 last_val = last_val.squeeze()
                 advantages, targets = _calculate_gae(traj_batch, last_val)
@@ -373,22 +565,31 @@ def train_liam_ego_agent(config, env, train_rng,
                 update_state = (
                     train_state,
                     encoder_decoder_train_state,
-                    init_ego_hstate, # (shape is (num_controlled_actors, encoder_hidden_dim) with all-0s value, shape is (num_controlled_actors, gru_hidden_dim) with all-0s value)
-                    traj_batch, # obs has shape (rollout_len, num_controlled_actors, -1)
+                    init_ego_hstate,  # (shape is (num_controlled_actors, encoder_hidden_dim) with all-0s value, shape is (num_controlled_actors, gru_hidden_dim) with all-0s value)
+                    traj_batch,  # obs has shape (rollout_len, num_controlled_actors, -1)
                     advantages,
                     targets,
-                    rng
+                    rng,
                 )
                 update_state, losses_and_grads = jax.lax.scan(
-                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                )
                 train_state = update_state[0]
                 encoder_decoder_train_state = update_state[1]
-                _, loss_terms, avg_grad_norm, encoder_avg_grad_norm, decoder_avg_grad_norm = losses_and_grads
+                (
+                    _,
+                    loss_terms,
+                    avg_grad_norm,
+                    encoder_avg_grad_norm,
+                    decoder_avg_grad_norm,
+                ) = losses_and_grads
 
                 def mask_and_mean(x, mask):
                     return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
-                
-                mask = traj_batch.info.get("returned_episode", jnp.ones_like(traj_batch.reward))
+
+                mask = traj_batch.info.get(
+                    "returned_episode", jnp.ones_like(traj_batch.reward)
+                )
                 metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch.info)
                 metric["update_steps"] = update_steps
                 metric["actor_loss"] = loss_terms[1].mean()
@@ -398,65 +599,97 @@ def train_liam_ego_agent(config, env, train_rng,
                 metric["avg_grad_norm"] = avg_grad_norm.mean()
                 metric["encoder_avg_grad_norm"] = encoder_avg_grad_norm.mean()
                 metric["decoder_avg_grad_norm"] = decoder_avg_grad_norm.mean()
-                new_runner_state = (train_state, encoder_decoder_train_state, rng, update_steps + 1)
+                new_runner_state = (
+                    train_state,
+                    encoder_decoder_train_state,
+                    rng,
+                    update_steps + 1,
+                )
                 return (new_runner_state, metric)
 
             # LIAM Update and Checkpoint saving
-            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)  # -1 because we store a ckpt at the last update
+            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                1, config["NUM_CHECKPOINTS"] - 1
+            )  # -1 because we store a ckpt at the last update
             num_ckpts = config["NUM_CHECKPOINTS"]
 
             # Build a PyTree that holds parameters for all FCP checkpoints
             def init_ckpt_array(params_pytree):
                 return jax.tree.map(
-                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype),
-                    params_pytree)
+                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
+                )
 
             max_episode_steps = config["ROLLOUT_LENGTH"]
 
             def _update_step_with_ckpt(state_with_ckpt, unused):
-                (update_state, checkpoint_array, ckpt_idx, init_eval_last_info) = state_with_ckpt
-
-                # Single LIAM update
-                new_update_state, metric = _update_step(
-                    update_state,
-                    None
+                (update_state, checkpoint_array, ckpt_idx, init_eval_last_info) = (
+                    state_with_ckpt
                 )
 
-                (train_state, encoder_decoder_train_state, rng, update_steps) = new_update_state
+                # Single LIAM update
+                new_update_state, metric = _update_step(update_state, None)
+
+                (train_state, encoder_decoder_train_state, rng, update_steps) = (
+                    new_update_state
+                )
 
                 # update steps is 1-indexed because it was incremented at the end of the update step
-                to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                        jnp.equal(update_steps, config["NUM_UPDATES"]))
-
+                to_store = jnp.logical_or(
+                    jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
+                )
 
                 def store_and_eval_ckpt(args):
-                    ckpt_arr, cidx, rng, prev_eval_ret_info = args
+                    ckpt_arr, cidx, rng, _prev_eval_ret_info = args
                     new_ckpt_arr = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr, {"encoder": encoder_decoder_train_state.params["encoder"],
-                                   "decoder": encoder_decoder_train_state.params["decoder"],
-                                   "policy": train_state.params}
+                        ckpt_arr,
+                        {
+                            "encoder": encoder_decoder_train_state.params["encoder"],
+                            "decoder": encoder_decoder_train_state.params["decoder"],
+                            "policy": train_state.params,
+                        },
                     )
 
                     eval_partner_indices = jnp.arange(num_total_partners)
-                    gathered_params = partner_population.gather_agent_params(partner_params, eval_partner_indices)
+                    gathered_params = partner_population.gather_agent_params(
+                        partner_params, eval_partner_indices
+                    )
 
                     rng, eval_rng = jax.random.split(rng)
-                    eval_eps_last_infos = jax.tree.map(lambda x: x.mean(), jax.vmap(lambda x: run_episodes(
-                        eval_rng, env, agent_0_param={"encoder": encoder_decoder_train_state.params["encoder"],
-                                                      "decoder": encoder_decoder_train_state.params["decoder"],
-                                                      "policy": train_state.params},
-                        agent_0_policy=ego_policy,
-                        agent_1_param=x, agent_1_policy=partner_population.policy_cls,
-                        max_episode_steps=max_episode_steps,
-                        num_eps=config["NUM_EVAL_EPISODES"]))(gathered_params))
+                    eval_eps_last_infos = jax.tree.map(
+                        lambda x: x.mean(),
+                        jax.vmap(
+                            lambda x: run_episodes(
+                                eval_rng,
+                                env,
+                                agent_0_param={
+                                    "encoder": encoder_decoder_train_state.params[
+                                        "encoder"
+                                    ],
+                                    "decoder": encoder_decoder_train_state.params[
+                                        "decoder"
+                                    ],
+                                    "policy": train_state.params,
+                                },
+                                agent_0_policy=ego_policy,
+                                agent_1_param=x,
+                                agent_1_policy=partner_population.policy_cls,
+                                max_episode_steps=max_episode_steps,
+                                num_eps=config["NUM_EVAL_EPISODES"],
+                            )
+                        )(gathered_params),
+                    )
                     return (new_ckpt_arr, cidx + 1, rng, eval_eps_last_infos)
 
                 def skip_ckpt(args):
                     return args
 
                 (checkpoint_array, ckpt_idx, rng, eval_last_infos) = jax.lax.cond(
-                    to_store, store_and_eval_ckpt, skip_ckpt, (checkpoint_array, ckpt_idx, rng, init_eval_last_info)
+                    to_store,
+                    store_and_eval_ckpt,
+                    skip_ckpt,
+                    (checkpoint_array, ckpt_idx, rng, init_eval_last_info),
                 )
 
                 # Condense per-timestep metrics to per-update scalars.
@@ -467,66 +700,109 @@ def train_liam_ego_agent(config, env, train_rng,
                 n_episodes = mask.sum()
                 condensed_metric = {}
                 for key, val in metric.items():
-                    if key in ("update_steps", "actor_loss", "value_loss",
-                               "entropy_loss", "reconstruction_loss",
-                               "avg_grad_norm", "encoder_avg_grad_norm",
-                               "decoder_avg_grad_norm"):
+                    if key in (
+                        "update_steps",
+                        "actor_loss",
+                        "value_loss",
+                        "entropy_loss",
+                        "reconstruction_loss",
+                        "avg_grad_norm",
+                        "encoder_avg_grad_norm",
+                        "decoder_avg_grad_norm",
+                    ):
                         condensed_metric[key] = val.mean() if val.ndim > 0 else val
                     elif key == "returned_episode":
                         condensed_metric[key] = n_episodes.astype(jnp.float32)
                     else:
                         condensed_metric[key] = jnp.where(
                             n_episodes > 0,
-                            jnp.where(mask, val, 0.0).sum() / jnp.maximum(n_episodes, 1),
+                            jnp.where(mask, val, 0.0).sum()
+                            / jnp.maximum(n_episodes, 1),
                             0.0,
                         )
                 condensed_metric["eval_ep_last_info"] = eval_last_infos
-                return ((train_state, encoder_decoder_train_state, rng, update_steps),
-                         checkpoint_array, ckpt_idx, eval_last_infos), condensed_metric
+                return (
+                    (train_state, encoder_decoder_train_state, rng, update_steps),
+                    checkpoint_array,
+                    ckpt_idx,
+                    eval_last_infos,
+                ), condensed_metric
 
             checkpoint_array = init_ckpt_array(
-                {"encoder": encoder_decoder_train_state.params["encoder"],
-                 "decoder": encoder_decoder_train_state.params["decoder"],
-                 "policy": train_state.params}
+                {
+                    "encoder": encoder_decoder_train_state.params["encoder"],
+                    "decoder": encoder_decoder_train_state.params["decoder"],
+                    "policy": train_state.params,
+                }
             )
             ckpt_idx = 0
 
             rng, rng_eval, rng_train = jax.random.split(rng, 3)
             # Init eval return infos
             eval_partner_indices = jnp.arange(num_total_partners)
-            gathered_params = partner_population.gather_agent_params(partner_params, eval_partner_indices)
-            eval_eps_last_infos = jax.tree.map(lambda x: x.mean(), jax.vmap(lambda x: run_episodes(
-                        rng_eval, env,
-                        agent_0_param={"encoder": encoder_decoder_train_state.params["encoder"],
-                                       "decoder": encoder_decoder_train_state.params["decoder"],
-                                       "policy": train_state.params},
+            gathered_params = partner_population.gather_agent_params(
+                partner_params, eval_partner_indices
+            )
+            eval_eps_last_infos = jax.tree.map(
+                lambda x: x.mean(),
+                jax.vmap(
+                    lambda x: run_episodes(
+                        rng_eval,
+                        env,
+                        agent_0_param={
+                            "encoder": encoder_decoder_train_state.params["encoder"],
+                            "decoder": encoder_decoder_train_state.params["decoder"],
+                            "policy": train_state.params,
+                        },
                         agent_0_policy=ego_policy,
-                        agent_1_param=x, agent_1_policy=partner_population.policy_cls,
+                        agent_1_param=x,
+                        agent_1_policy=partner_population.policy_cls,
                         max_episode_steps=max_episode_steps,
-                        num_eps=config["NUM_EVAL_EPISODES"]))(gathered_params))
+                        num_eps=config["NUM_EVAL_EPISODES"],
+                    )
+                )(gathered_params),
+            )
 
             # initial runner state for scanning
             update_steps = 0
-            rng_train, partner_rng = jax.random.split(rng_train)
+            rng_train, _partner_rng = jax.random.split(rng_train)
 
-            update_runner_state = (train_state, encoder_decoder_train_state, rng_train, update_steps)
-            state_with_ckpt = (update_runner_state, checkpoint_array, ckpt_idx, eval_eps_last_infos)
+            update_runner_state = (
+                train_state,
+                encoder_decoder_train_state,
+                rng_train,
+                update_steps,
+            )
+            state_with_ckpt = (
+                update_runner_state,
+                checkpoint_array,
+                ckpt_idx,
+                eval_eps_last_infos,
+            )
 
             state_with_ckpt, metrics = jax.lax.scan(
                 _update_step_with_ckpt,
                 state_with_ckpt,
                 xs=None,
-                length=config["NUM_UPDATES"]
+                length=config["NUM_UPDATES"],
             )
-            (final_runner_state, checkpoint_array, final_ckpt_idx, eval_eps_last_infos) = state_with_ckpt
+            (
+                final_runner_state,
+                checkpoint_array,
+                _final_ckpt_idx,
+                eval_eps_last_infos,
+            ) = state_with_ckpt
             out = {
-                "final_params": {"encoder": final_runner_state[1].params["encoder"],
-                                 "decoder": final_runner_state[1].params["decoder"],
-                                 "policy": final_runner_state[0].params},
+                "final_params": {
+                    "encoder": final_runner_state[1].params["encoder"],
+                    "decoder": final_runner_state[1].params["decoder"],
+                    "policy": final_runner_state[0].params,
+                },
                 "metrics": metrics,  # shape (NUM_UPDATES, ...)
                 "checkpoints": checkpoint_array,
             }
             return out
+
         return train
 
     # ------------------------------
@@ -537,12 +813,13 @@ def train_liam_ego_agent(config, env, train_rng,
     out = train_fn(rngs)
     return out
 
+
 def run_ego_training(config, wandb_logger):
-    '''Run ego agent training against the population of partner agents.
+    """Run ego agent training against the population of partner agents.
 
     Args:
         config: dict, config for the training
-    '''
+    """
     algorithm_config = dict(config["algorithm"])
 
     # Create only one environment instance
@@ -551,31 +828,39 @@ def run_ego_training(config, wandb_logger):
 
     # Set the policy input dimension for the LIAM policy
     # Embedding dimension + observation dimension
-    algorithm_config['POLICY_INPUT_DIM'] = algorithm_config['ENCODER_OUTPUT_DIM'] + env.observation_space(env.agents[0]).shape[0]
+    algorithm_config["POLICY_INPUT_DIM"] = (
+        algorithm_config["ENCODER_OUTPUT_DIM"]
+        + env.observation_space(env.agents[0]).shape[0]
+    )
 
     rng = jax.random.PRNGKey(algorithm_config["TRAIN_SEED"])
     rng, init_partner_rng, init_ego_rng, train_rng = jax.random.split(rng, 4)
 
-
     partner_agent_config = dict(algorithm_config["partner_agent"])
-    assert len(partner_agent_config) == 1, "Only supports training against one type of partner agent."
+    assert len(partner_agent_config) == 1, (
+        "Only supports training against one type of partner agent."
+    )
 
-    partner0_name = list(partner_agent_config.keys())[0]
-    partner0_agent_config = list(partner_agent_config.values())[0]
-    partner_policy, partner_params, init_partner_params, idx_labels = initialize_rl_agent_from_config(
-        partner0_agent_config, partner0_name, env, init_partner_rng)
+    partner0_name = next(iter(partner_agent_config.keys()))
+    partner0_agent_config = next(iter(partner_agent_config.values()))
+    partner_policy, partner_params, init_partner_params, _idx_labels = (
+        initialize_rl_agent_from_config(
+            partner0_agent_config, partner0_name, env, init_partner_rng
+        )
+    )
 
-    flattened_partner_params = jax.tree.map(lambda x, y: x.reshape((-1,) + y.shape), partner_params, init_partner_params)
+    flattened_partner_params = jax.tree.map(
+        lambda x, y: x.reshape((-1,) + y.shape), partner_params, init_partner_params
+    )
     pop_size = jax.tree.leaves(flattened_partner_params)[0].shape[0]
 
     # Create partner population
-    partner_population = AgentPopulation(
-        pop_size=pop_size,
-        policy_cls=partner_policy
-    )
+    partner_population = AgentPopulation(pop_size=pop_size, policy_cls=partner_policy)
 
     # Initialize ego agent policy
-    ego_policy, init_ego_params = initialize_liam_agent(algorithm_config, env, init_ego_rng)
+    ego_policy, init_ego_params = initialize_liam_agent(
+        algorithm_config, env, init_ego_rng
+    )
 
     log.info("Starting ego agent training...")
     start_time = time.time()
@@ -589,7 +874,7 @@ def run_ego_training(config, wandb_logger):
         init_ego_params=init_ego_params,
         n_ego_train_seeds=algorithm_config["NUM_EGO_TRAIN_SEEDS"],
         partner_population=partner_population,
-        partner_params=flattened_partner_params
+        partner_params=flattened_partner_params,
     )
 
     log.info(f"Training completed in {time.time() - start_time:.2f} seconds")
@@ -599,6 +884,7 @@ def run_ego_training(config, wandb_logger):
     log_metrics(config, out, wandb_logger, metric_names)
 
     return out["final_params"], ego_policy, init_ego_params
+
 
 def log_metrics(config, train_out, logger, metric_names: tuple):
     """Process training metrics and log them using the provided logger.
@@ -625,7 +911,9 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
     all_ego_decoder_grad_norms = np.asarray(train_metrics["decoder_avg_grad_norm"])
     # Process eval return metrics - average across ego seeds, eval episodes,
     # training partners and num_agents per game for each checkpoint
-    all_ego_returns = np.asarray(train_metrics["eval_ep_last_info"]["returned_episode_returns"])
+    all_ego_returns = np.asarray(
+        train_metrics["eval_ep_last_info"]["returned_episode_returns"]
+    )
     # Handle both condensed (scalars per update) and full metric shapes.
     # Condensed: (n_ego_train_seeds, num_updates)
     # Full: (n_ego_train_seeds, num_updates, num_partners, ...)
@@ -648,16 +936,58 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
         for stat_name, stat_data in train_stats.items():
             # second dimension contains the mean and std of the metric
             stat_mean = stat_data[step, 0]
-            logger.log_item(f"Train/Ego_{stat_name}", stat_mean, train_step=step, commit=True)
+            logger.log_item(
+                f"Train/Ego_{stat_name}", stat_mean, train_step=step, commit=True
+            )
 
-        logger.log_item("Eval/EgoReturn", average_ego_rets_per_iter[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoValueLoss", average_ego_value_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoActorLoss", average_ego_actor_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoEntropyLoss", average_ego_entropy_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoReconstructionLoss", average_ego_reconstruction_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoGradNorm", average_ego_grad_norms[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoEncoderGradNorm", average_ego_encoder_grad_norms[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoDecoderGradNorm", average_ego_decoder_grad_norms[step], train_step=step, commit=True)
+        logger.log_item(
+            "Eval/EgoReturn",
+            average_ego_rets_per_iter[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoValueLoss",
+            average_ego_value_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoActorLoss",
+            average_ego_actor_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoEntropyLoss",
+            average_ego_entropy_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoReconstructionLoss",
+            average_ego_reconstruction_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoGradNorm",
+            average_ego_grad_norms[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoEncoderGradNorm",
+            average_ego_encoder_grad_norms[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoDecoderGradNorm",
+            average_ego_decoder_grad_norms[step],
+            train_step=step,
+            commit=True,
+        )
         logger.commit()
 
     # Saving artifacts
@@ -665,7 +995,9 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
 
     out_savepath = save_train_run(train_out, savedir, savename="ego_train_run")
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="ego_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="ego_train_run", path=out_savepath, type_name="train_run"
+        )
         # Cleanup locally logged out file
     if not config["local_logger"]["save_train_out"]:
         shutil.rmtree(out_savepath)

--- a/ego_agent_training/liam_utils.py
+++ b/ego_agent_training/liam_utils.py
@@ -2,6 +2,7 @@ from typing import NamedTuple
 
 import jax.numpy as jnp
 
+
 class Transition(NamedTuple):
     done: jnp.ndarray  # done at t+1 (post-step); used for GAE bootstrapping
     action: jnp.ndarray

--- a/ego_agent_training/liam_utils.py
+++ b/ego_agent_training/liam_utils.py
@@ -3,7 +3,7 @@ from typing import NamedTuple
 import jax.numpy as jnp
 
 class Transition(NamedTuple):
-    done: jnp.ndarray
+    done: jnp.ndarray  # done at t+1 (post-step); used for GAE bootstrapping
     action: jnp.ndarray
     value: jnp.ndarray
     reward: jnp.ndarray
@@ -14,3 +14,4 @@ class Transition(NamedTuple):
     prev_action_onehot: jnp.ndarray
     partner_obs: jnp.ndarray
     partner_action_onehot: jnp.ndarray
+    prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay

--- a/ego_agent_training/meliba_ego.py
+++ b/ego_agent_training/meliba_ego.py
@@ -1,4 +1,4 @@
-'''
+"""
 Script for training a MeLIBA ego agent against a population of homogeneous partner agents.
 
 
@@ -16,39 +16,45 @@ python ego_agent_training/run.py algorithm=meliba_ego/lbf/lbf_7x7_nolevels task=
 Suggested debug command:
 
 python ego_agent_training/run.py algorithm=meliba_ego/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels logger.mode=disabled label=debug algorithm.TOTAL_TIMESTEPS=1e5
-'''
+"""
+
+import logging
 import shutil
 import time
-import logging
 
+import hydra
 import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
-import hydra
 from flax.training.train_state import TrainState
 
 from agents.initialize_agents import initialize_meliba_agent
 from agents.population_interface import AgentPopulation
+from common.agent_loader_from_config import initialize_rl_agent_from_config
+from common.plot_utils import get_metric_names, get_stats
 from common.run_episodes import run_episodes
-from common.plot_utils import get_stats, get_metric_names
 from common.save_load_utils import save_train_run
+from ego_agent_training.meliba_utils import Transition
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from common.agent_loader_from_config import initialize_rl_agent_from_config
 from marl.ppo_utils import _create_minibatches, unbatchify
-from ego_agent_training.meliba_utils import Transition
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-def train_meliba_ego_agent(config, env, train_rng,
-                        ego_policy, init_ego_params, n_ego_train_seeds,
-                        partner_population: AgentPopulation,
-                        partner_params
-                        ):
-    '''
+def train_meliba_ego_agent(
+    config,
+    env,
+    train_rng,
+    ego_policy,
+    init_ego_params,
+    n_ego_train_seeds,
+    partner_population: AgentPopulation,
+    partner_params,
+):
+    """
     Train MeLIBA ego agent using the given partner checkpoints and initial ego parameters.
 
     Args:
@@ -61,7 +67,7 @@ def train_meliba_ego_agent(config, env, train_rng,
         init_encoder_decoder_params: dict, initial parameters for the encoder and decoder
         partner_population: AgentPopulation, population of partner agents
         partner_params: pytree of parameters for the population of agents of shape (pop_size, ...).
-    '''
+    """
     # Get partner parameters from the population
     num_total_partners = partner_population.pop_size
 
@@ -69,21 +75,35 @@ def train_meliba_ego_agent(config, env, train_rng,
     # Build the MeLIBA training function
     # ------------------------------
     def make_meliba_train(config):
-        '''agent 0 is the ego agent while agent 1 is the confederate'''
+        """agent 0 is the ego agent while agent 1 is the confederate"""
         num_agents = env.num_agents
         assert num_agents == 2, "This snippet assumes exactly 2 agents."
 
         config["NUM_ACTORS"] = env.num_agents * config["NUM_ENVS"]
-        config["NUM_UNCONTROLLED_ACTORS"] = config["NUM_ENVS"] # assumption: we control 1 agent
-        config["NUM_CONTROLLED_ACTORS"] = config["NUM_ENVS"] # assumption: we control 1 agent
-        config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // config["ROLLOUT_LENGTH"] // config["NUM_ENVS"]
+        config["NUM_UNCONTROLLED_ACTORS"] = config[
+            "NUM_ENVS"
+        ]  # assumption: we control 1 agent
+        config["NUM_CONTROLLED_ACTORS"] = config[
+            "NUM_ENVS"
+        ]  # assumption: we control 1 agent
+        config["NUM_UPDATES"] = (
+            config["TOTAL_TIMESTEPS"] // config["ROLLOUT_LENGTH"] // config["NUM_ENVS"]
+        )
 
         config["NUM_ACTIONS"] = env.action_space(env.agents[0]).n
-        assert config["NUM_CONTROLLED_ACTORS"] % config["NUM_MINIBATCHES"] == 0, "NUM_CONTROLLED_ACTORS must be divisible by NUM_MINIBATCHES"
-        assert config["NUM_CONTROLLED_ACTORS"] >= config["NUM_MINIBATCHES"], "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        assert config["NUM_CONTROLLED_ACTORS"] % config["NUM_MINIBATCHES"] == 0, (
+            "NUM_CONTROLLED_ACTORS must be divisible by NUM_MINIBATCHES"
+        )
+        assert config["NUM_CONTROLLED_ACTORS"] >= config["NUM_MINIBATCHES"], (
+            "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        )
 
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng):
@@ -94,10 +114,18 @@ def train_meliba_ego_agent(config, env, train_rng,
             policy_opt = config.get("POLICY_OPTIMIZER", "rmsprop").lower()
             if config["ANNEAL_LR"]:
                 lr = linear_schedule
-                inner = optax.adam(learning_rate=lr, eps=1e-5) if policy_opt == "adam" else optax.rmsprop(learning_rate=lr)
+                inner = (
+                    optax.adam(learning_rate=lr, eps=1e-5)
+                    if policy_opt == "adam"
+                    else optax.rmsprop(learning_rate=lr)
+                )
             else:
                 lr = config["LR"]
-                inner = optax.adam(lr, eps=1e-5) if policy_opt == "adam" else optax.rmsprop(lr)
+                inner = (
+                    optax.adam(lr, eps=1e-5)
+                    if policy_opt == "adam"
+                    else optax.rmsprop(lr)
+                )
             tx = optax.chain(
                 optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
                 inner,
@@ -105,7 +133,7 @@ def train_meliba_ego_agent(config, env, train_rng,
 
             train_state = TrainState.create(
                 apply_fn=ego_policy.policy.network.apply,
-                params=init_ego_params['policy'],
+                params=init_ego_params["policy"],
                 tx=tx,
             )
 
@@ -116,13 +144,18 @@ def train_meliba_ego_agent(config, env, train_rng,
 
             encoder_decoder_train_state = TrainState.create(
                 apply_fn=ego_policy.encoder.model.apply,
-                params={'encoder': init_ego_params['encoder'], 'decoder': init_ego_params['decoder']},
+                params={
+                    "encoder": init_ego_params["encoder"],
+                    "decoder": init_ego_params["decoder"],
+                },
                 tx=encoder_decoder_tx,
             )
 
             #  Init ego and partner hstates
             init_ego_hstate = ego_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
-            init_partner_hstate = partner_population.init_hstate(config["NUM_UNCONTROLLED_ACTORS"])
+            init_partner_hstate = partner_population.init_hstate(
+                config["NUM_UNCONTROLLED_ACTORS"]
+            )
 
             def _env_step(runner_state, unused):
                 """
@@ -131,41 +164,76 @@ def train_meliba_ego_agent(config, env, train_rng,
                 2. Step environment using sampled actions
                 3. Return state, reward, ...
                 """
-                train_state, encoder_decoder_train_state, env_state, prev_obs, prev_done, prev_reward, prev_act_onehot, ego_hstate, partner_hstate, partner_indices, rng = runner_state
+                (
+                    train_state,
+                    encoder_decoder_train_state,
+                    env_state,
+                    prev_obs,
+                    prev_done,
+                    prev_reward,
+                    prev_act_onehot,
+                    ego_hstate,
+                    partner_hstate,
+                    partner_indices,
+                    rng,
+                ) = runner_state
                 rng, actor_rng, partner_rng, step_rng = jax.random.split(rng, 4)
 
-                 # Get available actions for agent 0 from environment state
+                # Get available actions for agent 0 from environment state
                 avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)
                 avail_actions = jax.lax.stop_gradient(avail_actions)
                 avail_actions_0 = avail_actions["agent_0"].astype(jnp.float32)
                 avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
                 # Conditionally resample partners based on prev_done["__all__"]
-                needs_resample = prev_done["__all__"] # shape (NUM_ENVS,) bool
-                sampled_indices_all = partner_population.sample_agent_indices(config["NUM_CONTROLLED_ACTORS"], partner_rng)
+                needs_resample = prev_done["__all__"]  # shape (NUM_ENVS,) bool
+                sampled_indices_all = partner_population.sample_agent_indices(
+                    config["NUM_CONTROLLED_ACTORS"], partner_rng
+                )
 
                 # Determine final indices based on whether resampling was needed for each env
                 updated_partner_indices = jnp.where(
-                    needs_resample,         # Mask shape (NUM_ENVS,)
-                    sampled_indices_all,    # Use newly sampled index if True
-                    partner_indices         # Else, keep index from previous step
+                    needs_resample,  # Mask shape (NUM_ENVS,)
+                    sampled_indices_all,  # Use newly sampled index if True
+                    partner_indices,  # Else, keep index from previous step
                 )
                 # Note that we do not need to reset the hidden states for both the ego and partner agents
                 # as the recurrent states are automatically reset when done is True, and the partner indices are only reset when done is True.
 
                 # Agent_0 (ego) action, value, log_prob
-                prev_joint_act_onehot = jnp.concatenate((prev_act_onehot["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                                                         prev_act_onehot["agent_1"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1)), axis=-1)
+                prev_joint_act_onehot = jnp.concatenate(
+                    (
+                        prev_act_onehot["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"], -1
+                        ),
+                        prev_act_onehot["agent_1"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"], -1
+                        ),
+                    ),
+                    axis=-1,
+                )
                 act_0, val_0, pi_0, new_ego_hstate = ego_policy.get_action_value_policy(
-                    params={"encoder": encoder_decoder_train_state.params["encoder"],
-                            "decoder": encoder_decoder_train_state.params["decoder"],
-                            "policy": train_state.params},
-                    obs=prev_obs["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=prev_done["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
+                    params={
+                        "encoder": encoder_decoder_train_state.params["encoder"],
+                        "decoder": encoder_decoder_train_state.params["decoder"],
+                        "policy": train_state.params,
+                    },
+                    obs=prev_obs["agent_0"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"], -1
+                    ),
+                    done=prev_done["agent_0"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"]
+                    ),
                     avail_actions=avail_actions_0,
                     hstate=ego_hstate,
                     rng=actor_rng,
-                    aux_obs=(None, prev_joint_act_onehot, prev_reward["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], 1)),
+                    aux_obs=(
+                        None,
+                        prev_joint_act_onehot,
+                        prev_reward["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"], 1
+                        ),
+                    ),
                 )
                 logp_0 = pi_0.log_prob(act_0)
 
@@ -178,26 +246,35 @@ def train_meliba_ego_agent(config, env, train_rng,
                     partner_params,
                     updated_partner_indices,
                     prev_obs["agent_1"].reshape(config["NUM_CONTROLLED_ACTORS"], 1, -1),
-                    prev_done["agent_1"].reshape(config["NUM_CONTROLLED_ACTORS"], 1, -1),
+                    prev_done["agent_1"].reshape(
+                        config["NUM_CONTROLLED_ACTORS"], 1, -1
+                    ),
                     avail_actions_1,
                     partner_hstate,
                     partner_rng,
                     env_state=env_state,
-                    aux_obs=None
+                    aux_obs=None,
                 )
                 act_1 = act_1.squeeze()
 
                 # Combine actions into the env format
-                combined_actions = jnp.concatenate([act_0, act_1], axis=0)  # shape (2*num_envs,)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                combined_actions = jnp.concatenate(
+                    [act_0, act_1], axis=0
+                )  # shape (2*num_envs,)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
-                env_act_onehot = {k: jax.nn.one_hot(v.flatten(), env.action_space(env.agents[i]).n) for i, (k, v) in enumerate(env_act.items())}
+                env_act_onehot = {
+                    k: jax.nn.one_hot(v.flatten(), env.action_space(env.agents[i]).n)
+                    for i, (k, v) in enumerate(env_act.items())
+                }
 
                 # Step env
                 step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done_next, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state, env_act
-                )
+                obs_next, env_state_next, reward, done_next, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 # note that num_actors = num_envs * num_agents
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
 
@@ -211,14 +288,27 @@ def train_meliba_ego_agent(config, env, train_rng,
                     obs=prev_obs["agent_0"],
                     info=info_0,
                     avail_actions=avail_actions_0,
-                    joint_act_onehot=jnp.concatenate((env_act_onehot["agent_0"], env_act_onehot["agent_1"]), axis=-1),
+                    joint_act_onehot=jnp.concatenate(
+                        (env_act_onehot["agent_0"], env_act_onehot["agent_1"]), axis=-1
+                    ),
                     prev_action_onehot=prev_act_onehot["agent_0"],
                     partner_action=act_1,
                     partner_action_onehot=env_act_onehot["agent_1"],
                     prev_done=prev_done["agent_0"],
                 )
-                new_runner_state = (train_state, encoder_decoder_train_state, env_state_next, obs_next, done_next, reward, env_act_onehot,
-                                    new_ego_hstate, new_partner_hstate, updated_partner_indices, rng)
+                new_runner_state = (
+                    train_state,
+                    encoder_decoder_train_state,
+                    env_state_next,
+                    obs_next,
+                    done_next,
+                    reward,
+                    env_act_onehot,
+                    new_ego_hstate,
+                    new_partner_hstate,
+                    updated_partner_indices,
+                    rng,
+                )
                 return new_runner_state, transition
 
             def _calculate_gae(traj_batch, last_val):
@@ -250,20 +340,36 @@ def train_meliba_ego_agent(config, env, train_rng,
                 train_state, encoder_decoder_train_state, rng = init_state
                 rng, loss_rng = jax.random.split(rng)
                 init_ego_hstate, traj_batch, advantages, returns = batch_info
-                def _loss_fn(params, encoder_decoder_params, init_ego_hstate, traj_batch, gae, target_v):
+
+                def _loss_fn(
+                    params,
+                    encoder_decoder_params,
+                    init_ego_hstate,
+                    traj_batch,
+                    gae,
+                    target_v,
+                ):
 
                     # MeLIBA KL loss and reconstruction loss
-                    _, value, pi, kl_loss, recon_loss, _ = ego_policy.compute_decoder_losses(
-                        params={"encoder": encoder_decoder_params["encoder"],
+                    _, value, pi, kl_loss, recon_loss, _ = (
+                        ego_policy.compute_decoder_losses(
+                            params={
+                                "encoder": encoder_decoder_params["encoder"],
                                 "decoder": encoder_decoder_params["decoder"],
-                                "policy": params},
-                        obs=traj_batch.obs,
-                        done=traj_batch.prev_done,
-                        avail_actions=traj_batch.avail_actions,
-                        hstate=init_ego_hstate,
-                        rng=loss_rng,
-                        aux_obs=(None, traj_batch.joint_act_onehot, traj_batch.reward),
-                        partner_action=traj_batch.partner_action
+                                "policy": params,
+                            },
+                            obs=traj_batch.obs,
+                            done=traj_batch.prev_done,
+                            avail_actions=traj_batch.avail_actions,
+                            hstate=init_ego_hstate,
+                            rng=loss_rng,
+                            aux_obs=(
+                                None,
+                                traj_batch.joint_act_onehot,
+                                traj_batch.reward,
+                            ),
+                            partner_action=traj_batch.partner_action,
+                        )
                     )
                     log_prob = pi.log_prob(traj_batch.action)
 
@@ -272,65 +378,134 @@ def train_meliba_ego_agent(config, env, train_rng,
                     # Value loss
                     value_pred_clipped = traj_batch.value + (
                         value - traj_batch.value
-                        ).clip(
-                        -config["CLIP_EPS"], config["CLIP_EPS"])
+                    ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                     value_losses = jnp.square(value - target_v)
                     value_losses_clipped = jnp.square(value_pred_clipped - target_v)
-                    value_loss = (
-                        jnp.maximum(value_losses, value_losses_clipped).mean()
-                    )
+                    value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
 
                     # Policy gradient loss
                     ratio = jnp.exp(log_prob - traj_batch.log_prob)
                     gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                     pg_loss_1 = ratio * gae_norm
-                    pg_loss_2 = jnp.clip(
-                        ratio,
-                        1.0 - config["CLIP_EPS"],
-                        1.0 + config["CLIP_EPS"]) * gae_norm
+                    pg_loss_2 = (
+                        jnp.clip(
+                            ratio, 1.0 - config["CLIP_EPS"], 1.0 + config["CLIP_EPS"]
+                        )
+                        * gae_norm
+                    )
                     pg_loss = -jnp.mean(jnp.minimum(pg_loss_1, pg_loss_2))
 
                     # Entropy
                     entropy = jnp.mean(pi.entropy())
 
                     # MeLIBA ELBO
-                    elbo = (config["DECODER_KL_WEIGHT"] * kl_loss) + (config["DECODER_LOSS_COEFF"] * recon_loss)
+                    elbo = (config["DECODER_KL_WEIGHT"] * kl_loss) + (
+                        config["DECODER_LOSS_COEFF"] * recon_loss
+                    )
 
-                    total_loss = pg_loss + (config["VF_COEF"] * value_loss) - (config["ENT_COEF"] * entropy) + elbo
-                    return total_loss, (value_loss, pg_loss, entropy, kl_loss, recon_loss, elbo)
+                    total_loss = (
+                        pg_loss
+                        + (config["VF_COEF"] * value_loss)
+                        - (config["ENT_COEF"] * entropy)
+                        + elbo
+                    )
+                    return total_loss, (
+                        value_loss,
+                        pg_loss,
+                        entropy,
+                        kl_loss,
+                        recon_loss,
+                        elbo,
+                    )
 
-                grad_fn = jax.value_and_grad(_loss_fn, argnums=(0,1), has_aux=True)
+                grad_fn = jax.value_and_grad(_loss_fn, argnums=(0, 1), has_aux=True)
                 (loss_val, aux_vals), (grads, encoder_decoder_grads) = grad_fn(
-                    train_state.params, encoder_decoder_train_state.params, init_ego_hstate, traj_batch, advantages, returns)
+                    train_state.params,
+                    encoder_decoder_train_state.params,
+                    init_ego_hstate,
+                    traj_batch,
+                    advantages,
+                    returns,
+                )
                 train_state = train_state.apply_gradients(grads=grads)
-                encoder_decoder_train_state = encoder_decoder_train_state.apply_gradients(grads=encoder_decoder_grads)
+                encoder_decoder_train_state = (
+                    encoder_decoder_train_state.apply_gradients(
+                        grads=encoder_decoder_grads
+                    )
+                )
 
                 # compute average grad norm
-                grad_l2_norms = jax.tree.map(lambda g: jnp.linalg.norm(g.astype(jnp.float32)), grads)
+                grad_l2_norms = jax.tree.map(
+                    lambda g: jnp.linalg.norm(g.astype(jnp.float32)), grads
+                )
                 sum_of_grad_norms = jax.tree.reduce(lambda x, y: x + y, grad_l2_norms)
                 n_elements = len(jax.tree.leaves(grad_l2_norms))
                 avg_grad_norm = sum_of_grad_norms / n_elements
 
-                encoder_grad_l2_norms = jax.tree.map(lambda g: jnp.linalg.norm(g.astype(jnp.float32)), encoder_decoder_grads["encoder"])
-                encoder_sum_of_grad_norms = jax.tree.reduce(lambda x, y: x + y, encoder_grad_l2_norms)
+                encoder_grad_l2_norms = jax.tree.map(
+                    lambda g: jnp.linalg.norm(g.astype(jnp.float32)),
+                    encoder_decoder_grads["encoder"],
+                )
+                encoder_sum_of_grad_norms = jax.tree.reduce(
+                    lambda x, y: x + y, encoder_grad_l2_norms
+                )
                 encoder_n_elements = len(jax.tree.leaves(encoder_grad_l2_norms))
                 encoder_avg_grad_norm = encoder_sum_of_grad_norms / encoder_n_elements
 
-                decoder_grad_l2_norms = jax.tree.map(lambda g: jnp.linalg.norm(g.astype(jnp.float32)), encoder_decoder_grads["decoder"])
-                decoder_sum_of_grad_norms = jax.tree.reduce(lambda x, y: x + y, decoder_grad_l2_norms)
+                decoder_grad_l2_norms = jax.tree.map(
+                    lambda g: jnp.linalg.norm(g.astype(jnp.float32)),
+                    encoder_decoder_grads["decoder"],
+                )
+                decoder_sum_of_grad_norms = jax.tree.reduce(
+                    lambda x, y: x + y, decoder_grad_l2_norms
+                )
                 decoder_n_elements = len(jax.tree.leaves(decoder_grad_l2_norms))
                 decoder_avg_grad_norm = decoder_sum_of_grad_norms / decoder_n_elements
 
-                return (train_state, encoder_decoder_train_state, rng), (loss_val, aux_vals, avg_grad_norm, encoder_avg_grad_norm, decoder_avg_grad_norm)
+                return (train_state, encoder_decoder_train_state, rng), (
+                    loss_val,
+                    aux_vals,
+                    avg_grad_norm,
+                    encoder_avg_grad_norm,
+                    decoder_avg_grad_norm,
+                )
 
             def _update_epoch(update_state, unused):
-                train_state, encoder_decoder_train_state, init_ego_hstate, traj_batch, advantages, targets, rng = update_state
+                (
+                    train_state,
+                    encoder_decoder_train_state,
+                    init_ego_hstate,
+                    traj_batch,
+                    advantages,
+                    targets,
+                    rng,
+                ) = update_state
                 rng, perm_rng, minbatch_rng = jax.random.split(rng, 3)
-                minibatches = _create_minibatches(traj_batch, advantages, targets, init_ego_hstate, config["NUM_CONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng)
-                (train_state, encoder_decoder_train_state, _), losses_and_grads = jax.lax.scan(
-                    _update_minbatch, (train_state, encoder_decoder_train_state, minbatch_rng), minibatches
+                minibatches = _create_minibatches(
+                    traj_batch,
+                    advantages,
+                    targets,
+                    init_ego_hstate,
+                    config["NUM_CONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng,
                 )
-                update_state = (train_state, encoder_decoder_train_state, init_ego_hstate, traj_batch, advantages, targets, rng)
+                (train_state, encoder_decoder_train_state, _), losses_and_grads = (
+                    jax.lax.scan(
+                        _update_minbatch,
+                        (train_state, encoder_decoder_train_state, minbatch_rng),
+                        minibatches,
+                    )
+                )
+                update_state = (
+                    train_state,
+                    encoder_decoder_train_state,
+                    init_ego_hstate,
+                    traj_batch,
+                    advantages,
+                    targets,
+                    rng,
+                )
                 return update_state, losses_and_grads
 
             def _update_step(update_runner_state, unused):
@@ -339,40 +514,100 @@ def train_meliba_ego_agent(config, env, train_rng,
                 2. Compute advantage
                 3. MeLIBA updates
                 """
-                (train_state, encoder_decoder_train_state, rng, update_steps) = update_runner_state
+                (train_state, encoder_decoder_train_state, rng, update_steps) = (
+                    update_runner_state
+                )
 
                 # Init envs & partner indices
                 rng, reset_rng, p_rng = jax.random.split(rng, 3)
                 reset_rngs = jax.random.split(reset_rng, config["NUM_ENVS"])
                 init_obs, init_env_state = jax.vmap(env.reset, in_axes=(0,))(reset_rngs)
-                init_done = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
-                init_reward = {k: jnp.zeros((config["NUM_ENVS"])) for i, k in enumerate(env.agents)}
-                new_partner_indices = partner_population.sample_agent_indices(config["NUM_UNCONTROLLED_ACTORS"], p_rng)
-                init_act_onehot = {k: jnp.zeros((config["NUM_ENVS"], env.action_space(env.agents[i]).n)) for i, k in enumerate(env.agents)}
+                init_done = {
+                    k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                    for k in env.agents + ["__all__"]
+                }
+                init_reward = {
+                    k: jnp.zeros(config["NUM_ENVS"]) for i, k in enumerate(env.agents)
+                }
+                new_partner_indices = partner_population.sample_agent_indices(
+                    config["NUM_UNCONTROLLED_ACTORS"], p_rng
+                )
+                init_act_onehot = {
+                    k: jnp.zeros(
+                        (config["NUM_ENVS"], env.action_space(env.agents[i]).n)
+                    )
+                    for i, k in enumerate(env.agents)
+                }
 
                 # 1) rollout
-                runner_state = (train_state, encoder_decoder_train_state, init_env_state, init_obs, init_done, init_reward, init_act_onehot, init_ego_hstate, init_partner_hstate, new_partner_indices, rng)
+                runner_state = (
+                    train_state,
+                    encoder_decoder_train_state,
+                    init_env_state,
+                    init_obs,
+                    init_done,
+                    init_reward,
+                    init_act_onehot,
+                    init_ego_hstate,
+                    init_partner_hstate,
+                    new_partner_indices,
+                    rng,
+                )
                 runner_state, traj_batch = jax.lax.scan(
-                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"])
-                (train_state, encoder_decoder_train_state, env_state, obs, done, reward, act_onehot, ego_hstate, partner_hstate, partner_indices, rng) = runner_state
+                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    train_state,
+                    encoder_decoder_train_state,
+                    env_state,
+                    obs,
+                    done,
+                    reward,
+                    act_onehot,
+                    ego_hstate,
+                    _partner_hstate,
+                    _partner_indices,
+                    rng,
+                ) = runner_state
 
                 # 2) advantage
                 # Get available actions for agent 0 from environment state
-                avail_actions_0 = jax.vmap(env.get_avail_actions)(env_state.env_state)["agent_0"].astype(jnp.float32)
+                avail_actions_0 = jax.vmap(env.get_avail_actions)(env_state.env_state)[
+                    "agent_0"
+                ].astype(jnp.float32)
 
                 # Get final value estimate for completed trajectory
-                joint_act_onehot = jnp.concatenate((act_onehot["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                                                    act_onehot["agent_1"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1)), axis=-1)
+                joint_act_onehot = jnp.concatenate(
+                    (
+                        act_onehot["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"], -1
+                        ),
+                        act_onehot["agent_1"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"], -1
+                        ),
+                    ),
+                    axis=-1,
+                )
                 _, last_val, _, _ = ego_policy.get_action_value_policy(
-                    params={"encoder": encoder_decoder_train_state.params["encoder"],
-                            "decoder": encoder_decoder_train_state.params["decoder"],
-                            "policy": train_state.params},
+                    params={
+                        "encoder": encoder_decoder_train_state.params["encoder"],
+                        "decoder": encoder_decoder_train_state.params["decoder"],
+                        "policy": train_state.params,
+                    },
                     obs=obs["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
                     done=done["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
                     avail_actions=jax.lax.stop_gradient(avail_actions_0),
                     hstate=ego_hstate,
-                    rng=jax.random.PRNGKey(0),  # Dummy key since we're just extracting the value
-                    aux_obs=(None, joint_act_onehot, reward["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], 1))
+                    rng=jax.random.PRNGKey(
+                        0
+                    ),  # Dummy key since we're just extracting the value
+                    aux_obs=(
+                        None,
+                        joint_act_onehot,
+                        reward["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"], 1
+                        ),
+                    ),
                 )
                 last_val = last_val.squeeze()
                 advantages, targets = _calculate_gae(traj_batch, last_val)
@@ -381,22 +616,31 @@ def train_meliba_ego_agent(config, env, train_rng,
                 update_state = (
                     train_state,
                     encoder_decoder_train_state,
-                    init_ego_hstate, # (shape is (num_controlled_actors, encoder_hidden_dim) with all-0s value, shape is (num_controlled_actors, gru_hidden_dim) with all-0s value)
-                    traj_batch, # obs has shape (rollout_len, num_controlled_actors, -1)
+                    init_ego_hstate,  # (shape is (num_controlled_actors, encoder_hidden_dim) with all-0s value, shape is (num_controlled_actors, gru_hidden_dim) with all-0s value)
+                    traj_batch,  # obs has shape (rollout_len, num_controlled_actors, -1)
                     advantages,
                     targets,
-                    rng
+                    rng,
                 )
                 update_state, losses_and_grads = jax.lax.scan(
-                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                )
                 train_state = update_state[0]
                 encoder_decoder_train_state = update_state[1]
-                _, loss_terms, avg_grad_norm, encoder_avg_grad_norm, decoder_avg_grad_norm = losses_and_grads
+                (
+                    _,
+                    loss_terms,
+                    avg_grad_norm,
+                    encoder_avg_grad_norm,
+                    decoder_avg_grad_norm,
+                ) = losses_and_grads
 
                 def mask_and_mean(x, mask):
                     return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
-                
-                mask = traj_batch.info.get("returned_episode", jnp.ones_like(traj_batch.reward))
+
+                mask = traj_batch.info.get(
+                    "returned_episode", jnp.ones_like(traj_batch.reward)
+                )
                 metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch.info)
                 metric["update_steps"] = update_steps
                 metric["actor_loss"] = loss_terms[1].mean()
@@ -408,114 +652,182 @@ def train_meliba_ego_agent(config, env, train_rng,
                 metric["avg_grad_norm"] = avg_grad_norm.mean()
                 metric["encoder_avg_grad_norm"] = encoder_avg_grad_norm.mean()
                 metric["decoder_avg_grad_norm"] = decoder_avg_grad_norm.mean()
-                new_runner_state = (train_state, encoder_decoder_train_state, rng, update_steps + 1)
+                new_runner_state = (
+                    train_state,
+                    encoder_decoder_train_state,
+                    rng,
+                    update_steps + 1,
+                )
                 return (new_runner_state, metric)
 
             # MeLIBA Update and Checkpoint saving
-            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)  # -1 because we store a ckpt at the last update
+            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                1, config["NUM_CHECKPOINTS"] - 1
+            )  # -1 because we store a ckpt at the last update
             num_ckpts = config["NUM_CHECKPOINTS"]
 
             # Build a PyTree that holds parameters for all FCP checkpoints
             def init_ckpt_array(params_pytree):
                 return jax.tree.map(
-                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype),
-                    params_pytree)
+                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
+                )
 
             max_episode_steps = config["ROLLOUT_LENGTH"]
 
             def _update_step_with_ckpt(state_with_ckpt, unused):
-                (update_state, checkpoint_array, ckpt_idx, init_eval_last_info) = state_with_ckpt
-
-                # Single MeLIBA update
-                new_update_state, metric = _update_step(
-                    update_state,
-                    None
+                (update_state, checkpoint_array, ckpt_idx, init_eval_last_info) = (
+                    state_with_ckpt
                 )
 
-                (train_state, encoder_decoder_train_state, rng, update_steps) = new_update_state
+                # Single MeLIBA update
+                new_update_state, metric = _update_step(update_state, None)
+
+                (train_state, encoder_decoder_train_state, rng, update_steps) = (
+                    new_update_state
+                )
 
                 # update steps is 1-indexed because it was incremented at the end of the update step
-                to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                        jnp.equal(update_steps, config["NUM_UPDATES"]))
-
+                to_store = jnp.logical_or(
+                    jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
+                )
 
                 def store_and_eval_ckpt(args):
-                    ckpt_arr, cidx, rng, prev_eval_ret_info = args
+                    ckpt_arr, cidx, rng, _prev_eval_ret_info = args
                     new_ckpt_arr = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr, {"encoder": encoder_decoder_train_state.params["encoder"],
-                                   "decoder": encoder_decoder_train_state.params["decoder"],
-                                   "policy": train_state.params}
+                        ckpt_arr,
+                        {
+                            "encoder": encoder_decoder_train_state.params["encoder"],
+                            "decoder": encoder_decoder_train_state.params["decoder"],
+                            "policy": train_state.params,
+                        },
                     )
 
                     eval_partner_indices = jnp.arange(num_total_partners)
-                    gathered_params = partner_population.gather_agent_params(partner_params, eval_partner_indices)
+                    gathered_params = partner_population.gather_agent_params(
+                        partner_params, eval_partner_indices
+                    )
 
                     rng, eval_rng = jax.random.split(rng)
-                    eval_eps_last_infos = jax.tree.map(lambda x: x.mean(), jax.vmap(lambda x: run_episodes(
-                        eval_rng, env, agent_0_param={"encoder": encoder_decoder_train_state.params["encoder"],
-                                                      "decoder": encoder_decoder_train_state.params["decoder"],
-                                                      "policy": train_state.params},
-                        agent_0_policy=ego_policy,
-                        agent_1_param=x, agent_1_policy=partner_population.policy_cls,
-                        max_episode_steps=max_episode_steps,
-                        num_eps=config["NUM_EVAL_EPISODES"]))(gathered_params))
+                    eval_eps_last_infos = jax.tree.map(
+                        lambda x: x.mean(),
+                        jax.vmap(
+                            lambda x: run_episodes(
+                                eval_rng,
+                                env,
+                                agent_0_param={
+                                    "encoder": encoder_decoder_train_state.params[
+                                        "encoder"
+                                    ],
+                                    "decoder": encoder_decoder_train_state.params[
+                                        "decoder"
+                                    ],
+                                    "policy": train_state.params,
+                                },
+                                agent_0_policy=ego_policy,
+                                agent_1_param=x,
+                                agent_1_policy=partner_population.policy_cls,
+                                max_episode_steps=max_episode_steps,
+                                num_eps=config["NUM_EVAL_EPISODES"],
+                            )
+                        )(gathered_params),
+                    )
                     return (new_ckpt_arr, cidx + 1, rng, eval_eps_last_infos)
 
                 def skip_ckpt(args):
                     return args
 
                 (checkpoint_array, ckpt_idx, rng, eval_last_infos) = jax.lax.cond(
-                    to_store, store_and_eval_ckpt, skip_ckpt, (checkpoint_array, ckpt_idx, rng, init_eval_last_info)
+                    to_store,
+                    store_and_eval_ckpt,
+                    skip_ckpt,
+                    (checkpoint_array, ckpt_idx, rng, init_eval_last_info),
                 )
 
                 metric["eval_ep_last_info"] = eval_last_infos
-                return ((train_state, encoder_decoder_train_state, rng, update_steps),
-                         checkpoint_array, ckpt_idx, eval_last_infos), metric
+                return (
+                    (train_state, encoder_decoder_train_state, rng, update_steps),
+                    checkpoint_array,
+                    ckpt_idx,
+                    eval_last_infos,
+                ), metric
 
             checkpoint_array = init_ckpt_array(
-                {"encoder": encoder_decoder_train_state.params["encoder"],
-                 "decoder": encoder_decoder_train_state.params["decoder"],
-                 "policy": train_state.params}
+                {
+                    "encoder": encoder_decoder_train_state.params["encoder"],
+                    "decoder": encoder_decoder_train_state.params["decoder"],
+                    "policy": train_state.params,
+                }
             )
             ckpt_idx = 0
 
             rng, rng_eval, rng_train = jax.random.split(rng, 3)
             # Init eval return infos
             eval_partner_indices = jnp.arange(num_total_partners)
-            gathered_params = partner_population.gather_agent_params(partner_params, eval_partner_indices)
-            eval_eps_last_infos = jax.tree.map(lambda x: x.mean(), jax.vmap(lambda x: run_episodes(
-                        rng_eval, env,
-                        agent_0_param={"encoder": encoder_decoder_train_state.params["encoder"],
-                                       "decoder": encoder_decoder_train_state.params["decoder"],
-                                       "policy": train_state.params},
+            gathered_params = partner_population.gather_agent_params(
+                partner_params, eval_partner_indices
+            )
+            eval_eps_last_infos = jax.tree.map(
+                lambda x: x.mean(),
+                jax.vmap(
+                    lambda x: run_episodes(
+                        rng_eval,
+                        env,
+                        agent_0_param={
+                            "encoder": encoder_decoder_train_state.params["encoder"],
+                            "decoder": encoder_decoder_train_state.params["decoder"],
+                            "policy": train_state.params,
+                        },
                         agent_0_policy=ego_policy,
-                        agent_1_param=x, agent_1_policy=partner_population.policy_cls,
+                        agent_1_param=x,
+                        agent_1_policy=partner_population.policy_cls,
                         max_episode_steps=max_episode_steps,
-                        num_eps=config["NUM_EVAL_EPISODES"]))(gathered_params))
+                        num_eps=config["NUM_EVAL_EPISODES"],
+                    )
+                )(gathered_params),
+            )
 
             # initial runner state for scanning
             update_steps = 0
-            rng_train, partner_rng = jax.random.split(rng_train)
+            rng_train, _partner_rng = jax.random.split(rng_train)
 
-            update_runner_state = (train_state, encoder_decoder_train_state, rng_train, update_steps)
-            state_with_ckpt = (update_runner_state, checkpoint_array, ckpt_idx, eval_eps_last_infos)
+            update_runner_state = (
+                train_state,
+                encoder_decoder_train_state,
+                rng_train,
+                update_steps,
+            )
+            state_with_ckpt = (
+                update_runner_state,
+                checkpoint_array,
+                ckpt_idx,
+                eval_eps_last_infos,
+            )
 
             state_with_ckpt, metrics = jax.lax.scan(
                 _update_step_with_ckpt,
                 state_with_ckpt,
                 xs=None,
-                length=config["NUM_UPDATES"]
+                length=config["NUM_UPDATES"],
             )
-            (final_runner_state, checkpoint_array, final_ckpt_idx, eval_eps_last_infos) = state_with_ckpt
+            (
+                final_runner_state,
+                checkpoint_array,
+                _final_ckpt_idx,
+                eval_eps_last_infos,
+            ) = state_with_ckpt
             out = {
-                "final_params": {"encoder": final_runner_state[1].params["encoder"],
-                                 "decoder": final_runner_state[1].params["decoder"],
-                                 "policy": final_runner_state[0].params},
+                "final_params": {
+                    "encoder": final_runner_state[1].params["encoder"],
+                    "decoder": final_runner_state[1].params["decoder"],
+                    "policy": final_runner_state[0].params,
+                },
                 "metrics": metrics,  # shape (NUM_UPDATES, ...)
                 "checkpoints": checkpoint_array,
             }
             return out
+
         return train
 
     # ------------------------------
@@ -526,12 +838,13 @@ def train_meliba_ego_agent(config, env, train_rng,
     out = train_fn(rngs)
     return out
 
+
 def run_ego_training(config, wandb_logger):
-    '''Run ego agent training against the population of partner agents.
+    """Run ego agent training against the population of partner agents.
 
     Args:
         config: dict, config for the training
-    '''
+    """
     algorithm_config = dict(config["algorithm"])
 
     # Create only one environment instance
@@ -540,31 +853,38 @@ def run_ego_training(config, wandb_logger):
 
     # Set the policy input dimension for the meliba policy
     # (Latent dim * 4) + observation dimension
-    algorithm_config['POLICY_INPUT_DIM'] = (algorithm_config['ENCODER_LATENT_DIM'] * 4) + env.observation_space(env.agents[0]).shape[0]
+    algorithm_config["POLICY_INPUT_DIM"] = (
+        algorithm_config["ENCODER_LATENT_DIM"] * 4
+    ) + env.observation_space(env.agents[0]).shape[0]
 
     rng = jax.random.PRNGKey(algorithm_config["TRAIN_SEED"])
     rng, init_partner_rng, init_ego_rng, train_rng = jax.random.split(rng, 4)
 
-
     partner_agent_config = dict(algorithm_config["partner_agent"])
-    assert len(partner_agent_config) == 1, "Only supports training against one type of partner agent."
+    assert len(partner_agent_config) == 1, (
+        "Only supports training against one type of partner agent."
+    )
 
-    partner0_name = list(partner_agent_config.keys())[0]
-    partner0_agent_config = list(partner_agent_config.values())[0]
-    partner_policy, partner_params, init_partner_params, idx_labels = initialize_rl_agent_from_config(
-        partner0_agent_config, partner0_name, env, init_partner_rng)
+    partner0_name = next(iter(partner_agent_config.keys()))
+    partner0_agent_config = next(iter(partner_agent_config.values()))
+    partner_policy, partner_params, init_partner_params, _idx_labels = (
+        initialize_rl_agent_from_config(
+            partner0_agent_config, partner0_name, env, init_partner_rng
+        )
+    )
 
-    flattened_partner_params = jax.tree.map(lambda x, y: x.reshape((-1,) + y.shape), partner_params, init_partner_params)
+    flattened_partner_params = jax.tree.map(
+        lambda x, y: x.reshape((-1,) + y.shape), partner_params, init_partner_params
+    )
     pop_size = jax.tree.leaves(flattened_partner_params)[0].shape[0]
 
     # Create partner population
-    partner_population = AgentPopulation(
-        pop_size=pop_size,
-        policy_cls=partner_policy
-    )
+    partner_population = AgentPopulation(pop_size=pop_size, policy_cls=partner_policy)
 
     # Initialize ego agent policy
-    ego_policy, init_ego_params = initialize_meliba_agent(algorithm_config, env, init_ego_rng)
+    ego_policy, init_ego_params = initialize_meliba_agent(
+        algorithm_config, env, init_ego_rng
+    )
 
     log.info("Starting ego agent training...")
     start_time = time.time()
@@ -578,7 +898,7 @@ def run_ego_training(config, wandb_logger):
         init_ego_params=init_ego_params,
         n_ego_train_seeds=algorithm_config["NUM_EGO_TRAIN_SEEDS"],
         partner_population=partner_population,
-        partner_params=flattened_partner_params
+        partner_params=flattened_partner_params,
     )
 
     log.info(f"Training completed in {time.time() - start_time:.2f} seconds")
@@ -588,6 +908,7 @@ def run_ego_training(config, wandb_logger):
     log_metrics(config, out, wandb_logger, metric_names)
 
     return out["final_params"], ego_policy, init_ego_params
+
 
 def log_metrics(config, train_out, logger, metric_names: tuple):
     """Process training metrics and log them using the provided logger.
@@ -605,18 +926,38 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
     # where the last dimension contains the mean and std of the metric
     train_stats = {k: np.mean(np.array(v), axis=0) for k, v in train_stats.items()}
 
-    all_ego_value_losses = np.asarray(train_metrics["value_loss"]) # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
-    all_ego_actor_losses = np.asarray(train_metrics["actor_loss"]) # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
-    all_ego_entropy_losses = np.asarray(train_metrics["entropy_loss"]) # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
-    all_ego_kl_divergence_losses = np.asarray(train_metrics["kl_divergence_loss"]) # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
-    all_ego_reconstruction_losses = np.asarray(train_metrics["reconstruction_loss"]) # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
-    all_ego_elbo_losses = np.asarray(train_metrics["elbo_loss"]) # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
-    all_ego_grad_norms = np.asarray(train_metrics["avg_grad_norm"]) # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
-    all_ego_encoder_grad_norms = np.asarray(train_metrics["encoder_avg_grad_norm"]) # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
-    all_ego_decoder_grad_norms = np.asarray(train_metrics["decoder_avg_grad_norm"]) # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
+    all_ego_value_losses = np.asarray(
+        train_metrics["value_loss"]
+    )  # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
+    all_ego_actor_losses = np.asarray(
+        train_metrics["actor_loss"]
+    )  # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
+    all_ego_entropy_losses = np.asarray(
+        train_metrics["entropy_loss"]
+    )  # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
+    all_ego_kl_divergence_losses = np.asarray(
+        train_metrics["kl_divergence_loss"]
+    )  # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
+    all_ego_reconstruction_losses = np.asarray(
+        train_metrics["reconstruction_loss"]
+    )  # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
+    all_ego_elbo_losses = np.asarray(
+        train_metrics["elbo_loss"]
+    )  # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
+    all_ego_grad_norms = np.asarray(
+        train_metrics["avg_grad_norm"]
+    )  # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
+    all_ego_encoder_grad_norms = np.asarray(
+        train_metrics["encoder_avg_grad_norm"]
+    )  # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
+    all_ego_decoder_grad_norms = np.asarray(
+        train_metrics["decoder_avg_grad_norm"]
+    )  # shape (n_ego_train_seeds, num_updates, num_partners, num_minibatches)
     # Process eval return metrics - average across ego seeds, eval episodes,  training partners
     # and num_agents per game for each checkpoint
-    all_ego_returns = np.asarray(train_metrics["eval_ep_last_info"]["returned_episode_returns"]) # shape (n_ego_train_seeds, num_updates)  [pre-scalarized: mean over partners, eval eps, and agents taken inside scan]
+    all_ego_returns = np.asarray(
+        train_metrics["eval_ep_last_info"]["returned_episode_returns"]
+    )  # shape (n_ego_train_seeds, num_updates)  [pre-scalarized: mean over partners, eval eps, and agents taken inside scan]
     average_ego_rets_per_iter = np.mean(all_ego_returns, axis=0)
 
     # Process loss metrics - average across ego seeds, partners and minibatches dims
@@ -637,18 +978,70 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
         for stat_name, stat_data in train_stats.items():
             # second dimension contains the mean and std of the metric
             stat_mean = stat_data[step, 0]
-            logger.log_item(f"Train/Ego_{stat_name}", stat_mean, train_step=step, commit=True)
+            logger.log_item(
+                f"Train/Ego_{stat_name}", stat_mean, train_step=step, commit=True
+            )
 
-        logger.log_item("Eval/EgoReturn", average_ego_rets_per_iter[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoValueLoss", average_ego_value_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoActorLoss", average_ego_actor_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoEntropyLoss", average_ego_entropy_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoKLDivergenceLoss", average_ego_kl_divergence_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoReconstructionLoss", average_ego_reconstruction_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoELBOLoss", average_ego_elbo_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoGradNorm", average_ego_grad_norms[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoEncoderGradNorm", average_ego_encoder_grad_norms[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoDecoderGradNorm", average_ego_decoder_grad_norms[step], train_step=step, commit=True)
+        logger.log_item(
+            "Eval/EgoReturn",
+            average_ego_rets_per_iter[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoValueLoss",
+            average_ego_value_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoActorLoss",
+            average_ego_actor_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoEntropyLoss",
+            average_ego_entropy_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoKLDivergenceLoss",
+            average_ego_kl_divergence_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoReconstructionLoss",
+            average_ego_reconstruction_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoELBOLoss",
+            average_ego_elbo_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoGradNorm",
+            average_ego_grad_norms[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoEncoderGradNorm",
+            average_ego_encoder_grad_norms[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoDecoderGradNorm",
+            average_ego_decoder_grad_norms[step],
+            train_step=step,
+            commit=True,
+        )
         logger.commit()
 
     # Saving artifacts
@@ -656,7 +1049,9 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
 
     out_savepath = save_train_run(train_out, savedir, savename="ego_train_run")
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="ego_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="ego_train_run", path=out_savepath, type_name="train_run"
+        )
         # Cleanup locally logged out file
     if not config["local_logger"]["save_train_out"]:
         shutil.rmtree(out_savepath)

--- a/ego_agent_training/meliba_ego.py
+++ b/ego_agent_training/meliba_ego.py
@@ -214,7 +214,8 @@ def train_meliba_ego_agent(config, env, train_rng,
                     joint_act_onehot=jnp.concatenate((env_act_onehot["agent_0"], env_act_onehot["agent_1"]), axis=-1),
                     prev_action_onehot=prev_act_onehot["agent_0"],
                     partner_action=act_1,
-                    partner_action_onehot=env_act_onehot["agent_1"]
+                    partner_action_onehot=env_act_onehot["agent_1"],
+                    prev_done=prev_done["agent_0"],
                 )
                 new_runner_state = (train_state, encoder_decoder_train_state, env_state_next, obs_next, done_next, reward, env_act_onehot,
                                     new_ego_hstate, new_partner_hstate, updated_partner_indices, rng)
@@ -257,7 +258,7 @@ def train_meliba_ego_agent(config, env, train_rng,
                                 "decoder": encoder_decoder_params["decoder"],
                                 "policy": params},
                         obs=traj_batch.obs,
-                        done=traj_batch.done,
+                        done=traj_batch.prev_done,
                         avail_actions=traj_batch.avail_actions,
                         hstate=init_ego_hstate,
                         rng=loss_rng,

--- a/ego_agent_training/meliba_utils.py
+++ b/ego_agent_training/meliba_utils.py
@@ -1,11 +1,11 @@
 import functools
-import numpy as np
-
 from typing import NamedTuple
 
+import flax.linen as nn
 import jax
 import jax.numpy as jnp
-import flax.linen as nn
+import numpy as np
+
 
 class Transition(NamedTuple):
     done: jnp.ndarray  # done at t+1 (post-step); used for GAE bootstrapping
@@ -22,6 +22,7 @@ class Transition(NamedTuple):
     partner_action_onehot: jnp.ndarray
     prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
+
 class DecoderScannedRNN(nn.Module):
     """
     A RNN module that can be scanned over time.
@@ -29,6 +30,7 @@ class DecoderScannedRNN(nn.Module):
     It resets its state based on the `dones` signal and
     resets to the provided `hiddens` state when `done` is True.
     """
+
     @functools.partial(
         nn.scan,
         variable_broadcast="params",
@@ -49,7 +51,10 @@ class DecoderScannedRNN(nn.Module):
         new_rnn_state, y = nn.GRUCell(features=ins.shape[1])(rnn_state, ins)
         return new_rnn_state, y
 
-def transform_timestep_to_k_batch(array, pad_value=0.0, return_mask=False, start_indices=None):
+
+def transform_timestep_to_k_batch(
+    array, pad_value=0.0, return_mask=False, start_indices=None
+):
     """
     Transform array from (timestep, feat) to (k_batch, timesteps, feat)
 
@@ -114,6 +119,7 @@ def transform_timestep_to_k_batch(array, pad_value=0.0, return_mask=False, start
         results = jax.vmap(get_subsequence_for_start_idx)(start_indices)
         return results
 
+
 def shift_padding_to_front_vectorized(data, mask):
     """
     Shift padding in data to the front based on the mask.
@@ -166,16 +172,13 @@ def shift_padding_to_front_vectorized(data, mask):
 
     # Gather the data
     # (batch, seq_len, feat_dim)
-    gathered_data = jnp.take_along_axis(
-        data, source_positions[..., None], axis=1
-    )
+    gathered_data = jnp.take_along_axis(data, source_positions[..., None], axis=1)
 
     # Zero out padding positions
-    shifted_data = jnp.where(
-        new_mask[..., None], gathered_data, 0.0
-    )
+    shifted_data = jnp.where(new_mask[..., None], gathered_data, 0.0)
 
     return shifted_data, new_mask
+
 
 def fill_to_first_true(array):
     """

--- a/ego_agent_training/meliba_utils.py
+++ b/ego_agent_training/meliba_utils.py
@@ -8,7 +8,7 @@ import jax.numpy as jnp
 import flax.linen as nn
 
 class Transition(NamedTuple):
-    done: jnp.ndarray
+    done: jnp.ndarray  # done at t+1 (post-step); used for GAE bootstrapping
     action: jnp.ndarray
     value: jnp.ndarray
     reward: jnp.ndarray
@@ -20,6 +20,7 @@ class Transition(NamedTuple):
     prev_action_onehot: jnp.ndarray
     partner_action: jnp.ndarray
     partner_action_onehot: jnp.ndarray
+    prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
 class DecoderScannedRNN(nn.Module):
     """

--- a/ego_agent_training/ppo_ego.py
+++ b/ego_agent_training/ppo_ego.py
@@ -1,9 +1,9 @@
-'''
-Script for training a PPO ego agent against a *population* of homogeneous, RL-based partner agents. 
-Does not support training against heuristic partner agents. 
+"""
+Script for training a PPO ego agent against a *population* of homogeneous, RL-based partner agents.
+Does not support training against heuristic partner agents.
 **Warning**: modify with caution, as this script is used as the main script for ego training throughout the project.
 
-If running the script directly, please specify a partner agent config at 
+If running the script directly, please specify a partner agent config at
 `ego_agent_training/configs/algorithm/ppo_ego/_base_.yaml`.
 
 Command to run PPO ego training:
@@ -11,38 +11,44 @@ python ego_agent_training/run.py algorithm=ppo_ego/lbf/lbf_7x7_nolevels task=lbf
 
 Suggested debug command:
 python ego_agent_training/run.py algorithm=ppo_ego/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels logger.mode=disabled label=debug algorithm.TOTAL_TIMESTEPS=1e5
-'''
+"""
+
+import logging
 import shutil
 import time
-import logging
 
+import hydra
 import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
-import hydra
 from flax.training.train_state import TrainState
 
 from agents.population_interface import AgentPopulation
+from common.agent_loader_from_config import initialize_rl_agent_from_config
+from common.plot_utils import get_metric_names, get_stats
 from common.run_episodes import run_episodes
-from common.plot_utils import get_stats, get_metric_names
 from common.save_load_utils import save_train_run
 from ego_agent_training.utils import initialize_ego_agent
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from common.agent_loader_from_config import initialize_rl_agent_from_config
-from marl.ppo_utils import _create_minibatches, Transition, unbatchify
+from marl.ppo_utils import Transition, _create_minibatches, unbatchify
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-def train_ppo_ego_agent(config, env, train_rng, 
-                        ego_policy, init_ego_params, n_ego_train_seeds,
-                        partner_population: AgentPopulation,
-                        partner_params
-                        ):
-    '''
+def train_ppo_ego_agent(
+    config,
+    env,
+    train_rng,
+    ego_policy,
+    init_ego_params,
+    n_ego_train_seeds,
+    partner_population: AgentPopulation,
+    partner_params,
+):
+    """
     Train PPO ego agent using the given partner checkpoints and initial ego parameters.
 
     Args:
@@ -54,7 +60,7 @@ def train_ppo_ego_agent(config, env, train_rng,
         n_ego_train_seeds: int, number of ego training seeds
         partner_population: AgentPopulation, population of partner agents
         partner_params: pytree of parameters for the population of agents of shape (pop_size, ...).
-    '''
+    """
     # Get partner parameters from the population
     num_total_partners = partner_population.pop_size
     progress_interval = int(config.get("PROGRESS_LOG_INTERVAL", 0) or 0)
@@ -63,22 +69,38 @@ def train_ppo_ego_agent(config, env, train_rng,
     # Build the PPO training function
     # ------------------------------
     def make_ppo_train(config):
-        '''agent 0 is the ego agent while agent 1 is the confederate'''
+        """agent 0 is the ego agent while agent 1 is the confederate"""
         num_agents = env.num_agents
         assert num_agents == 2, "This snippet assumes exactly 2 agents."
 
         config["NUM_ACTORS"] = env.num_agents * config["NUM_ENVS"]
-        config["NUM_UNCONTROLLED_ACTORS"] = config["NUM_ENVS"] # assumption: we control 1 agent
-        config["NUM_CONTROLLED_ACTORS"] = config["NUM_ENVS"] # assumption: we control 1 agent
-        config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // config["ROLLOUT_LENGTH"] // config["NUM_ENVS"]
-        local_progress_interval = progress_interval or max(1, int(config["NUM_UPDATES"] // 20))
+        config["NUM_UNCONTROLLED_ACTORS"] = config[
+            "NUM_ENVS"
+        ]  # assumption: we control 1 agent
+        config["NUM_CONTROLLED_ACTORS"] = config[
+            "NUM_ENVS"
+        ]  # assumption: we control 1 agent
+        config["NUM_UPDATES"] = (
+            config["TOTAL_TIMESTEPS"] // config["ROLLOUT_LENGTH"] // config["NUM_ENVS"]
+        )
+        local_progress_interval = progress_interval or max(
+            1, int(config["NUM_UPDATES"] // 20)
+        )
 
         config["NUM_ACTIONS"] = env.action_space(env.agents[0]).n
-        assert config["NUM_CONTROLLED_ACTORS"] % config["NUM_MINIBATCHES"] == 0, "NUM_CONTROLLED_ACTORS must be divisible by NUM_MINIBATCHES"
-        assert config["NUM_CONTROLLED_ACTORS"] >= config["NUM_MINIBATCHES"], "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        assert config["NUM_CONTROLLED_ACTORS"] % config["NUM_MINIBATCHES"] == 0, (
+            "NUM_CONTROLLED_ACTORS must be divisible by NUM_MINIBATCHES"
+        )
+        assert config["NUM_CONTROLLED_ACTORS"] >= config["NUM_MINIBATCHES"], (
+            "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        )
 
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng):
@@ -100,8 +122,10 @@ def train_ppo_ego_agent(config, env, train_rng,
             )
             #  Init ego and partner hstates
             init_ego_hstate = ego_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
-            init_partner_hstate = partner_population.init_hstate(config["NUM_UNCONTROLLED_ACTORS"])
-            
+            init_partner_hstate = partner_population.init_hstate(
+                config["NUM_UNCONTROLLED_ACTORS"]
+            )
+
             def _env_step(runner_state, unused):
                 """
                 One step of the environment:
@@ -109,37 +133,52 @@ def train_ppo_ego_agent(config, env, train_rng,
                 2. Step environment using sampled actions
                 3. Return state, reward, ...
                 """
-                train_state, env_state, prev_obs, prev_done, ego_hstate, partner_hstate, partner_indices, rng = runner_state
+                (
+                    train_state,
+                    env_state,
+                    prev_obs,
+                    prev_done,
+                    ego_hstate,
+                    partner_hstate,
+                    partner_indices,
+                    rng,
+                ) = runner_state
                 rng, actor_rng, partner_rng, step_rng = jax.random.split(rng, 4)
 
-                 # Get available actions for agent 0 from environment state
+                # Get available actions for agent 0 from environment state
                 avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)
                 avail_actions = jax.lax.stop_gradient(avail_actions)
                 avail_actions_0 = avail_actions["agent_0"].astype(jnp.float32)
                 avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
-                # Conditionally resample partners based on prev_done["__all__"]                
-                needs_resample = prev_done["__all__"] # shape (NUM_ENVS,) bool
-                sampled_indices_all = partner_population.sample_agent_indices(config["NUM_CONTROLLED_ACTORS"], partner_rng)
+                # Conditionally resample partners based on prev_done["__all__"]
+                needs_resample = prev_done["__all__"]  # shape (NUM_ENVS,) bool
+                sampled_indices_all = partner_population.sample_agent_indices(
+                    config["NUM_CONTROLLED_ACTORS"], partner_rng
+                )
 
                 # Determine final indices based on whether resampling was needed for each env
                 updated_partner_indices = jnp.where(
-                    needs_resample,         # Mask shape (NUM_ENVS,)
-                    sampled_indices_all,    # Use newly sampled index if True
-                    partner_indices         # Else, keep index from previous step
+                    needs_resample,  # Mask shape (NUM_ENVS,)
+                    sampled_indices_all,  # Use newly sampled index if True
+                    partner_indices,  # Else, keep index from previous step
                 )
 
                 # Note that we do not need to reset the hiden states for both the ego and partner agents
                 # as the recurrent states are automatically reset when done is True, and the partner indices are only reset when done is True.
-                
+
                 # Agent_0 (ego) action, value, log_prob
                 act_0, val_0, pi_0, new_ego_hstate = ego_policy.get_action_value_policy(
                     params=train_state.params,
-                    obs=prev_obs["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=prev_done["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
+                    obs=prev_obs["agent_0"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"], -1
+                    ),
+                    done=prev_done["agent_0"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"]
+                    ),
                     avail_actions=avail_actions_0,
                     hstate=ego_hstate,
-                    rng=actor_rng
+                    rng=actor_rng,
                 )
                 logp_0 = pi_0.log_prob(act_0)
 
@@ -152,25 +191,31 @@ def train_ppo_ego_agent(config, env, train_rng,
                     partner_params,
                     updated_partner_indices,
                     prev_obs["agent_1"].reshape(config["NUM_CONTROLLED_ACTORS"], 1, -1),
-                    prev_done["agent_1"].reshape(config["NUM_CONTROLLED_ACTORS"], 1, -1),
+                    prev_done["agent_1"].reshape(
+                        config["NUM_CONTROLLED_ACTORS"], 1, -1
+                    ),
                     avail_actions_1,
                     partner_hstate,
                     partner_rng,
                     env_state=env_state,
-                    aux_obs=None
+                    aux_obs=None,
                 )
                 act_1 = act_1.squeeze()
 
                 # Combine actions into the env format
-                combined_actions = jnp.concatenate([act_0, act_1], axis=0)  # shape (2*num_envs,)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                combined_actions = jnp.concatenate(
+                    [act_0, act_1], axis=0
+                )  # shape (2*num_envs,)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
 
                 # Step env
                 step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done_next, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state, env_act
-                )
+                obs_next, env_state_next, reward, done_next, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 # note that num_actors = num_envs * num_agents
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
 
@@ -184,10 +229,18 @@ def train_ppo_ego_agent(config, env, train_rng,
                     obs=prev_obs["agent_0"],
                     info=info_0,
                     avail_actions=avail_actions_0,
-                    prev_done=prev_done["agent_0"]
+                    prev_done=prev_done["agent_0"],
                 )
-                new_runner_state = (train_state, env_state_next, obs_next, done_next, 
-                                    new_ego_hstate, new_partner_hstate, updated_partner_indices, rng)
+                new_runner_state = (
+                    train_state,
+                    env_state_next,
+                    obs_next,
+                    done_next,
+                    new_ego_hstate,
+                    new_partner_hstate,
+                    updated_partner_indices,
+                    rng,
+                )
                 return new_runner_state, transition
 
             def _calculate_gae(traj_batch, last_val):
@@ -212,70 +265,96 @@ def train_ppo_ego_agent(config, env, train_rng,
                     reverse=True,
                     unroll=16,
                 )
-                
+
                 return advantages, advantages + traj_batch.value
 
             def _update_minbatch(train_state, batch_info):
                 init_ego_hstate, traj_batch, advantages, returns = batch_info
+
                 def _loss_fn(params, init_ego_hstate, traj_batch, gae, target_v):
                     _, value, pi, _ = ego_policy.get_action_value_policy(
-                        params=params, 
+                        params=params,
                         obs=traj_batch.obs,
                         done=traj_batch.prev_done,
                         avail_actions=traj_batch.avail_actions,
                         hstate=init_ego_hstate,
-                        rng=jax.random.PRNGKey(0) # only used for action sampling, which is unused here
+                        rng=jax.random.PRNGKey(
+                            0
+                        ),  # only used for action sampling, which is unused here
                     )
                     log_prob = pi.log_prob(traj_batch.action)
 
                     # Value loss
                     value_pred_clipped = traj_batch.value + (
                         value - traj_batch.value
-                        ).clip(
-                        -config["CLIP_EPS"], config["CLIP_EPS"])
+                    ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                     value_losses = jnp.square(value - target_v)
                     value_losses_clipped = jnp.square(value_pred_clipped - target_v)
-                    value_loss = (
-                        jnp.maximum(value_losses, value_losses_clipped).mean()
-                    )
+                    value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
 
                     # Policy gradient loss
                     ratio = jnp.exp(log_prob - traj_batch.log_prob)
                     gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                     pg_loss_1 = ratio * gae_norm
-                    pg_loss_2 = jnp.clip(
-                        ratio, 
-                        1.0 - config["CLIP_EPS"], 
-                        1.0 + config["CLIP_EPS"]) * gae_norm
+                    pg_loss_2 = (
+                        jnp.clip(
+                            ratio, 1.0 - config["CLIP_EPS"], 1.0 + config["CLIP_EPS"]
+                        )
+                        * gae_norm
+                    )
                     pg_loss = -jnp.mean(jnp.minimum(pg_loss_1, pg_loss_2))
 
                     # Entropy
                     entropy = jnp.mean(pi.entropy())
 
-                    total_loss = pg_loss + config["VF_COEF"] * value_loss - config["ENT_COEF"] * entropy
+                    total_loss = (
+                        pg_loss
+                        + config["VF_COEF"] * value_loss
+                        - config["ENT_COEF"] * entropy
+                    )
                     return total_loss, (value_loss, pg_loss, entropy)
 
                 grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
                 (loss_val, aux_vals), grads = grad_fn(
-                    train_state.params, init_ego_hstate, traj_batch, advantages, returns)
+                    train_state.params, init_ego_hstate, traj_batch, advantages, returns
+                )
                 train_state = train_state.apply_gradients(grads=grads)
-                
+
                 # compute average grad norm
-                grad_l2_norms = jax.tree.map(lambda g: jnp.linalg.norm(g.astype(jnp.float32)), grads)
+                grad_l2_norms = jax.tree.map(
+                    lambda g: jnp.linalg.norm(g.astype(jnp.float32)), grads
+                )
                 sum_of_grad_norms = jax.tree.reduce(lambda x, y: x + y, grad_l2_norms)
                 n_elements = len(jax.tree.leaves(grad_l2_norms))
                 avg_grad_norm = sum_of_grad_norms / n_elements
-                
+
                 return train_state, (loss_val, aux_vals, avg_grad_norm)
 
             def _update_epoch(update_state, unused):
-                train_state, init_ego_hstate, traj_batch, advantages, targets, rng = update_state
+                train_state, init_ego_hstate, traj_batch, advantages, targets, rng = (
+                    update_state
+                )
                 rng, perm_rng = jax.random.split(rng)
-                minibatches = _create_minibatches(traj_batch, advantages, targets, init_ego_hstate, config["NUM_CONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng)
+                minibatches = _create_minibatches(
+                    traj_batch,
+                    advantages,
+                    targets,
+                    init_ego_hstate,
+                    config["NUM_CONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng,
+                )
                 train_state, losses_and_grads = jax.lax.scan(
                     _update_minbatch, train_state, minibatches
                 )
-                update_state = (train_state, init_ego_hstate, traj_batch, advantages, targets, rng)
+                update_state = (
+                    train_state,
+                    init_ego_hstate,
+                    traj_batch,
+                    advantages,
+                    targets,
+                    rng,
+                )
                 return update_state, losses_and_grads
 
             def _update_step(update_runner_state, unused):
@@ -289,28 +368,56 @@ def train_ppo_ego_agent(config, env, train_rng,
                 rng, reset_rng, p_rng = jax.random.split(rng, 3)
                 reset_rngs = jax.random.split(reset_rng, config["NUM_ENVS"])
                 init_obs, init_env_state = jax.vmap(env.reset, in_axes=(0,))(reset_rngs)
-                init_done = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
-                new_partner_indices = partner_population.sample_agent_indices(config["NUM_UNCONTROLLED_ACTORS"], p_rng)
+                init_done = {
+                    k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                    for k in env.agents + ["__all__"]
+                }
+                new_partner_indices = partner_population.sample_agent_indices(
+                    config["NUM_UNCONTROLLED_ACTORS"], p_rng
+                )
 
                 # 1) rollout
-                runner_state = (train_state, init_env_state, init_obs, init_done, init_ego_hstate, init_partner_hstate, new_partner_indices, rng)
+                runner_state = (
+                    train_state,
+                    init_env_state,
+                    init_obs,
+                    init_done,
+                    init_ego_hstate,
+                    init_partner_hstate,
+                    new_partner_indices,
+                    rng,
+                )
 
                 runner_state, traj_batch = jax.lax.scan(
-                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"])
-                (train_state, env_state, obs, done, ego_hstate, partner_hstate, partner_indices, rng) = runner_state
+                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    train_state,
+                    env_state,
+                    obs,
+                    done,
+                    ego_hstate,
+                    _partner_hstate,
+                    _partner_indices,
+                    rng,
+                ) = runner_state
 
                 # 2) advantage
                 # Get available actions for agent 0 from environment state
-                avail_actions_0 = jax.vmap(env.get_avail_actions)(env_state.env_state)["agent_0"].astype(jnp.float32)
-                                
+                avail_actions_0 = jax.vmap(env.get_avail_actions)(env_state.env_state)[
+                    "agent_0"
+                ].astype(jnp.float32)
+
                 # Get final value estimate for completed trajectory
                 _, last_val, _, _ = ego_policy.get_action_value_policy(
-                    params=train_state.params, 
+                    params=train_state.params,
                     obs=obs["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
                     done=done["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
                     avail_actions=jax.lax.stop_gradient(avail_actions_0),
                     hstate=ego_hstate,
-                    rng=jax.random.PRNGKey(0)  # Dummy key since we're just extracting the value
+                    rng=jax.random.PRNGKey(
+                        0
+                    ),  # Dummy key since we're just extracting the value
                 )
                 last_val = last_val.squeeze()
                 advantages, targets = _calculate_gae(traj_batch, last_val)
@@ -318,21 +425,24 @@ def train_ppo_ego_agent(config, env, train_rng,
                 # 3) PPO update
                 update_state = (
                     train_state,
-                    init_ego_hstate, # shape is (num_controlled_actors, gru_hidden_dim) with all-0s value
-                    traj_batch, # obs has shape (rollout_len, num_controlled_actors, -1)
+                    init_ego_hstate,  # shape is (num_controlled_actors, gru_hidden_dim) with all-0s value
+                    traj_batch,  # obs has shape (rollout_len, num_controlled_actors, -1)
                     advantages,
                     targets,
-                    rng
+                    rng,
                 )
                 update_state, losses_and_grads = jax.lax.scan(
-                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                )
                 train_state = update_state[0]
                 _, loss_terms, avg_grad_norm = losses_and_grads
-                
+
                 def mask_and_mean(x, mask):
                     return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
-                
-                mask = traj_batch.info.get("returned_episode", jnp.ones_like(traj_batch.reward))
+
+                mask = traj_batch.info.get(
+                    "returned_episode", jnp.ones_like(traj_batch.reward)
+                )
                 metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch.info)
                 metric["update_steps"] = update_steps
                 metric["actor_loss"] = loss_terms[1].mean()
@@ -343,14 +453,16 @@ def train_ppo_ego_agent(config, env, train_rng,
                 return (new_runner_state, metric)
 
             # PPO Update and Checkpoint saving
-            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)  # -1 because we store a ckpt at the last update
+            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                1, config["NUM_CHECKPOINTS"] - 1
+            )  # -1 because we store a ckpt at the last update
             num_ckpts = config["NUM_CHECKPOINTS"]
 
             # Build a PyTree that holds parameters for all FCP checkpoints
             def init_ckpt_array(params_pytree):
                 return jax.tree.map(
-                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), 
-                    params_pytree)
+                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
+                )
 
             max_episode_steps = config["ROLLOUT_LENGTH"]
 
@@ -359,45 +471,61 @@ def train_ppo_ego_agent(config, env, train_rng,
                     f"[train] update {int(step)}/{int(config['NUM_UPDATES'])} "
                     f"avg_eval_return={float(ret):.4f}"
                 )
-            
+
             def _update_step_with_ckpt(state_with_ckpt, unused):
-                (update_state, checkpoint_array, ckpt_idx, init_eval_last_info) = state_with_ckpt
+                (update_state, checkpoint_array, ckpt_idx, init_eval_last_info) = (
+                    state_with_ckpt
+                )
 
                 # Single PPO update
-                new_update_state, metric = _update_step(
-                    update_state,
-                    None
-                )
+                new_update_state, metric = _update_step(update_state, None)
                 (train_state, rng, update_steps) = new_update_state
 
                 # update steps is 1-indexed because it was incremented at the end of the update step
-                to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                        jnp.equal(update_steps, config["NUM_UPDATES"]))
-
+                to_store = jnp.logical_or(
+                    jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
+                )
 
                 def store_and_eval_ckpt(args):
-                    ckpt_arr, cidx, rng, prev_eval_ret_info = args
+                    ckpt_arr, cidx, rng, _prev_eval_ret_info = args
                     new_ckpt_arr = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr, train_state.params
+                        ckpt_arr,
+                        train_state.params,
                     )
 
                     eval_partner_indices = jnp.arange(num_total_partners)
-                    gathered_params = partner_population.gather_agent_params(partner_params, eval_partner_indices)
-                    
+                    gathered_params = partner_population.gather_agent_params(
+                        partner_params, eval_partner_indices
+                    )
+
                     rng, eval_rng = jax.random.split(rng)
-                    eval_eps_last_infos = jax.tree.map(lambda x: x.mean(), jax.vmap(lambda x: run_episodes(
-                        eval_rng, env, agent_0_param=train_state.params, agent_0_policy=ego_policy,
-                        agent_1_param=x, agent_1_policy=partner_population.policy_cls,
-                        max_episode_steps=max_episode_steps,
-                        num_eps=config["NUM_EVAL_EPISODES"]))(gathered_params))
+                    eval_eps_last_infos = jax.tree.map(
+                        lambda x: x.mean(),
+                        jax.vmap(
+                            lambda x: run_episodes(
+                                eval_rng,
+                                env,
+                                agent_0_param=train_state.params,
+                                agent_0_policy=ego_policy,
+                                agent_1_param=x,
+                                agent_1_policy=partner_population.policy_cls,
+                                max_episode_steps=max_episode_steps,
+                                num_eps=config["NUM_EVAL_EPISODES"],
+                            )
+                        )(gathered_params),
+                    )
                     return (new_ckpt_arr, cidx + 1, rng, eval_eps_last_infos)
-                
+
                 def skip_ckpt(args):
                     return args
 
                 (checkpoint_array, ckpt_idx, rng, eval_last_infos) = jax.lax.cond(
-                    to_store, store_and_eval_ckpt, skip_ckpt, (checkpoint_array, ckpt_idx, rng, init_eval_last_info)
+                    to_store,
+                    store_and_eval_ckpt,
+                    skip_ckpt,
+                    (checkpoint_array, ckpt_idx, rng, init_eval_last_info),
                 )
 
                 # Condense per-timestep metrics to per-update scalars.
@@ -408,8 +536,13 @@ def train_ppo_ego_agent(config, env, train_rng,
                 n_episodes = mask.sum()
                 condensed_metric = {}
                 for key, val in metric.items():
-                    if key in ("update_steps", "actor_loss", "value_loss",
-                               "entropy_loss", "avg_grad_norm"):
+                    if key in (
+                        "update_steps",
+                        "actor_loss",
+                        "value_loss",
+                        "entropy_loss",
+                        "avg_grad_norm",
+                    ):
                         # Already scalar-ish from loss aggregation
                         condensed_metric[key] = val.mean() if val.ndim > 0 else val
                     elif key == "returned_episode":
@@ -417,7 +550,8 @@ def train_ppo_ego_agent(config, env, train_rng,
                     else:
                         condensed_metric[key] = jnp.where(
                             n_episodes > 0,
-                            jnp.where(mask, val, 0.0).sum() / jnp.maximum(n_episodes, 1),
+                            jnp.where(mask, val, 0.0).sum()
+                            / jnp.maximum(n_episodes, 1),
                             0.0,
                         )
                 condensed_metric["eval_ep_last_info"] = eval_last_infos
@@ -425,13 +559,12 @@ def train_ppo_ego_agent(config, env, train_rng,
                 avg_eval_return = eval_last_infos["returned_episode_returns"].mean()
                 should_log_progress = jnp.logical_or(
                     jnp.equal(jnp.mod(update_steps, local_progress_interval), 0),
-                    jnp.equal(update_steps, config["NUM_UPDATES"])
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
                 )
 
                 def _log_progress(args):
                     step, ret = args
                     jax.debug.callback(_emit_progress, step, ret)
-                    return None
 
                 jax.lax.cond(
                     should_log_progress,
@@ -439,8 +572,12 @@ def train_ppo_ego_agent(config, env, train_rng,
                     lambda _: None,
                     (update_steps, avg_eval_return),
                 )
-                return ((train_state, rng, update_steps),
-                         checkpoint_array, ckpt_idx, eval_last_infos), condensed_metric
+                return (
+                    (train_state, rng, update_steps),
+                    checkpoint_array,
+                    ckpt_idx,
+                    eval_last_infos,
+                ), condensed_metric
 
             checkpoint_array = init_ckpt_array(train_state.params)
             ckpt_idx = 0
@@ -448,34 +585,56 @@ def train_ppo_ego_agent(config, env, train_rng,
             rng, rng_eval, rng_train = jax.random.split(rng, 3)
             # Init eval return infos
             eval_partner_indices = jnp.arange(num_total_partners)
-            gathered_params = partner_population.gather_agent_params(partner_params, eval_partner_indices)
-            eval_eps_last_infos = jax.tree.map(lambda x: x.mean(), jax.vmap(lambda x: run_episodes(
-                        rng_eval, env,
-                        agent_0_param=train_state.params, agent_0_policy=ego_policy,
-                        agent_1_param=x, agent_1_policy=partner_population.policy_cls,
+            gathered_params = partner_population.gather_agent_params(
+                partner_params, eval_partner_indices
+            )
+            eval_eps_last_infos = jax.tree.map(
+                lambda x: x.mean(),
+                jax.vmap(
+                    lambda x: run_episodes(
+                        rng_eval,
+                        env,
+                        agent_0_param=train_state.params,
+                        agent_0_policy=ego_policy,
+                        agent_1_param=x,
+                        agent_1_policy=partner_population.policy_cls,
                         max_episode_steps=max_episode_steps,
-                        num_eps=config["NUM_EVAL_EPISODES"]))(gathered_params))
+                        num_eps=config["NUM_EVAL_EPISODES"],
+                    )
+                )(gathered_params),
+            )
 
             # initial runner state for scanning
             update_steps = 0
-            rng_train, partner_rng = jax.random.split(rng_train)
+            rng_train, _partner_rng = jax.random.split(rng_train)
 
             update_runner_state = (train_state, rng_train, update_steps)
-            state_with_ckpt = (update_runner_state, checkpoint_array, ckpt_idx, eval_eps_last_infos)
-            
+            state_with_ckpt = (
+                update_runner_state,
+                checkpoint_array,
+                ckpt_idx,
+                eval_eps_last_infos,
+            )
+
             state_with_ckpt, metrics = jax.lax.scan(
                 _update_step_with_ckpt,
                 state_with_ckpt,
                 xs=None,
-                length=config["NUM_UPDATES"]
+                length=config["NUM_UPDATES"],
             )
-            (final_runner_state, checkpoint_array, final_ckpt_idx, eval_eps_last_infos) = state_with_ckpt
+            (
+                final_runner_state,
+                checkpoint_array,
+                _final_ckpt_idx,
+                eval_eps_last_infos,
+            ) = state_with_ckpt
             out = {
                 "final_params": final_runner_state[0].params,
                 "metrics": metrics,  # shape (NUM_UPDATES, ...)
                 "checkpoints": checkpoint_array,
             }
             return out
+
         return train
 
     # ------------------------------
@@ -483,15 +642,16 @@ def train_ppo_ego_agent(config, env, train_rng,
     # ------------------------------
     rngs = jax.random.split(train_rng, n_ego_train_seeds)
     train_fn = jax.jit(jax.vmap(make_ppo_train(config)))
-    out = train_fn(rngs)    
+    out = train_fn(rngs)
     return out
 
+
 def run_ego_training(config, wandb_logger):
-    '''Run ego agent training against the population of partner agents.
-    
+    """Run ego agent training against the population of partner agents.
+
     Args:
         config: dict, config for the training
-    '''
+    """
     algorithm_config = dict(config["algorithm"])
 
     # Create only one environment instance
@@ -500,35 +660,43 @@ def run_ego_training(config, wandb_logger):
 
     rng = jax.random.PRNGKey(algorithm_config["TRAIN_SEED"])
     rng, init_partner_rng, init_ego_rng, train_rng = jax.random.split(rng, 4)
-    
 
     partner_agent_config = dict(algorithm_config["partner_agent"])
-    assert len(partner_agent_config) == 1, "Only supports training against one type of partner agent."
-    
-    partner0_name = list(partner_agent_config.keys())[0]
-    partner0_agent_config = list(partner_agent_config.values())[0]
-    partner_policy, partner_params, init_partner_params, idx_labels = initialize_rl_agent_from_config(
-        partner0_agent_config, partner0_name, env, init_partner_rng)
+    assert len(partner_agent_config) == 1, (
+        "Only supports training against one type of partner agent."
+    )
 
-    flattened_partner_params = jax.tree.map(lambda x, y: x.reshape((-1,) + y.shape), partner_params, init_partner_params)        
+    partner0_name = next(iter(partner_agent_config.keys()))
+    partner0_agent_config = next(iter(partner_agent_config.values()))
+    partner_policy, partner_params, init_partner_params, _idx_labels = (
+        initialize_rl_agent_from_config(
+            partner0_agent_config, partner0_name, env, init_partner_rng
+        )
+    )
+
+    flattened_partner_params = jax.tree.map(
+        lambda x, y: x.reshape((-1,) + y.shape), partner_params, init_partner_params
+    )
     pop_size = jax.tree.leaves(flattened_partner_params)[0].shape[0]
 
     # Create partner population
-    partner_population = AgentPopulation(
-        pop_size=pop_size,
-        policy_cls=partner_policy
-    )
-    
+    partner_population = AgentPopulation(pop_size=pop_size, policy_cls=partner_policy)
+
     # Initialize ego agent
-    ego_policy, init_ego_params = initialize_ego_agent(algorithm_config, env, init_ego_rng)
+    ego_policy, init_ego_params = initialize_ego_agent(
+        algorithm_config, env, init_ego_rng
+    )
 
     expected_updates = int(
-        algorithm_config["TOTAL_TIMESTEPS"] //
-        algorithm_config["ROLLOUT_LENGTH"] //
-        algorithm_config["NUM_ENVS"]
+        algorithm_config["TOTAL_TIMESTEPS"]
+        // algorithm_config["ROLLOUT_LENGTH"]
+        // algorithm_config["NUM_ENVS"]
     )
-    progress_interval = int(algorithm_config.get("PROGRESS_LOG_INTERVAL", 0) or max(1, expected_updates // 20))
-    
+    progress_interval = int(
+        algorithm_config.get("PROGRESS_LOG_INTERVAL", 0)
+        or max(1, expected_updates // 20)
+    )
+
     log.info(
         "Starting ego agent training with %s updates, %s envs, %s partner(s). "
         "Progress will be logged every ~%s updates.",
@@ -538,7 +706,7 @@ def run_ego_training(config, wandb_logger):
         progress_interval,
     )
     start_time = time.time()
-    
+
     # Run the training
     out = train_ppo_ego_agent(
         config=algorithm_config,
@@ -548,20 +716,21 @@ def run_ego_training(config, wandb_logger):
         init_ego_params=init_ego_params,
         n_ego_train_seeds=algorithm_config["NUM_EGO_TRAIN_SEEDS"],
         partner_population=partner_population,
-        partner_params=flattened_partner_params
+        partner_params=flattened_partner_params,
     )
-    
+
     log.info(f"Training completed in {time.time() - start_time:.2f} seconds")
-    
+
     # process and log metrics
     metric_names = get_metric_names(config["ENV_NAME"])
     log_metrics(config, out, wandb_logger, metric_names)
-    
+
     return out["final_params"], ego_policy, init_ego_params
+
 
 def log_metrics(config, train_out, logger, metric_names: tuple):
     """Process training metrics and log them using the provided logger.
-    
+
     Args:
         training_logs: dict, the logs from training
         logger: Logger, instance to log metrics
@@ -574,14 +743,16 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
     # each key in train_stats is a metric name, and the value is an array of shape (num_seeds, num_updates, 2)
     # where the last dimension contains the mean and std of the metric
     train_stats = {k: np.mean(np.array(v), axis=0) for k, v in train_stats.items()}
-    
+
     all_ego_value_losses = np.asarray(train_metrics["value_loss"])
     all_ego_actor_losses = np.asarray(train_metrics["actor_loss"])
     all_ego_entropy_losses = np.asarray(train_metrics["entropy_loss"])
     all_ego_grad_norms = np.asarray(train_metrics["avg_grad_norm"])
     # Process eval return metrics - average across ego seeds, eval episodes,
     # training partners and num_agents per game for each checkpoint
-    all_ego_returns = np.asarray(train_metrics["eval_ep_last_info"]["returned_episode_returns"])
+    all_ego_returns = np.asarray(
+        train_metrics["eval_ep_last_info"]["returned_episode_returns"]
+    )
     # Handle both condensed (scalars per update) and full metric shapes.
     # Condensed: (n_ego_train_seeds, num_updates)
     # Full: (n_ego_train_seeds, num_updates, num_partners, ...)
@@ -601,21 +772,50 @@ def log_metrics(config, train_out, logger, metric_names: tuple):
         for stat_name, stat_data in train_stats.items():
             # second dimension contains the mean and std of the metric
             stat_mean = stat_data[step, 0]
-            logger.log_item(f"Train/Ego_{stat_name}", stat_mean, train_step=step, commit=True)
+            logger.log_item(
+                f"Train/Ego_{stat_name}", stat_mean, train_step=step, commit=True
+            )
 
-        logger.log_item("Eval/EgoReturn", average_ego_rets_per_iter[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoValueLoss", average_ego_value_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoActorLoss", average_ego_actor_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoEntropyLoss", average_ego_entropy_losses[step], train_step=step, commit=True)
-        logger.log_item("Train/EgoGradNorm", average_ego_grad_norms[step], train_step=step, commit=True)
+        logger.log_item(
+            "Eval/EgoReturn",
+            average_ego_rets_per_iter[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoValueLoss",
+            average_ego_value_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoActorLoss",
+            average_ego_actor_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoEntropyLoss",
+            average_ego_entropy_losses[step],
+            train_step=step,
+            commit=True,
+        )
+        logger.log_item(
+            "Train/EgoGradNorm",
+            average_ego_grad_norms[step],
+            train_step=step,
+            commit=True,
+        )
         logger.commit()
-    
+
     # Saving artifacts
     savedir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
 
     out_savepath = save_train_run(train_out, savedir, savename="ego_train_run")
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="ego_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="ego_train_run", path=out_savepath, type_name="train_run"
+        )
         # Cleanup locally logged out file
     if not config["local_logger"]["save_train_out"]:
         shutil.rmtree(out_savepath)

--- a/ego_agent_training/ppo_ego.py
+++ b/ego_agent_training/ppo_ego.py
@@ -183,7 +183,8 @@ def train_ppo_ego_agent(config, env, train_rng,
                     log_prob=logp_0,
                     obs=prev_obs["agent_0"],
                     info=info_0,
-                    avail_actions=avail_actions_0
+                    avail_actions=avail_actions_0,
+                    prev_done=prev_done["agent_0"]
                 )
                 new_runner_state = (train_state, env_state_next, obs_next, done_next, 
                                     new_ego_hstate, new_partner_hstate, updated_partner_indices, rng)
@@ -220,7 +221,7 @@ def train_ppo_ego_agent(config, env, train_rng,
                     _, value, pi, _ = ego_policy.get_action_value_policy(
                         params=params, 
                         obs=traj_batch.obs,
-                        done=traj_batch.done,
+                        done=traj_batch.prev_done,
                         avail_actions=traj_batch.avail_actions,
                         hstate=init_ego_hstate,
                         rng=jax.random.PRNGKey(0) # only used for action sampling, which is unused here

--- a/marl/ippo.py
+++ b/marl/ippo.py
@@ -1,28 +1,33 @@
-'''
+"""
 Based on the IPPO implementation from JaxMarl. Trains a parameter-shared IPPO agent on a
 fully cooperative multi-agent environment.
 
 Recommended run command:
 python marl/run.py task=lbf/lbf_7x7_nolevels algorithm=ippo/lbf/lbf_7x7_nolevels
-'''
+"""
+
 import copy
 import shutil
 
 import hydra
-import numpy as np
 import jax
-from tqdm import tqdm
 import jax.numpy as jnp
+import numpy as np
 import optax
 from flax.training.train_state import TrainState
+from tqdm import tqdm
 
-from agents.initialize_agents import initialize_s5_agent, initialize_mlp_agent, \
-    initialize_rnn_agent, initialize_pseudo_actor_with_double_critic, initialize_pseudo_actor_with_conditional_critic
-from common.plot_utils import get_stats, get_metric_names
+from agents.initialize_agents import (
+    initialize_mlp_agent,
+    initialize_pseudo_actor_with_conditional_critic,
+    initialize_pseudo_actor_with_double_critic,
+    initialize_rnn_agent,
+    initialize_s5_agent,
+)
 from common.save_load_utils import save_train_run
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from marl.ppo_utils import Transition, batchify, unbatchify, _create_minibatches
+from marl.ppo_utils import Transition, _create_minibatches, batchify, unbatchify
 
 
 def initialize_agent(actor_type, algorithm_config, env, init_rng):
@@ -33,13 +38,18 @@ def initialize_agent(actor_type, algorithm_config, env, init_rng):
     elif actor_type == "rnn":
         policy, init_params = initialize_rnn_agent(algorithm_config, env, init_rng)
     elif actor_type == "pseudo_actor_with_double_critic":
-        policy, init_params = initialize_pseudo_actor_with_double_critic(algorithm_config, env, init_rng)
+        policy, init_params = initialize_pseudo_actor_with_double_critic(
+            algorithm_config, env, init_rng
+        )
     elif actor_type == "pseudo_actor_with_conditional_critic":
-        policy, init_params = initialize_pseudo_actor_with_conditional_critic(algorithm_config, env, init_rng)
+        policy, init_params = initialize_pseudo_actor_with_conditional_critic(
+            algorithm_config, env, init_rng
+        )
     return policy, init_params
 
+
 def make_train(config, env, logger, progress_callback=None):
-    config = copy.copy(config)    
+    config = copy.copy(config)
     config["NUM_ACTORS"] = env.num_agents * config["NUM_ENVS"]
     config["NUM_UPDATES"] = (
         config["TOTAL_TIMESTEPS"] // config["ROLLOUT_LENGTH"] // config["NUM_ENVS"]
@@ -49,13 +59,19 @@ def make_train(config, env, logger, progress_callback=None):
     )
 
     def linear_schedule(count):
-        frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+        frac = (
+            1.0
+            - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+            / config["NUM_UPDATES"]
+        )
         return config["LR"] * frac
 
     def train(rng):
         # INIT NETWORK
         rng, init_rng = jax.random.split(rng)
-        policy, init_params = initialize_agent(config["ACTOR_TYPE"], config, env, init_rng)
+        policy, init_params = initialize_agent(
+            config["ACTOR_TYPE"], config, env, init_rng
+        )
 
         if config["ANNEAL_LR"]:
             tx = optax.chain(
@@ -64,8 +80,9 @@ def make_train(config, env, logger, progress_callback=None):
             )
         else:
             tx = optax.chain(
-                optax.clip_by_global_norm(config["MAX_GRAD_NORM"]), 
-                optax.adam(config["LR"], eps=1e-5))
+                optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
+                optax.adam(config["LR"], eps=1e-5),
+            )
         train_state = TrainState.create(
             apply_fn=policy.network.apply,
             params=init_params,
@@ -82,7 +99,9 @@ def make_train(config, env, logger, progress_callback=None):
             runner_state, update_steps = update_runner_state
 
             def _env_step(runner_state, unused):
-                train_state, env_state, last_obs, last_done, last_hstate, rng = runner_state
+                train_state, env_state, last_obs, last_done, last_hstate, rng = (
+                    runner_state
+                )
 
                 rng, act_rng = jax.random.split(rng, 2)
 
@@ -93,8 +112,11 @@ def make_train(config, env, logger, progress_callback=None):
                 # SymmetryAugmentationWrapper inside env.reset/step/get_avail_actions.
                 # See envs/common/symmetry_wrapper.py and envs/hanabi/other_play.py.
                 avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)
-                avail_actions = jax.lax.stop_gradient(batchify(avail_actions,
-                    env.agents, config["NUM_ACTORS"]).astype(jnp.float32))
+                avail_actions = jax.lax.stop_gradient(
+                    batchify(avail_actions, env.agents, config["NUM_ACTORS"]).astype(
+                        jnp.float32
+                    )
+                )
 
                 action, value, pi, new_hstate = policy.get_action_value_policy(
                     params=train_state.params,
@@ -102,7 +124,7 @@ def make_train(config, env, logger, progress_callback=None):
                     done=last_done_batch.reshape(1, config["NUM_ACTORS"]),
                     avail_actions=avail_actions.reshape(1, config["NUM_ACTORS"], -1),
                     hstate=last_hstate,
-                    rng=act_rng
+                    rng=act_rng,
                 )
                 log_prob = pi.log_prob(action)
 
@@ -110,18 +132,20 @@ def make_train(config, env, logger, progress_callback=None):
                 log_prob = log_prob.squeeze()
                 value = value.squeeze()
 
-                env_act = unbatchify(action, env.agents, config["NUM_ENVS"], env.num_agents)
-                env_act = {k:v.flatten() for k,v in env_act.items()}
+                env_act = unbatchify(
+                    action, env.agents, config["NUM_ENVS"], env.num_agents
+                )
+                env_act = {k: v.flatten() for k, v in env_act.items()}
 
                 rng, _rng = jax.random.split(rng)
                 rng_step = jax.random.split(_rng, config["NUM_ENVS"])
 
-                new_obs, new_env_state, reward, new_done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    rng_step, env_state, env_act
-                )
-                
+                new_obs, new_env_state, reward, new_done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(rng_step, env_state, env_act)
+
                 # note that num_actors = num_envs * num_agents
-                info = jax.tree.map(lambda x: x.reshape((config["NUM_ACTORS"])), info)
+                info = jax.tree.map(lambda x: x.reshape(config["NUM_ACTORS"]), info)
 
                 transition = Transition(
                     batchify(new_done, env.agents, config["NUM_ACTORS"]).squeeze(),
@@ -134,9 +158,16 @@ def make_train(config, env, logger, progress_callback=None):
                     avail_actions,
                     last_done_batch.squeeze(),
                 )
-                runner_state = (train_state, new_env_state, new_obs, new_done, new_hstate, rng)
+                runner_state = (
+                    train_state,
+                    new_env_state,
+                    new_obs,
+                    new_done,
+                    new_hstate,
+                    rng,
+                )
                 return runner_state, transition
-            
+
             runner_state, traj_batch = jax.lax.scan(
                 _env_step, runner_state, None, config["ROLLOUT_LENGTH"]
             )
@@ -148,16 +179,21 @@ def make_train(config, env, logger, progress_callback=None):
             last_done_batch = batchify(last_done, env.agents, config["NUM_ACTORS"])
             last_done_batch = last_done_batch.reshape(1, config["NUM_ACTORS"])
             last_avail_batch = jax.vmap(env.get_avail_actions)(env_state.env_state)
-            last_avail_batch = jax.lax.stop_gradient(batchify(last_avail_batch, 
-                env.agents, config["NUM_ACTORS"]).astype(jnp.float32))
-            
+            last_avail_batch = jax.lax.stop_gradient(
+                batchify(last_avail_batch, env.agents, config["NUM_ACTORS"]).astype(
+                    jnp.float32
+                )
+            )
+
             _, last_val, _, _ = policy.get_action_value_policy(
                 params=train_state.params,
                 obs=last_obs_batch,
                 done=last_done_batch,
                 avail_actions=last_avail_batch,
                 hstate=last_hstate,
-                rng=jax.random.PRNGKey(0)  # Dummy key since we're just extracting the value
+                rng=jax.random.PRNGKey(
+                    0
+                ),  # Dummy key since we're just extracting the value
             )
             last_val = last_val.squeeze()
 
@@ -190,6 +226,7 @@ def make_train(config, env, logger, progress_callback=None):
             def _update_epoch(update_state, unused):
                 def _update_minbatch(train_state, batch_info):
                     init_hstate, traj_batch, advantages, targets = batch_info
+
                     def _loss_fn(params, traj_batch, gae, targets):
                         # RERUN NETWORK
                         _, value, pi, _ = policy.get_action_value_policy(
@@ -198,7 +235,9 @@ def make_train(config, env, logger, progress_callback=None):
                             done=traj_batch.prev_done,
                             avail_actions=traj_batch.avail_actions,
                             hstate=init_hstate,
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is unused here
+                            rng=jax.random.PRNGKey(
+                                0
+                            ),  # only used for action sampling, which is unused here
                         )
                         log_prob = pi.log_prob(traj_batch.action)
 
@@ -208,9 +247,9 @@ def make_train(config, env, logger, progress_callback=None):
                         ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                         value_losses = jnp.square(value - targets)
                         value_losses_clipped = jnp.square(value_pred_clipped - targets)
-                        value_loss = (
-                            jnp.maximum(value_losses, value_losses_clipped).mean()
-                        )
+                        value_loss = jnp.maximum(
+                            value_losses, value_losses_clipped
+                        ).mean()
 
                         # CALCULATE ACTOR LOSS
                         ratio = jnp.exp(log_prob - traj_batch.log_prob)
@@ -242,26 +281,53 @@ def make_train(config, env, logger, progress_callback=None):
                     train_state = train_state.apply_gradients(grads=grads)
                     return train_state, total_loss
 
-                train_state, init_hstate, traj_batch, advantages, targets, rng = update_state
+                train_state, init_hstate, traj_batch, advantages, targets, rng = (
+                    update_state
+                )
                 rng, perm_rng = jax.random.split(rng)
-                minibatches = _create_minibatches(traj_batch, advantages, targets, init_hstate, 
-                                                  config["NUM_ACTORS"], config["NUM_MINIBATCHES"], perm_rng)
+                minibatches = _create_minibatches(
+                    traj_batch,
+                    advantages,
+                    targets,
+                    init_hstate,
+                    config["NUM_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng,
+                )
 
                 train_state, total_loss = jax.lax.scan(
                     _update_minbatch, train_state, minibatches
                 )
-                update_state = (train_state, init_hstate, traj_batch, advantages, targets, rng)
+                update_state = (
+                    train_state,
+                    init_hstate,
+                    traj_batch,
+                    advantages,
+                    targets,
+                    rng,
+                )
                 return update_state, total_loss
+
             init_hstate = policy.init_hstate(config["NUM_ACTORS"])
-            update_state = (train_state, init_hstate, traj_batch, advantages, targets, rng)
+            update_state = (
+                train_state,
+                init_hstate,
+                traj_batch,
+                advantages,
+                targets,
+                rng,
+            )
             update_state, loss_info = jax.lax.scan(
                 _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
             )
             train_state = update_state[0]
+
             def mask_and_mean(x, mask):
                 return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
-            
-            mask = traj_batch.info.get("returned_episode", jnp.ones_like(traj_batch.reward))
+
+            mask = traj_batch.info.get(
+                "returned_episode", jnp.ones_like(traj_batch.reward)
+            )
             metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch.info)
             metric["update_steps"] = update_steps
 
@@ -275,7 +341,14 @@ def make_train(config, env, logger, progress_callback=None):
 
             rng = update_state[-1]
             update_steps += 1
-            runner_state = (train_state, env_state, last_obs, last_done, last_hstate, rng)
+            runner_state = (
+                train_state,
+                env_state,
+                last_obs,
+                last_done,
+                last_hstate,
+                rng,
+            )
 
             # Condense metrics to per-update scalars for the scan output.
             # Full per-timestep metrics are already logged via io_callback above.
@@ -306,25 +379,30 @@ def make_train(config, env, logger, progress_callback=None):
 
             return (runner_state, update_steps), condensed_metric
 
-        ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)
+        ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+            1, config["NUM_CHECKPOINTS"] - 1
+        )
         num_ckpts = config["NUM_CHECKPOINTS"]
 
         # build a pytree that can hold the parameters for all checkpoints.
         def init_ckpt_array(params_pytree):
             return jax.tree.map(
-                lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype),
-                params_pytree
+                lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
             )
 
         def _update_step_with_checkpoint(update_with_ckpt_runner_state, unused):
-            (update_runner_state, checkpoint_array, ckpt_idx) = update_with_ckpt_runner_state
+            (update_runner_state, checkpoint_array, ckpt_idx) = (
+                update_with_ckpt_runner_state
+            )
             # update_runner_state is ((train_state, env_state, obs, done, hstate, rng), update_steps)
             # Run one PPO update step
             update_runner_state, metric = _update_step(update_runner_state, None)
             _, update_steps = update_runner_state
             # update steps is 1-indexed because it was incremented at the end of the update step
-            to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                      jnp.equal(update_steps, config["NUM_UPDATES"]))
+            to_store = jnp.logical_or(
+                jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                jnp.equal(update_steps, config["NUM_UPDATES"]),
+            )
 
             def store_ckpt_fn(args):
                 # Write current runner_state[0].params into checkpoint_array at ckpt_idx
@@ -333,18 +411,19 @@ def make_train(config, env, logger, progress_callback=None):
                 new_checkpoint_array = jax.tree.map(
                     lambda c_arr, p: c_arr.at[_ckpt_idx].set(p),
                     _checkpoint_array,
-                    update_runner_state[0][0].params
+                    update_runner_state[0][0].params,
                 )
-                return new_checkpoint_array, _ckpt_idx + 1 
+                return new_checkpoint_array, _ckpt_idx + 1
+
             # TODO: potential issue is that if this function is always executed regardless of whether to_store is true or false, then _ckpt_idx will be wrong
 
             def skip_ckpt_fn(args):
                 return args  # No changes if we don't store
 
             checkpoint_array, ckpt_idx = jax.lax.cond(
-                to_store, # if to_store, execute true function(operand). else, execute false function(operand).
-                store_ckpt_fn, # true fn
-                skip_ckpt_fn, # false fn
+                to_store,  # if to_store, execute true function(operand). else, execute false function(operand).
+                store_ckpt_fn,  # true fn
+                skip_ckpt_fn,  # false fn
                 (checkpoint_array, ckpt_idx),
             )
 
@@ -355,11 +434,21 @@ def make_train(config, env, logger, progress_callback=None):
         rng, _rng = jax.random.split(rng)
         update_steps = 0
         init_hstate = policy.init_hstate(config["NUM_ACTORS"])
-        init_done = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
-        update_runner_state = ((train_state, env_state, obsv, init_done, init_hstate, _rng), update_steps)
+        init_done = {
+            k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+            for k in env.agents + ["__all__"]
+        }
+        update_runner_state = (
+            (train_state, env_state, obsv, init_done, init_hstate, _rng),
+            update_steps,
+        )
         checkpoint_array = init_ckpt_array(train_state.params)
         ckpt_idx = 0
-        update_with_ckpt_runner_state = (update_runner_state, checkpoint_array, ckpt_idx)
+        update_with_ckpt_runner_state = (
+            update_runner_state,
+            checkpoint_array,
+            ckpt_idx,
+        )
 
         runner_state, metrics = jax.lax.scan(
             _update_step_with_checkpoint,
@@ -374,9 +463,11 @@ def make_train(config, env, logger, progress_callback=None):
             "final_params": update_runner_state[0][0].params,
             "metrics": metrics,
             "checkpoints": checkpoint_array,
-            "final_ckpt_idx": final_ckpt_idx # CLEANUP FLAG
+            "final_ckpt_idx": final_ckpt_idx,  # CLEANUP FLAG
         }
+
     return train
+
 
 def run_ippo(config, logger):
     algorithm_config = dict(config.algorithm)
@@ -391,15 +482,18 @@ def run_ippo(config, logger):
                 "USE_OTHER_PLAY currently only supports env_name='hanabi'. "
                 "Add a new EnvSymmetry subclass to use this on other envs."
             )
-        from envs.hanabi.other_play import HanabiColorSymmetry
         from envs.common.symmetry_wrapper import SymmetryAugmentationWrapper
+        from envs.hanabi.other_play import HanabiColorSymmetry
+
         sym = HanabiColorSymmetry(**algorithm_config["ENV_KWARGS"])
         env = SymmetryAugmentationWrapper(env, sym)
 
     env = LogWrapper(env)
 
     num_updates = (
-        algorithm_config["TOTAL_TIMESTEPS"] // algorithm_config["ROLLOUT_LENGTH"] // algorithm_config["NUM_ENVS"]
+        algorithm_config["TOTAL_TIMESTEPS"]
+        // algorithm_config["ROLLOUT_LENGTH"]
+        // algorithm_config["NUM_ENVS"]
     )
     num_seeds = algorithm_config["NUM_SEEDS"]
     pbar = tqdm(total=num_updates, desc="IPPO Training", unit="update")
@@ -415,7 +509,13 @@ def run_ippo(config, logger):
     rngs = jax.random.split(rng, algorithm_config["NUM_SEEDS"])
 
     with jax.disable_jit(False):
-        train_jit = jax.jit(jax.vmap(make_train(algorithm_config, env, logger, progress_callback=update_progress_bar)))
+        train_jit = jax.jit(
+            jax.vmap(
+                make_train(
+                    algorithm_config, env, logger, progress_callback=update_progress_bar
+                )
+            )
+        )
         out = train_jit(rngs)
 
     pbar.close()
@@ -425,23 +525,27 @@ def run_ippo(config, logger):
 
     return out
 
+
 def log_metrics_intermediate(train_stats, logger):
     # Log metrics for one update step
     step = int(np.array(train_stats.pop("update_steps")))
-    
+
     metric_names = [k for k in train_stats if k != "returned_episode"]
-    for stat_name in metric_names:        
+    for stat_name in metric_names:
         stat_mean = float(np.array(train_stats[stat_name]))
         logger.log_item(f"Train/{stat_name}", stat_mean, train_step=step, commit=True)
     logger.commit()
 
+
 def log_artifacts(config, out, logger):
-    '''Save train run output and log to wandb as artifact.'''    
+    """Save train run output and log to wandb as artifact."""
     # save artifacts
     savedir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
     out_savepath = save_train_run(out, savedir, savename="saved_train_run")
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="saved_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="saved_train_run", path=out_savepath, type_name="train_run"
+        )
         # Cleanup locally logged out file
     if not config["local_logger"]["save_train_out"]:
         shutil.rmtree(out_savepath)

--- a/marl/ippo.py
+++ b/marl/ippo.py
@@ -131,7 +131,8 @@ def make_train(config, env, logger, progress_callback=None):
                     log_prob,
                     last_obs_batch,
                     info,
-                    avail_actions
+                    avail_actions,
+                    last_done_batch.squeeze(),
                 )
                 runner_state = (train_state, new_env_state, new_obs, new_done, new_hstate, rng)
                 return runner_state, transition
@@ -194,7 +195,7 @@ def make_train(config, env, logger, progress_callback=None):
                         _, value, pi, _ = policy.get_action_value_policy(
                             params=params,
                             obs=traj_batch.obs,
-                            done=traj_batch.done,
+                            done=traj_batch.prev_done,
                             avail_actions=traj_batch.avail_actions,
                             hstate=init_hstate,
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is unused here

--- a/marl/ppo_utils.py
+++ b/marl/ppo_utils.py
@@ -1,6 +1,8 @@
+from typing import NamedTuple
+
 import jax
 import jax.numpy as jnp
-from typing import NamedTuple
+
 
 class Transition(NamedTuple):
     done: jnp.ndarray  # done at t+1 (post-step); used for GAE bootstrapping
@@ -13,50 +15,55 @@ class Transition(NamedTuple):
     avail_actions: jnp.ndarray
     prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
+
 def batchify(x: dict, agent_list, num_actors):
     x = jnp.stack([x[a] for a in agent_list])
     return x.reshape((num_actors, -1))
 
+
 def batchify_info(x: dict, agent_list, num_actors):
-    '''Handle special case that info has both per-agent and global information'''
+    """Handle special case that info has both per-agent and global information"""
     x = jnp.stack([x[a] for a in x if a in agent_list])
     return x.reshape((num_actors, -1))
+
 
 def unbatchify(x: jnp.ndarray, agent_list, num_envs, num_agents):
     x = x.reshape((num_agents, num_envs, -1))
     return {a: x[i] for i, a in enumerate(agent_list)}
 
 
-def _create_minibatches(traj_batch, advantages, targets, init_hstate, num_actors, num_minibatches, perm_rng):
-    """Create minibatches for PPO updates, where each leaf has shape 
-        (num_minibatches, rollout_len, num_actors / num_minibatches, ...) 
-    This function ensures that the rollout (time) dimension is kept separate from the minibatch and num_actors 
+def _create_minibatches(
+    traj_batch, advantages, targets, init_hstate, num_actors, num_minibatches, perm_rng
+):
+    """Create minibatches for PPO updates, where each leaf has shape
+        (num_minibatches, rollout_len, num_actors / num_minibatches, ...)
+    This function ensures that the rollout (time) dimension is kept separate from the minibatch and num_actors
     dimensions, so that the minibatches are compatible with recurrent ActorCritics.
     """
     # Create batch containing trajectory, advantages, and targets
     batch = (
-        init_hstate, # shape (1, num_actors, hidden_dim)
-        traj_batch, # pytree: obs is shape (rollout_len, num_actors, feat_shape)
-        advantages, # shape (rollout_len, num_actors)
-        targets # shape (rollout_len, num_actors)
-            )
+        init_hstate,  # shape (1, num_actors, hidden_dim)
+        traj_batch,  # pytree: obs is shape (rollout_len, num_actors, feat_shape)
+        advantages,  # shape (rollout_len, num_actors)
+        targets,  # shape (rollout_len, num_actors)
+    )
 
     permutation = jax.random.permutation(perm_rng, num_actors)
 
     # each leaf of shuffled batch has shape (rollout_len, num_actors, feat_shape)
     # except for init_hstate which has shape (1, num_actors, hidden_dim)
-    shuffled_batch = jax.tree.map(
-        lambda x: jnp.take(x, permutation, axis=1), batch
-    )
+    shuffled_batch = jax.tree.map(lambda x: jnp.take(x, permutation, axis=1), batch)
     # each leaf has shape (num_minibatches, rollout_len, num_actors/num_minibatches, feat_shape)
     # except for init_hstate which has shape (num_minibatches, 1, num_actors/num_minibatches, hidden_dim)
     minibatches = jax.tree_util.tree_map(
         lambda x: jnp.swapaxes(
             jnp.reshape(
                 x,
-                [x.shape[0], num_minibatches, -1] 
-                + list(x.shape[2:]),
-        ), 1, 0,),
+                [x.shape[0], num_minibatches, -1] + list(x.shape[2:]),
+            ),
+            1,
+            0,
+        ),
         shuffled_batch,
     )
 

--- a/marl/ppo_utils.py
+++ b/marl/ppo_utils.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 from typing import NamedTuple
 
 class Transition(NamedTuple):
-    done: jnp.ndarray
+    done: jnp.ndarray  # done at t+1 (post-step); used for GAE bootstrapping
     action: jnp.ndarray
     value: jnp.ndarray
     reward: jnp.ndarray
@@ -11,6 +11,7 @@ class Transition(NamedTuple):
     obs: jnp.ndarray
     info: jnp.ndarray
     avail_actions: jnp.ndarray
+    prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
 def batchify(x: dict, agent_list, num_actors):
     x = jnp.stack([x[a] for a in agent_list])

--- a/open_ended_training/cole.py
+++ b/open_ended_training/cole.py
@@ -380,7 +380,8 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                             log_prob=logp_0,
                             obs=last_obs["agent_0"],
                             info=info_0,
-                            avail_actions=avail_actions_0
+                            avail_actions=avail_actions_0,
+                            prev_done=last_dones["agent_0"]
                         )
                         new_runner_state = (train_state, pop_buffer, partner_indices,
                                             env_state_next, obs_next, done,
@@ -453,7 +454,8 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                             log_prob=logp_0,
                             obs=last_obs["agent_0"],
                             info=info_0,
-                            avail_actions=avail_actions_0
+                            avail_actions=avail_actions_0,
+                            prev_done=last_dones["agent_0"]
                         )
                         # Store agent_1 data in transition
                         transition_1 = Transition(
@@ -464,7 +466,8 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                             log_prob=logp_1,
                             obs=last_obs["agent_1"],
                             info=info_1,
-                            avail_actions=avail_actions_1
+                            avail_actions=avail_actions_1,
+                            prev_done=last_dones["agent_1"]
                         )
                         new_runner_state = (train_state, env_state_next, obs_next, done,
                                             new_ego_hstate_sp0, new_ego_hstate_sp1, rng)
@@ -604,7 +607,7 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                                 _, value_xp, pi_xp, _ = policy.get_action_value_policy(
                                     params=params,
                                     obs=traj_batch_xp.obs,
-                                    done=traj_batch_xp.done,
+                                    done=traj_batch_xp.prev_done,
                                     avail_actions=traj_batch_xp.avail_actions,
                                     hstate=init_hstate_xp,
                                     rng=jax.random.PRNGKey(0),
@@ -614,7 +617,7 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                                 _, value_sp0, pi_sp0, _ = policy.get_action_value_policy(
                                     params=params,
                                     obs=traj_batch_sp0.obs,
-                                    done=traj_batch_sp0.done,
+                                    done=traj_batch_sp0.prev_done,
                                     avail_actions=traj_batch_sp0.avail_actions,
                                     hstate=init_hstate_sp0,
                                     rng=jax.random.PRNGKey(0),
@@ -624,7 +627,7 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                                 _, value_sp1, pi_sp1, _ = policy.get_action_value_policy(
                                     params=params,
                                     obs=traj_batch_sp1.obs,
-                                    done=traj_batch_sp1.done,
+                                    done=traj_batch_sp1.prev_done,
                                     avail_actions=traj_batch_sp1.avail_actions,
                                     hstate=init_hstate_sp1,
                                     rng=jax.random.PRNGKey(0),

--- a/open_ended_training/cole.py
+++ b/open_ended_training/cole.py
@@ -18,35 +18,34 @@ python open_ended_training/run.py \
     local_logger.save_train_out=false \
     local_logger.save_eval_out=false
 """
-from functools import partial
-from tqdm import tqdm
+
 import logging
 import shutil
 import time
+from functools import partial
 
-from flax.training.train_state import TrainState
 import hydra
 import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
-
-
+from flax.training.train_state import TrainState
+from tqdm import tqdm
 
 from agents.initialize_agents import (
-    initialize_s5_agent,
     initialize_mlp_agent,
     initialize_rnn_agent,
+    initialize_s5_agent,
 )
-from agents.population_interface import AgentPopulation
 from agents.population_buffer import BufferedPopulation
-from common.save_load_utils import save_train_run
+from agents.population_interface import AgentPopulation
 from common.plot_utils import get_metric_names
 from common.run_episodes import run_episodes
+from common.save_load_utils import save_train_run
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from marl.ppo_utils import Transition, unbatchify, _create_minibatches
-from open_ended_training.shapley_utils import masked_softmax, shapley_values
+from marl.ppo_utils import Transition, _create_minibatches, unbatchify
+from open_ended_training.shapley_utils import shapley_values
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -61,17 +60,19 @@ def initialize_agent(actor_type, config, env, rng):
     elif actor_type == "rnn":
         return initialize_rnn_agent(config, env, rng)
     else:
-        raise ValueError(f"Unsupported ACTOR_TYPE for COLE: {actor_type!r}. "
-                         "Choose from 's5', 'mlp', 'rnn'.")
+        raise ValueError(
+            f"Unsupported ACTOR_TYPE for COLE: {actor_type!r}. "
+            "Choose from 's5', 'mlp', 'rnn'."
+        )
 
 
 def compute_total_updates(config):
-    '''Compute the total number of updates and updates per iter.
+    """Compute the total number of updates and updates per iter.
 
     TOTAL_TIMESTEPS_PER_ITERATION counts training rollout steps only
     (evaluation episodes are not budgeted), matching the convention used
     by the other open-ended trainers (e.g. rotate).
-    '''
+    """
     # Training rollouts (SP, XP) per update
     training_steps_per_update = 2 * config["ROLLOUT_LENGTH"] * config["NUM_ENVS"]
     num_updates_per_iter = int(
@@ -81,6 +82,7 @@ def compute_total_updates(config):
     # agents are trained.
     total_num_updates = num_updates_per_iter * (config["PARTNER_POP_SIZE"] - 1)
     return num_updates_per_iter, total_num_updates
+
 
 def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=None):
     num_agents = env.num_agents
@@ -100,17 +102,21 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
 
     def make_cole_agents(config):
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng):
             # Start by training a single PPO agent via self-play
-            rng, init_ppo_rng, init_rng, xp_init_rng = jax.random.split(rng, 4)
+            rng, _init_ppo_rng, init_rng, xp_init_rng = jax.random.split(rng, 4)
 
             # Initialize a population buffer
             dummy_policy, dummy_init_params = initialize_agent(
                 config["ACTOR_TYPE"], config, env, init_rng
-                )
+            )
             partner_population = BufferedPopulation(
                 max_pop_size=config["PARTNER_POP_SIZE"],
                 policy_cls=dummy_policy,
@@ -120,19 +126,21 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
             population_buffer = partner_population.reset_buffer(dummy_init_params)
             # explicitly add a random agent to buffer rather than a PPO agent
             population_buffer = partner_population.add_agent(
-                population_buffer, 
-                dummy_init_params
+                population_buffer, dummy_init_params
             )
 
             # Initialize XP matrix: shape (POP_SIZE, POP_SIZE)
             # Entry (i, j) = mean return of agent_i vs agent j
             # Seed entry (0, 0) with the SP return of the initial random policy.
             sp_init_return = run_episodes(
-                rng=xp_init_rng, env=env,
-                agent_0_param=dummy_init_params, agent_0_policy=dummy_policy,
-                agent_1_param=dummy_init_params, agent_1_policy=dummy_policy,
+                rng=xp_init_rng,
+                env=env,
+                agent_0_param=dummy_init_params,
+                agent_0_policy=dummy_policy,
+                agent_1_param=dummy_init_params,
+                agent_1_policy=dummy_policy,
                 max_episode_steps=config["ROLLOUT_LENGTH"],
-                num_eps=config["XP_EVAL_ROLLOUT_EPS"]
+                num_eps=config["XP_EVAL_ROLLOUT_EPS"],
             )
             init_sp_mean = sp_init_return["returned_episode_returns"][:, 0].mean()
             xp_matrix = jnp.zeros((config["POP_SIZE"], config["POP_SIZE"]))
@@ -145,7 +153,7 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
 
                 policy, init_params = initialize_agent(
                     config["ACTOR_TYPE"], config, env, init_rng
-                    )
+                )
 
                 # Create a train_state and optimizer for the newly initialzied model
                 if config["ANNEAL_LR"]:
@@ -156,7 +164,8 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                 else:
                     tx = optax.chain(
                         optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                        optax.adam(config["LR"], eps=1e-5))
+                        optax.adam(config["LR"], eps=1e-5),
+                    )
 
                 train_state = TrainState.create(
                     apply_fn=policy.network.apply,
@@ -165,21 +174,30 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                 )
 
                 # Reset envs for SP and XP
-                rng, reset_rng_eval, reset_rng_sp, reset_rng_xp = jax.random.split(rng, 4)
+                rng, _reset_rng_eval, reset_rng_sp, reset_rng_xp = jax.random.split(
+                    rng, 4
+                )
 
                 reset_rngs_sps = jax.random.split(reset_rng_sp, config["NUM_ENVS"])
                 reset_rngs_xps = jax.random.split(reset_rng_xp, config["NUM_ENVS"])
 
-                obsv_xp, env_state_xp = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_xps)
-                obsv_sp, env_state_sp = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_sps)
+                obsv_xp, env_state_xp = jax.vmap(env.reset, in_axes=(0,))(
+                    reset_rngs_xps
+                )
+                obsv_sp, env_state_sp = jax.vmap(env.reset, in_axes=(0,))(
+                    reset_rngs_sps
+                )
 
                 # build a pytree that can hold the parameters for all checkpoints.
-                ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)
+                ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                    1, config["NUM_CHECKPOINTS"] - 1
+                )
                 num_ckpts = config["NUM_CHECKPOINTS"]
+
                 def init_ckpt_array(params_pytree):
                     return jax.tree.map(
                         lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype),
-                        params_pytree
+                        params_pytree,
                     )
 
                 # define evaluation function
@@ -188,11 +206,14 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                 def eval_pair_ij(agent_i_param, agent_j_param):
                     """Return mean reward of agent_i vs agent_j."""
                     outs = run_episodes(
-                        rng=eval_rng, env=env,
-                        agent_0_param=agent_i_param, agent_0_policy=policy,
-                        agent_1_param=agent_j_param, agent_1_policy=policy,
+                        rng=eval_rng,
+                        env=env,
+                        agent_0_param=agent_i_param,
+                        agent_0_policy=policy,
+                        agent_1_param=agent_j_param,
+                        agent_1_policy=policy,
                         max_episode_steps=config["ROLLOUT_LENGTH"],
-                        num_eps=config["XP_EVAL_ROLLOUT_EPS"]
+                        num_eps=config["XP_EVAL_ROLLOUT_EPS"],
                     )
                     return outs["returned_episode_returns"][:, 0].mean()
 
@@ -202,23 +223,28 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                     """
                     agent1_param = partner_population.gather_agent_params(
                         pop_buffer,
-                        agent_indices=agent1_id * jnp.ones((1,), dtype=np.int32)
+                        agent_indices=agent1_id * jnp.ones((1,), dtype=np.int32),
                     )
-                    agent1_param = jax.tree_map(lambda y: jnp.squeeze(y, 0), agent1_param)
+                    agent1_param = jax.tree_map(
+                        lambda y: jnp.squeeze(y, 0), agent1_param
+                    )
                     return run_episodes(
-                        rng=eval_rng, env=env,
-                        agent_0_param=agent0_param, agent_0_policy=policy,
-                        agent_1_param=agent1_param, agent_1_policy=policy,
+                        rng=eval_rng,
+                        env=env,
+                        agent_0_param=agent0_param,
+                        agent_0_policy=policy,
+                        agent_1_param=agent1_param,
+                        agent_1_policy=policy,
                         max_episode_steps=config["ROLLOUT_LENGTH"],
-                        num_eps=config["XP_EVAL_ROLLOUT_EPS"]
+                        num_eps=config["XP_EVAL_ROLLOUT_EPS"],
                     )
 
                 def metasolve_game_graph(xp_matrix, num_prev_trained_agents, rng):
                     """Derive a sampling distribution over the trained population.
 
-                    Supports two modes, selected by config["METASOLVE_MODE"]. 
-                    In both modes, agents {num_prev_trained_agents, ..., POP_SIZE-1} 
-                    receive probability zero (untrained agents are excluded).    
+                    Supports two modes, selected by config["METASOLVE_MODE"].
+                    In both modes, agents {num_prev_trained_agents, ..., POP_SIZE-1}
+                    receive probability zero (untrained agents are excluded).
 
                     returns:
                         This is the metasolver used by ZSCEval's COLE.
@@ -229,12 +255,16 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                     shapley:
                         This is the metasolver of original COLE paper.
                         Compute Shapley values over the valid sub-matrix of the
-                        XP matrix using coalition-aware weighted PageRank. 
+                        XP matrix using coalition-aware weighted PageRank.
                         Higher probability given to agents with higher Shapley value
                         (i.e. those whose presence most improves coalition performance).
                     """
-                    valid_mask = jnp.arange(config["POP_SIZE"]) < num_prev_trained_agents
-                    uniform = valid_mask.astype(jnp.float32) / jnp.maximum(valid_mask.sum(), 1)
+                    valid_mask = (
+                        jnp.arange(config["POP_SIZE"]) < num_prev_trained_agents
+                    )
+                    uniform = valid_mask.astype(jnp.float32) / jnp.maximum(
+                        valid_mask.sum(), 1
+                    )
 
                     if config["METASOLVE_MODE"] == "shapley":
                         # Min-max normalise the XP matrix locally so all edge weights
@@ -245,11 +275,14 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         xp_min = jnp.min(jnp.where(valid_2d, xp_matrix, jnp.inf))
                         xp_max = jnp.max(jnp.where(valid_2d, xp_matrix, -jnp.inf))
                         xp_range = jnp.maximum(xp_max - xp_min, 1e-8)
-                        xp_norm = jnp.where(valid_2d, (xp_matrix - xp_min) / xp_range, 0.0)
+                        xp_norm = jnp.where(
+                            valid_2d, (xp_matrix - xp_min) / xp_range, 0.0
+                        )
 
                         N = config["POP_SIZE"]
                         phi = shapley_values(
-                            rng, xp_norm,
+                            rng,
+                            xp_norm,
                             N=N,
                             valid_mask=valid_mask,
                             max_iter=config["SHAPLEY_MAX_ITER"],
@@ -261,24 +294,34 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         # The paper uses a linear inversion to prioritise agents with lower Shapley values:
                         # phi = phi / sum(phi)
                         # phi = (1 - phi) / sum(1 - phi)
-                        # We use min-max normalisation over the valid agents to safely handle negative 
+                        # We use min-max normalisation over the valid agents to safely handle negative
                         # marginal contributions without losing scaling and relative ordering.
-                        valid_phi_min = jnp.where(valid_mask, phi, jnp.finfo(phi.dtype).max)
+                        valid_phi_min = jnp.where(
+                            valid_mask, phi, jnp.finfo(phi.dtype).max
+                        )
                         phi_min = jnp.min(valid_phi_min)
-                        
-                        valid_phi_max = jnp.where(valid_mask, phi, jnp.finfo(phi.dtype).min)
+
+                        valid_phi_max = jnp.where(
+                            valid_mask, phi, jnp.finfo(phi.dtype).min
+                        )
                         phi_max = jnp.max(valid_phi_max)
-                        
+
                         phi_range = jnp.maximum(phi_max - phi_min, 1e-8)
-                        phi_minmax_norm = jnp.where(valid_mask, (phi - phi_min) / phi_range, 0.0)
-                        
+                        phi_minmax_norm = jnp.where(
+                            valid_mask, (phi - phi_min) / phi_range, 0.0
+                        )
+
                         sum_phi = jnp.sum(phi_minmax_norm)
-                        phi_norm = jnp.where(sum_phi > 0, phi_minmax_norm / sum_phi, uniform)
+                        phi_norm = jnp.where(
+                            sum_phi > 0, phi_minmax_norm / sum_phi, uniform
+                        )
 
                         # Invert probabilities: lower Shapley value -> higher sampling probability
                         phi_inv = jnp.where(valid_mask, 1.0 - phi_norm, 0.0)
                         sum_phi_inv = jnp.sum(phi_inv)
-                        sampling_dist = jnp.where(sum_phi_inv > 0, phi_inv / sum_phi_inv, uniform)
+                        sampling_dist = jnp.where(
+                            sum_phi_inv > 0, phi_inv / sum_phi_inv, uniform
+                        )
 
                     elif config["METASOLVE_MODE"] == "returns":
                         xp_row = xp_matrix[num_prev_trained_agents - 1]  # (POP_SIZE,)
@@ -289,23 +332,34 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         total = weights.sum()
                         sampling_dist = jnp.where(total > 0, weights / total, uniform)
                     else:
-                        raise ValueError(f"Unknown METASOLVE_MODE: {config['METASOLVE_MODE']}")
+                        raise ValueError(
+                            f"Unknown METASOLVE_MODE: {config['METASOLVE_MODE']}"
+                        )
 
                     return sampling_dist
 
                 def _update_step(update_with_ckpt_runner_state, unused):
-                    update_runner_state, checkpoint_array, ckpt_idx = update_with_ckpt_runner_state
+                    update_runner_state, checkpoint_array, ckpt_idx = (
+                        update_with_ckpt_runner_state
+                    )
                     (
-                        train_state, pop_buffer,
-                        env_state_sp, obsv_sp,
-                        env_state_xp, obsv_xp,
+                        train_state,
+                        pop_buffer,
+                        env_state_sp,
+                        obsv_sp,
+                        env_state_xp,
+                        obsv_xp,
                         last_dones_xp,
                         last_dones_sp,
                         partner_indices_xp,
-                        ego_hstate_xp, partner_hstate,
-                        ego_hstate_sp0, ego_hstate_sp1,
-                        rng, update_steps,
-                        num_prev_trained_agents, partner_visit_counts
+                        ego_hstate_xp,
+                        partner_hstate,
+                        ego_hstate_sp0,
+                        ego_hstate_sp1,
+                        rng,
+                        update_steps,
+                        num_prev_trained_agents,
+                        partner_visit_counts,
                     ) = update_runner_state
 
                     def _env_step_xp(runner_state, unused):
@@ -316,31 +370,60 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         stored in pop_buffer.scores.
                         Returns updated runner_state and a Transition for agent_0.
                         """
-                        train_state, pop_buffer, partner_indices, env_state, last_obs, last_dones, ego_hstate, partner_hstate, partner_visit_counts, rng = runner_state
-                        rng, act_rng, partner_rng, step_rng, resample_rng = jax.random.split(rng, 5)
+                        (
+                            train_state,
+                            pop_buffer,
+                            partner_indices,
+                            env_state,
+                            last_obs,
+                            last_dones,
+                            ego_hstate,
+                            partner_hstate,
+                            partner_visit_counts,
+                            rng,
+                        ) = runner_state
+                        rng, act_rng, partner_rng, step_rng, resample_rng = (
+                            jax.random.split(rng, 5)
+                        )
 
                         # Resample partner index for envs that just finished an episode
                         needs_resample = last_dones["__all__"]
-                        new_sampled, pop_buffer = partner_population.sample_agent_indices(
-                            pop_buffer, config["NUM_ENVS"], resample_rng,
-                            needs_resample_mask=needs_resample
+                        new_sampled, pop_buffer = (
+                            partner_population.sample_agent_indices(
+                                pop_buffer,
+                                config["NUM_ENVS"],
+                                resample_rng,
+                                needs_resample_mask=needs_resample,
+                            )
                         )
-                        partner_indices = jnp.where(needs_resample, new_sampled, partner_indices)
-                        partner_visit_counts = partner_visit_counts.at[new_sampled].add(needs_resample.astype(jnp.int32))
+                        partner_indices = jnp.where(
+                            needs_resample, new_sampled, partner_indices
+                        )
+                        partner_visit_counts = partner_visit_counts.at[new_sampled].add(
+                            needs_resample.astype(jnp.int32)
+                        )
 
                         # Get available actions from environment state
-                        avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)
+                        avail_actions = jax.vmap(env.get_avail_actions)(
+                            env_state.env_state
+                        )
                         avail_actions_0 = avail_actions["agent_0"].astype(jnp.float32)
                         avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
                         # Agent_0 (trained ego agent) action
-                        act_0, val_0, pi_0, new_ego_hstate = policy.get_action_value_policy(
-                            params=train_state.params,
-                            obs=last_obs["agent_0"].reshape(1, config["NUM_ENVS"], -1),
-                            done=last_dones["agent_0"].reshape(1, config["NUM_ENVS"]),
-                            avail_actions=jax.lax.stop_gradient(avail_actions_0),
-                            hstate=ego_hstate,
-                            rng=act_rng,
+                        act_0, val_0, pi_0, new_ego_hstate = (
+                            policy.get_action_value_policy(
+                                params=train_state.params,
+                                obs=last_obs["agent_0"].reshape(
+                                    1, config["NUM_ENVS"], -1
+                                ),
+                                done=last_dones["agent_0"].reshape(
+                                    1, config["NUM_ENVS"]
+                                ),
+                                avail_actions=jax.lax.stop_gradient(avail_actions_0),
+                                hstate=ego_hstate,
+                                rng=act_rng,
+                            )
                         )
                         logp_0 = pi_0.log_prob(act_0)
                         act_0 = act_0.squeeze()
@@ -360,15 +443,19 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         act_1 = act_1.squeeze()
 
                         # Combine actions into the env format
-                        combined_actions = jnp.concatenate([act_0, act_1], axis=0)  # (2*num_envs,)
-                        env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                        combined_actions = jnp.concatenate(
+                            [act_0, act_1], axis=0
+                        )  # (2*num_envs,)
+                        env_act = unbatchify(
+                            combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                        )
                         env_act = {k: v.flatten() for k, v in env_act.items()}
 
                         # Step env
                         step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                        obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0, 0, 0))(
-                            step_rngs, env_state, env_act
-                        )
+                        obs_next, env_state_next, reward, done, info = jax.vmap(
+                            env.step, in_axes=(0, 0, 0)
+                        )(step_rngs, env_state, env_act)
                         info_0 = jax.tree.map(lambda x: x[:, 0], info)
 
                         # Store agent_0 data in transition
@@ -381,12 +468,20 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                             obs=last_obs["agent_0"],
                             info=info_0,
                             avail_actions=avail_actions_0,
-                            prev_done=last_dones["agent_0"]
+                            prev_done=last_dones["agent_0"],
                         )
-                        new_runner_state = (train_state, pop_buffer, partner_indices,
-                                            env_state_next, obs_next, done,
-                                            new_ego_hstate, new_partner_hstate, partner_visit_counts, 
-                                            rng)
+                        new_runner_state = (
+                            train_state,
+                            pop_buffer,
+                            partner_indices,
+                            env_state_next,
+                            obs_next,
+                            done,
+                            new_ego_hstate,
+                            new_partner_hstate,
+                            partner_visit_counts,
+                            rng,
+                        )
                         return new_runner_state, transition
 
                     def _env_step_sp(runner_state, unused):
@@ -396,22 +491,38 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         Separate hidden states are tracked per slot so recurrent agents are handled correctly.
                         Returns updated runner_state and Transitions for both agent slots.
                         """
-                        train_state, env_state, last_obs, last_dones, ego_hstate_sp0, ego_hstate_sp1, rng = runner_state
+                        (
+                            train_state,
+                            env_state,
+                            last_obs,
+                            last_dones,
+                            ego_hstate_sp0,
+                            ego_hstate_sp1,
+                            rng,
+                        ) = runner_state
                         rng, rng_sp0, rng_sp1, step_rng = jax.random.split(rng, 4)
 
                         # Get available actions for agent 0 from environment state
-                        avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)
+                        avail_actions = jax.vmap(env.get_avail_actions)(
+                            env_state.env_state
+                        )
                         avail_actions_0 = avail_actions["agent_0"].astype(jnp.float32)
                         avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
                         # Agent_0 (agent slot 0 in SP) action
-                        act_0, val_0, pi_0, new_ego_hstate_sp0 = policy.get_action_value_policy(
-                            params=train_state.params,
-                            obs=last_obs["agent_0"].reshape(1, config["NUM_ENVS"], -1),
-                            done=last_dones["agent_0"].reshape(1, config["NUM_ENVS"]),
-                            avail_actions=jax.lax.stop_gradient(avail_actions_0),
-                            hstate=ego_hstate_sp0,
-                            rng=rng_sp0
+                        act_0, val_0, pi_0, new_ego_hstate_sp0 = (
+                            policy.get_action_value_policy(
+                                params=train_state.params,
+                                obs=last_obs["agent_0"].reshape(
+                                    1, config["NUM_ENVS"], -1
+                                ),
+                                done=last_dones["agent_0"].reshape(
+                                    1, config["NUM_ENVS"]
+                                ),
+                                avail_actions=jax.lax.stop_gradient(avail_actions_0),
+                                hstate=ego_hstate_sp0,
+                                rng=rng_sp0,
+                            )
                         )
                         logp_0 = pi_0.log_prob(act_0)
                         act_0 = act_0.squeeze()
@@ -419,13 +530,19 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         val_0 = val_0.squeeze()
 
                         # Agent_1 (agent slot 1 in SP) action — same params, different hstate
-                        act_1, val_1, pi_1, new_ego_hstate_sp1 = policy.get_action_value_policy(
-                            params=train_state.params,
-                            obs=last_obs["agent_1"].reshape(1, config["NUM_ENVS"], -1),
-                            done=last_dones["agent_1"].reshape(1, config["NUM_ENVS"]),
-                            avail_actions=jax.lax.stop_gradient(avail_actions_1),
-                            hstate=ego_hstate_sp1,
-                            rng=rng_sp1
+                        act_1, val_1, pi_1, new_ego_hstate_sp1 = (
+                            policy.get_action_value_policy(
+                                params=train_state.params,
+                                obs=last_obs["agent_1"].reshape(
+                                    1, config["NUM_ENVS"], -1
+                                ),
+                                done=last_dones["agent_1"].reshape(
+                                    1, config["NUM_ENVS"]
+                                ),
+                                avail_actions=jax.lax.stop_gradient(avail_actions_1),
+                                hstate=ego_hstate_sp1,
+                                rng=rng_sp1,
+                            )
                         )
                         logp_1 = pi_1.log_prob(act_1)
                         act_1 = act_1.squeeze()
@@ -433,15 +550,19 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         val_1 = val_1.squeeze()
 
                         # Combine actions into the env format
-                        combined_actions = jnp.concatenate([act_0, act_1], axis=0)  # shape (2*num_envs,)
-                        env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                        combined_actions = jnp.concatenate(
+                            [act_0, act_1], axis=0
+                        )  # shape (2*num_envs,)
+                        env_act = unbatchify(
+                            combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                        )
                         env_act = {k: v.flatten() for k, v in env_act.items()}
 
                         # Step env
                         step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                        obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0, 0, 0))(
-                            step_rngs, env_state, env_act
-                        )
+                        obs_next, env_state_next, reward, done, info = jax.vmap(
+                            env.step, in_axes=(0, 0, 0)
+                        )(step_rngs, env_state, env_act)
                         info_0 = jax.tree.map(lambda x: x[:, 0], info)
                         info_1 = jax.tree.map(lambda x: x[:, 1], info)
 
@@ -455,7 +576,7 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                             obs=last_obs["agent_0"],
                             info=info_0,
                             avail_actions=avail_actions_0,
-                            prev_done=last_dones["agent_0"]
+                            prev_done=last_dones["agent_0"],
                         )
                         # Store agent_1 data in transition
                         transition_1 = Transition(
@@ -467,18 +588,29 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                             obs=last_obs["agent_1"],
                             info=info_1,
                             avail_actions=avail_actions_1,
-                            prev_done=last_dones["agent_1"]
+                            prev_done=last_dones["agent_1"],
                         )
-                        new_runner_state = (train_state, env_state_next, obs_next, done,
-                                            new_ego_hstate_sp0, new_ego_hstate_sp1, rng)
+                        new_runner_state = (
+                            train_state,
+                            env_state_next,
+                            obs_next,
+                            done,
+                            new_ego_hstate_sp0,
+                            new_ego_hstate_sp1,
+                            rng,
+                        )
                         return new_runner_state, (transition_0, transition_1)
 
                     # Sample per-env XP partner indices, resampling only for envs that finished an episode
                     rng, sample_rng, rng_xp, rng_sp = jax.random.split(rng, 4)
                     needs_resample_xp = last_dones_xp["__all__"]
-                    sampled_indices_all, pop_buffer = partner_population.sample_agent_indices(
-                        pop_buffer, config["NUM_ENVS"], sample_rng,
-                        needs_resample_mask=needs_resample_xp
+                    sampled_indices_all, pop_buffer = (
+                        partner_population.sample_agent_indices(
+                            pop_buffer,
+                            config["NUM_ENVS"],
+                            sample_rng,
+                            needs_resample_mask=needs_resample_xp,
+                        )
                     )
                     partner_indices_xp = jnp.where(
                         needs_resample_xp, sampled_indices_all, partner_indices_xp
@@ -489,30 +621,64 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                     # proportional to p_i * exp(bonus_i), keeping the metasolver term
                     # on a comparable scale instead of being swamped by the bonus.
                     sum_counts = partner_visit_counts.sum()
-                    ucb_scores = init_log_sampling_dist + config["C_UCT"] * jnp.sqrt(sum_counts / (1 + partner_visit_counts))
+                    ucb_scores = init_log_sampling_dist + config["C_UCT"] * jnp.sqrt(
+                        sum_counts / (1 + partner_visit_counts)
+                    )
                     pop_buffer = partner_population.update_scores(
                         pop_buffer, jnp.arange(config["POP_SIZE"]), ucb_scores
                     )
 
                     # Do XP rollout
-                    runner_state_xp = (train_state, pop_buffer, partner_indices_xp,
-                                       env_state_xp, obsv_xp, last_dones_xp,
-                                       ego_hstate_xp, partner_hstate, partner_visit_counts, rng_xp)
+                    runner_state_xp = (
+                        train_state,
+                        pop_buffer,
+                        partner_indices_xp,
+                        env_state_xp,
+                        obsv_xp,
+                        last_dones_xp,
+                        ego_hstate_xp,
+                        partner_hstate,
+                        partner_visit_counts,
+                        rng_xp,
+                    )
                     runner_state_xp, traj_batch_xp = jax.lax.scan(
-                        _env_step_xp, 
-                        runner_state_xp, 
-                        None, 
-                        config["ROLLOUT_LENGTH"])
-                    (train_state, pop_buffer, partner_indices_xp, env_state_xp,
-                     last_obs_xp, last_dones_xp, ego_hstate_xp, partner_hstate, partner_visit_counts, rng_xp) = runner_state_xp
+                        _env_step_xp, runner_state_xp, None, config["ROLLOUT_LENGTH"]
+                    )
+                    (
+                        train_state,
+                        pop_buffer,
+                        partner_indices_xp,
+                        env_state_xp,
+                        last_obs_xp,
+                        last_dones_xp,
+                        ego_hstate_xp,
+                        partner_hstate,
+                        partner_visit_counts,
+                        rng_xp,
+                    ) = runner_state_xp
 
                     # Do self-play (based on train_state params) rollout
-                    runner_state_sp = (train_state, env_state_sp, obsv_sp, last_dones_sp,
-                                       ego_hstate_sp0, ego_hstate_sp1, rng_sp)
+                    runner_state_sp = (
+                        train_state,
+                        env_state_sp,
+                        obsv_sp,
+                        last_dones_sp,
+                        ego_hstate_sp0,
+                        ego_hstate_sp1,
+                        rng_sp,
+                    )
                     runner_state_sp, (traj_batch_sp0, traj_batch_sp1) = jax.lax.scan(
-                        _env_step_sp, runner_state_sp, None, config["ROLLOUT_LENGTH"])
-                    (train_state, env_state_sp, last_obs_sp, last_dones_sp,
-                     ego_hstate_sp0, ego_hstate_sp1, rng_sp) = runner_state_sp
+                        _env_step_sp, runner_state_sp, None, config["ROLLOUT_LENGTH"]
+                    )
+                    (
+                        train_state,
+                        env_state_sp,
+                        last_obs_sp,
+                        last_dones_sp,
+                        ego_hstate_sp0,
+                        ego_hstate_sp1,
+                        rng_sp,
+                    ) = runner_state_sp
 
                     def _calculate_gae(traj_batch, last_val):
                         def _get_advantages(gae_and_next_value, transition):
@@ -522,10 +688,17 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                                 transition.value,
                                 transition.reward,
                             )
-                            delta = reward + config["GAMMA"] * next_value * (1 - done) - value
+                            delta = (
+                                reward
+                                + config["GAMMA"] * next_value * (1 - done)
+                                - value
+                            )
                             gae = (
                                 delta
-                                + config["GAMMA"] * config["GAE_LAMBDA"] * (1 - done) * gae
+                                + config["GAMMA"]
+                                * config["GAE_LAMBDA"]
+                                * (1 - done)
+                                * gae
                             )
                             return (gae, value), gae
 
@@ -538,17 +711,33 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         )
                         return advantages, advantages + traj_batch.value
 
-                    def _compute_advantages_and_targets(env_state, policy, policy_params, policy_hstate,
-                                                    last_obs, last_dones, traj_batch, agent_name):
+                    def _compute_advantages_and_targets(
+                        env_state,
+                        policy,
+                        policy_params,
+                        policy_hstate,
+                        last_obs,
+                        last_dones,
+                        traj_batch,
+                        agent_name,
+                    ):
                         """Compute GAE advantages and value targets for a trajectory."""
-                        avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)[agent_name].astype(jnp.float32)
+                        avail_actions = jax.vmap(env.get_avail_actions)(
+                            env_state.env_state
+                        )[agent_name].astype(jnp.float32)
                         _, vals, _, _ = policy.get_action_value_policy(
                             params=policy_params,
-                            obs=last_obs[agent_name].reshape(1, last_obs[agent_name].shape[0], -1),
-                            done=last_dones[agent_name].reshape(1, last_obs[agent_name].shape[0]),
+                            obs=last_obs[agent_name].reshape(
+                                1, last_obs[agent_name].shape[0], -1
+                            ),
+                            done=last_dones[agent_name].reshape(
+                                1, last_obs[agent_name].shape[0]
+                            ),
                             avail_actions=jax.lax.stop_gradient(avail_actions),
                             hstate=policy_hstate,
-                            rng=jax.random.PRNGKey(0),  # dummy key as we don't sample actions
+                            rng=jax.random.PRNGKey(
+                                0
+                            ),  # dummy key as we don't sample actions
                         )
                         last_val = vals.squeeze()
                         advantages, targets = _calculate_gae(traj_batch, last_val)
@@ -556,30 +745,52 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
 
                     # Compute ego-agent advantages for XP interaction (ego vs population partner)
                     advantages_xp, targets_xp = _compute_advantages_and_targets(
-                        env_state_xp, policy, train_state.params, ego_hstate_xp,
-                        last_obs_xp, last_dones_xp, traj_batch_xp, "agent_0")
+                        env_state_xp,
+                        policy,
+                        train_state.params,
+                        ego_hstate_xp,
+                        last_obs_xp,
+                        last_dones_xp,
+                        traj_batch_xp,
+                        "agent_0",
+                    )
 
                     # Compute ego-agent advantages for both SP slots (ego plays both sides)
                     advantages_sp0, targets_sp0 = _compute_advantages_and_targets(
-                        env_state_sp, policy, train_state.params, ego_hstate_sp0,
-                        last_obs_sp, last_dones_sp, traj_batch_sp0, "agent_0")
+                        env_state_sp,
+                        policy,
+                        train_state.params,
+                        ego_hstate_sp0,
+                        last_obs_sp,
+                        last_dones_sp,
+                        traj_batch_sp0,
+                        "agent_0",
+                    )
 
                     advantages_sp1, targets_sp1 = _compute_advantages_and_targets(
-                        env_state_sp, policy, train_state.params, ego_hstate_sp1,
-                        last_obs_sp, last_dones_sp, traj_batch_sp1, "agent_1")
+                        env_state_sp,
+                        policy,
+                        train_state.params,
+                        ego_hstate_sp1,
+                        last_obs_sp,
+                        last_dones_sp,
+                        traj_batch_sp1,
+                        "agent_1",
+                    )
 
                     def _update_epoch(update_state, unused):
                         def _compute_ppo_value_loss(pred_value, traj_batch, target_v):
                             """Value loss function for PPO"""
                             value_pred_clipped = traj_batch.value + (
                                 pred_value - traj_batch.value
-                                ).clip(
-                                -config["CLIP_EPS"], config["CLIP_EPS"])
+                            ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                             value_losses = jnp.square(pred_value - target_v)
-                            value_losses_clipped = jnp.square(value_pred_clipped - target_v)
-                            value_loss = (
-                                jnp.maximum(value_losses, value_losses_clipped).mean()
+                            value_losses_clipped = jnp.square(
+                                value_pred_clipped - target_v
                             )
+                            value_loss = jnp.maximum(
+                                value_losses, value_losses_clipped
+                            ).mean()
                             return value_loss
 
                         def _compute_ppo_pg_loss(log_prob, traj_batch, gae):
@@ -587,22 +798,47 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                             ratio = jnp.exp(log_prob - traj_batch.log_prob)
                             gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                             pg_loss_1 = ratio * gae_norm
-                            pg_loss_2 = jnp.clip(
-                                ratio,
-                                1.0 - config["CLIP_EPS"],
-                                1.0 + config["CLIP_EPS"]) * gae_norm
+                            pg_loss_2 = (
+                                jnp.clip(
+                                    ratio,
+                                    1.0 - config["CLIP_EPS"],
+                                    1.0 + config["CLIP_EPS"],
+                                )
+                                * gae_norm
+                            )
                             pg_loss = -jnp.mean(jnp.minimum(pg_loss_1, pg_loss_2))
                             return pg_loss
 
                         def _update_minbatch(train_state, batch_infos):
                             minbatch_xp, minbatch_sp0, minbatch_sp1 = batch_infos
-                            init_hstate_xp, traj_batch_xp, advantages_xp, returns_xp = minbatch_xp
-                            init_hstate_sp0, traj_batch_sp0, advantages_sp0, returns_sp0 = minbatch_sp0
-                            init_hstate_sp1, traj_batch_sp1, advantages_sp1, returns_sp1 = minbatch_sp1
+                            init_hstate_xp, traj_batch_xp, advantages_xp, returns_xp = (
+                                minbatch_xp
+                            )
+                            (
+                                init_hstate_sp0,
+                                traj_batch_sp0,
+                                advantages_sp0,
+                                returns_sp0,
+                            ) = minbatch_sp0
+                            (
+                                init_hstate_sp1,
+                                traj_batch_sp1,
+                                advantages_sp1,
+                                returns_sp1,
+                            ) = minbatch_sp1
 
-                            def _loss_fn(params, traj_batch_xp, gae_xp, target_v_xp,
-                                            traj_batch_sp0, gae_sp0, target_v_sp0,
-                                            traj_batch_sp1, gae_sp1, target_v_sp1):
+                            def _loss_fn(
+                                params,
+                                traj_batch_xp,
+                                gae_xp,
+                                target_v_xp,
+                                traj_batch_sp0,
+                                gae_sp0,
+                                target_v_sp0,
+                                traj_batch_sp1,
+                                gae_sp1,
+                                target_v_sp1,
+                            ):
                                 # XP: training agent interacting with population partner
                                 _, value_xp, pi_xp, _ = policy.get_action_value_policy(
                                     params=params,
@@ -614,36 +850,52 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                                 )
 
                                 # SP: agent slot 0 interacting with itself
-                                _, value_sp0, pi_sp0, _ = policy.get_action_value_policy(
-                                    params=params,
-                                    obs=traj_batch_sp0.obs,
-                                    done=traj_batch_sp0.prev_done,
-                                    avail_actions=traj_batch_sp0.avail_actions,
-                                    hstate=init_hstate_sp0,
-                                    rng=jax.random.PRNGKey(0),
+                                _, value_sp0, pi_sp0, _ = (
+                                    policy.get_action_value_policy(
+                                        params=params,
+                                        obs=traj_batch_sp0.obs,
+                                        done=traj_batch_sp0.prev_done,
+                                        avail_actions=traj_batch_sp0.avail_actions,
+                                        hstate=init_hstate_sp0,
+                                        rng=jax.random.PRNGKey(0),
+                                    )
                                 )
 
                                 # SP: ego agent in slot 1 playing against itself
-                                _, value_sp1, pi_sp1, _ = policy.get_action_value_policy(
-                                    params=params,
-                                    obs=traj_batch_sp1.obs,
-                                    done=traj_batch_sp1.prev_done,
-                                    avail_actions=traj_batch_sp1.avail_actions,
-                                    hstate=init_hstate_sp1,
-                                    rng=jax.random.PRNGKey(0),
+                                _, value_sp1, pi_sp1, _ = (
+                                    policy.get_action_value_policy(
+                                        params=params,
+                                        obs=traj_batch_sp1.obs,
+                                        done=traj_batch_sp1.prev_done,
+                                        avail_actions=traj_batch_sp1.avail_actions,
+                                        hstate=init_hstate_sp1,
+                                        rng=jax.random.PRNGKey(0),
+                                    )
                                 )
 
                                 log_prob_xp = pi_xp.log_prob(traj_batch_xp.action)
                                 log_prob_sp0 = pi_sp0.log_prob(traj_batch_sp0.action)
                                 log_prob_sp1 = pi_sp1.log_prob(traj_batch_sp1.action)
 
-                                value_loss_xp = _compute_ppo_value_loss(value_xp, traj_batch_xp, target_v_xp)
-                                value_loss_sp0 = _compute_ppo_value_loss(value_sp0, traj_batch_sp0, target_v_sp0)
-                                value_loss_sp1 = _compute_ppo_value_loss(value_sp1, traj_batch_sp1, target_v_sp1)
+                                value_loss_xp = _compute_ppo_value_loss(
+                                    value_xp, traj_batch_xp, target_v_xp
+                                )
+                                value_loss_sp0 = _compute_ppo_value_loss(
+                                    value_sp0, traj_batch_sp0, target_v_sp0
+                                )
+                                value_loss_sp1 = _compute_ppo_value_loss(
+                                    value_sp1, traj_batch_sp1, target_v_sp1
+                                )
 
-                                pg_loss_xp = _compute_ppo_pg_loss(log_prob_xp, traj_batch_xp, gae_xp)
-                                pg_loss_sp0 = _compute_ppo_pg_loss(log_prob_sp0, traj_batch_sp0, gae_sp0)
-                                pg_loss_sp1 = _compute_ppo_pg_loss(log_prob_sp1, traj_batch_sp1, gae_sp1)
+                                pg_loss_xp = _compute_ppo_pg_loss(
+                                    log_prob_xp, traj_batch_xp, gae_xp
+                                )
+                                pg_loss_sp0 = _compute_ppo_pg_loss(
+                                    log_prob_sp0, traj_batch_sp0, gae_sp0
+                                )
+                                pg_loss_sp1 = _compute_ppo_pg_loss(
+                                    log_prob_sp1, traj_batch_sp1, gae_sp1
+                                )
 
                                 entropy_xp = jnp.mean(pi_xp.entropy())
                                 entropy_sp0 = jnp.mean(pi_sp0.entropy())
@@ -651,61 +903,122 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
 
                                 # Loss = XP_loss + COLE_ALPHA * SP_loss (both maximized)
                                 cole_alpha = config["COLE_ALPHA"]
-                                xp_loss = pg_loss_xp + config["VF_COEF"] * value_loss_xp - config["ENT_COEF"] * entropy_xp
-                                sp0_loss = pg_loss_sp0 + config["VF_COEF"] * value_loss_sp0 - config["ENT_COEF"] * entropy_sp0
-                                sp1_loss = pg_loss_sp1 + config["VF_COEF"] * value_loss_sp1 - config["ENT_COEF"] * entropy_sp1
+                                xp_loss = (
+                                    pg_loss_xp
+                                    + config["VF_COEF"] * value_loss_xp
+                                    - config["ENT_COEF"] * entropy_xp
+                                )
+                                sp0_loss = (
+                                    pg_loss_sp0
+                                    + config["VF_COEF"] * value_loss_sp0
+                                    - config["ENT_COEF"] * entropy_sp0
+                                )
+                                sp1_loss = (
+                                    pg_loss_sp1
+                                    + config["VF_COEF"] * value_loss_sp1
+                                    - config["ENT_COEF"] * entropy_sp1
+                                )
 
-                                total_loss = xp_loss + cole_alpha * (sp0_loss + sp1_loss)
-                                return total_loss, (value_loss_xp, value_loss_sp0 + value_loss_sp1,
-                                                    pg_loss_xp, pg_loss_sp0 + pg_loss_sp1,
-                                                    entropy_xp, entropy_sp0 + entropy_sp1)
+                                total_loss = xp_loss + cole_alpha * (
+                                    sp0_loss + sp1_loss
+                                )
+                                return total_loss, (
+                                    value_loss_xp,
+                                    value_loss_sp0 + value_loss_sp1,
+                                    pg_loss_xp,
+                                    pg_loss_sp0 + pg_loss_sp1,
+                                    entropy_xp,
+                                    entropy_sp0 + entropy_sp1,
+                                )
 
                             grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
                             (loss_val, aux_vals), grads = grad_fn(
                                 train_state.params,
-                                traj_batch_xp, advantages_xp, returns_xp,
-                                traj_batch_sp0, advantages_sp0, returns_sp0,
-                                traj_batch_sp1, advantages_sp1, returns_sp1)
+                                traj_batch_xp,
+                                advantages_xp,
+                                returns_xp,
+                                traj_batch_sp0,
+                                advantages_sp0,
+                                returns_sp0,
+                                traj_batch_sp1,
+                                advantages_sp1,
+                                returns_sp1,
+                            )
                             train_state = train_state.apply_gradients(grads=grads)
                             return train_state, (loss_val, aux_vals)
 
                         (
-                            train_state, traj_batch_xp,
-                            traj_batch_sp0, traj_batch_sp1,
-                            advantages_xp, 
-                            advantages_sp0, advantages_sp1, 
+                            train_state,
+                            traj_batch_xp,
+                            traj_batch_sp0,
+                            traj_batch_sp1,
+                            advantages_xp,
+                            advantages_sp0,
+                            advantages_sp1,
                             targets_xp,
-                            targets_sp0, targets_sp1,
-                            init_hstate_xp, init_hstate_sp0, init_hstate_sp1, rng
+                            targets_sp0,
+                            targets_sp1,
+                            init_hstate_xp,
+                            init_hstate_sp0,
+                            init_hstate_sp1,
+                            rng,
                         ) = update_state
 
-                        rng, perm_rng_xp, perm_rng_sp0, perm_rng_sp1 = jax.random.split(rng, 4)
+                        rng, perm_rng_xp, perm_rng_sp0, perm_rng_sp1 = jax.random.split(
+                            rng, 4
+                        )
 
                         # Create minibatches for XP and SP interaction types
                         minibatches_xp = _create_minibatches(
-                            traj_batch_xp, advantages_xp, targets_xp, init_hstate_xp,
-                            config["NUM_ENVS"], config["NUM_MINIBATCHES"], perm_rng_xp
+                            traj_batch_xp,
+                            advantages_xp,
+                            targets_xp,
+                            init_hstate_xp,
+                            config["NUM_ENVS"],
+                            config["NUM_MINIBATCHES"],
+                            perm_rng_xp,
                         )
                         minibatches_sp0 = _create_minibatches(
-                            traj_batch_sp0, advantages_sp0, targets_sp0, init_hstate_sp0,
-                            config["NUM_ENVS"], config["NUM_MINIBATCHES"], perm_rng_sp0
+                            traj_batch_sp0,
+                            advantages_sp0,
+                            targets_sp0,
+                            init_hstate_sp0,
+                            config["NUM_ENVS"],
+                            config["NUM_MINIBATCHES"],
+                            perm_rng_sp0,
                         )
                         minibatches_sp1 = _create_minibatches(
-                            traj_batch_sp1, advantages_sp1, targets_sp1, init_hstate_sp1,
-                            config["NUM_ENVS"], config["NUM_MINIBATCHES"], perm_rng_sp1
+                            traj_batch_sp1,
+                            advantages_sp1,
+                            targets_sp1,
+                            init_hstate_sp1,
+                            config["NUM_ENVS"],
+                            config["NUM_MINIBATCHES"],
+                            perm_rng_sp1,
                         )
 
                         # Update ego agent
                         train_state, total_loss = jax.lax.scan(
-                            _update_minbatch, train_state,
-                            (minibatches_xp, minibatches_sp0, minibatches_sp1)
+                            _update_minbatch,
+                            train_state,
+                            (minibatches_xp, minibatches_sp0, minibatches_sp1),
                         )
 
-                        update_state = (train_state,
-                            traj_batch_xp, traj_batch_sp0, traj_batch_sp1,
-                            advantages_xp, advantages_sp0, advantages_sp1,
-                            targets_xp, targets_sp0, targets_sp1,
-                            init_hstate_xp, init_hstate_sp0, init_hstate_sp1, rng
+                        update_state = (
+                            train_state,
+                            traj_batch_xp,
+                            traj_batch_sp0,
+                            traj_batch_sp1,
+                            advantages_xp,
+                            advantages_sp0,
+                            advantages_sp1,
+                            targets_xp,
+                            targets_sp0,
+                            targets_sp1,
+                            init_hstate_xp,
+                            init_hstate_sp0,
+                            init_hstate_sp1,
+                            rng,
                         )
                         return update_state, total_loss
 
@@ -716,45 +1029,69 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                     rng, sub_rng = jax.random.split(rng, 2)
                     update_state = (
                         train_state,
-                        traj_batch_xp, traj_batch_sp0,
+                        traj_batch_xp,
+                        traj_batch_sp0,
                         traj_batch_sp1,
                         advantages_xp,
-                        advantages_sp0, advantages_sp1,
-                        targets_xp, targets_sp0,
+                        advantages_sp0,
+                        advantages_sp1,
+                        targets_xp,
+                        targets_sp0,
                         targets_sp1,
-                        init_hstate_xp, init_hstate_sp0, init_hstate_sp1, sub_rng
+                        init_hstate_xp,
+                        init_hstate_sp0,
+                        init_hstate_sp1,
+                        sub_rng,
                     )
                     update_state, losses = jax.lax.scan(
-                        _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                        _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                    )
                     train_state = update_state[0]
 
                     (
-                        value_loss_xp, value_loss_sp,
-                        pg_loss_xp, pg_loss_sp,
-                        entropy_xp, entropy_sp
+                        value_loss_xp,
+                        value_loss_sp,
+                        pg_loss_xp,
+                        pg_loss_sp,
+                        entropy_xp,
+                        entropy_sp,
                     ) = losses[1]
 
                     new_update_runner_state = (
-                        train_state, pop_buffer,
-                        env_state_sp, last_obs_sp,
-                        env_state_xp, last_obs_xp,
-                        last_dones_xp, last_dones_sp,
+                        train_state,
+                        pop_buffer,
+                        env_state_sp,
+                        last_obs_sp,
+                        env_state_xp,
+                        last_obs_xp,
+                        last_dones_xp,
+                        last_dones_sp,
                         partner_indices_xp,
-                        ego_hstate_xp, partner_hstate,
-                        ego_hstate_sp0, ego_hstate_sp1,
-                        rng, update_steps+1, num_prev_trained_agents,
-                        partner_visit_counts
+                        ego_hstate_xp,
+                        partner_hstate,
+                        ego_hstate_sp0,
+                        ego_hstate_sp1,
+                        rng,
+                        update_steps + 1,
+                        num_prev_trained_agents,
+                        partner_visit_counts,
                     )
 
                     # Metrics
                     def mask_and_mean(x, mask):
                         return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
 
-                    mask = traj_batch_xp.info.get("returned_episode", jnp.ones_like(traj_batch_xp.reward))
-                    metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_xp.info)
+                    mask = traj_batch_xp.info.get(
+                        "returned_episode", jnp.ones_like(traj_batch_xp.reward)
+                    )
+                    metric = jax.tree.map(
+                        lambda x: mask_and_mean(x, mask), traj_batch_xp.info
+                    )
                     # Global step across generations so wandb curves don't overlap:
                     # num_prev_trained_agents is 1 for the first trained generation.
-                    metric["update_steps"] = (num_prev_trained_agents - 1) * config["NUM_UPDATES"] + update_steps
+                    metric["update_steps"] = (num_prev_trained_agents - 1) * config[
+                        "NUM_UPDATES"
+                    ] + update_steps
                     metric["value_loss_xp"] = value_loss_xp.mean()
                     metric["value_loss_sp"] = value_loss_sp.mean()
 
@@ -774,22 +1111,35 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
 
                     jax.experimental.io_callback(callback, None, metric)
 
-                    return (new_update_runner_state, checkpoint_array, ckpt_idx+1), metric
+                    return (
+                        new_update_runner_state,
+                        checkpoint_array,
+                        ckpt_idx + 1,
+                    ), metric
 
                 # XP eval current policy against all policies in the buffer
                 # shape (pop_size,) after pre-scalarization (mean over eval episodes and agents)
-                xp_eval_returns = jax.tree.map(lambda x: x.mean(axis=(-2, -1)),
+                xp_eval_returns = jax.tree.map(
+                    lambda x: x.mean(axis=(-2, -1)),
                     jax.vmap(per_id_run_episode_fixed_rng, in_axes=(None, 0))(
-                        train_state.params, jnp.arange(config["POP_SIZE"])))
+                        train_state.params, jnp.arange(config["POP_SIZE"])
+                    ),
+                )
 
                 # SP performance against itself
-                sp_eval_returns = jax.tree.map(lambda x: x.mean(), run_episodes(
-                    eval_rng, env,
-                    agent_0_param=train_state.params, agent_0_policy=policy,
-                    agent_1_param=train_state.params, agent_1_policy=policy,
-                    max_episode_steps=config["ROLLOUT_LENGTH"],
-                    num_eps=config["NUM_EVAL_EPISODES"]
-                ))
+                sp_eval_returns = jax.tree.map(
+                    lambda x: x.mean(),
+                    run_episodes(
+                        eval_rng,
+                        env,
+                        agent_0_param=train_state.params,
+                        agent_0_policy=policy,
+                        agent_1_param=train_state.params,
+                        agent_1_policy=policy,
+                        max_episode_steps=config["ROLLOUT_LENGTH"],
+                        num_eps=config["NUM_EVAL_EPISODES"],
+                    ),
+                )
 
                 # Pre-compute the metasolve sampling distribution for agent i and write it into
                 # pop_buffer.scores so that sample_agent_indices uses it throughout the PPO loop.
@@ -806,104 +1156,175 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                 )
 
                 update_steps = 0
-                init_done_xp = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
-                init_done_sp = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
+                init_done_xp = {
+                    k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                    for k in env.agents + ["__all__"]
+                }
+                init_done_sp = {
+                    k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                    for k in env.agents + ["__all__"]
+                }
                 # Initialize XP partner indices: default to agent 0 until resampled
-                init_partner_indices_xp = jnp.zeros((config["NUM_ENVS"],), dtype=jnp.int32)
+                init_partner_indices_xp = jnp.zeros(
+                    (config["NUM_ENVS"],), dtype=jnp.int32
+                )
 
                 # Initialize hidden states for the training agent (xp + sp slots) and population partner
                 init_ego_hstate_xp = policy.init_hstate(config["NUM_ENVS"])
-                init_partner_hstate = partner_population.policy_cls.init_hstate(config["NUM_ENVS"])
+                init_partner_hstate = partner_population.policy_cls.init_hstate(
+                    config["NUM_ENVS"]
+                )
                 init_ego_hstate_sp0 = policy.init_hstate(config["NUM_ENVS"])
                 init_ego_hstate_sp1 = policy.init_hstate(config["NUM_ENVS"])
 
                 # Initialize visit counts for UCB style sampling of partners
-                init_partner_visit_counts = jnp.zeros((config["POP_SIZE"],), dtype=jnp.int32)
+                init_partner_visit_counts = jnp.zeros(
+                    (config["POP_SIZE"],), dtype=jnp.int32
+                )
 
                 update_runner_state = (
-                    train_state, pop_buffer,
-                    env_state_sp, obsv_sp,
-                    env_state_xp, obsv_xp,
-                    init_done_xp, init_done_sp,
+                    train_state,
+                    pop_buffer,
+                    env_state_sp,
+                    obsv_sp,
+                    env_state_xp,
+                    obsv_xp,
+                    init_done_xp,
+                    init_done_sp,
                     init_partner_indices_xp,
-                    init_ego_hstate_xp, init_partner_hstate,
-                    init_ego_hstate_sp0, init_ego_hstate_sp1,
-                    rng, update_steps,
+                    init_ego_hstate_xp,
+                    init_partner_hstate,
+                    init_ego_hstate_sp0,
+                    init_ego_hstate_sp1,
+                    rng,
+                    update_steps,
                     num_existing_agents,
                     init_partner_visit_counts,
                 )
 
-
                 checkpoint_array = init_ckpt_array(train_state.params)
                 ckpt_idx = 0
                 update_with_ckpt_runner_state = (
-                    update_runner_state, checkpoint_array, ckpt_idx, 
-                    xp_eval_returns, sp_eval_returns
+                    update_runner_state,
+                    checkpoint_array,
+                    ckpt_idx,
+                    xp_eval_returns,
+                    sp_eval_returns,
                 )
 
                 def _update_step_with_ckpt(state_with_ckpt, unused):
-                    (update_runner_state, checkpoint_array, ckpt_idx, xp_eval_returns, sp_eval_returns) = state_with_ckpt
+                    (
+                        update_runner_state,
+                        checkpoint_array,
+                        ckpt_idx,
+                        xp_eval_returns,
+                        sp_eval_returns,
+                    ) = state_with_ckpt
                     train_state = update_runner_state[0]
 
                     # Single PPO update
                     new_state_with_ckpt, metric = _update_step(
-                        (update_runner_state, checkpoint_array, ckpt_idx),
-                        None
+                        (update_runner_state, checkpoint_array, ckpt_idx), None
                     )
                     new_update_runner_state = new_state_with_ckpt[0]
-                    rng, update_steps = new_update_runner_state[13], new_update_runner_state[14]
+                    rng, update_steps = (
+                        new_update_runner_state[13],
+                        new_update_runner_state[14],
+                    )
 
                     # Decide if we store a checkpoint
                     # update steps is 1-indexed because it was incremented at the end of the update step
-                    to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                            jnp.equal(update_steps, config["NUM_UPDATES"]))
+                    to_store = jnp.logical_or(
+                        jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                        jnp.equal(update_steps, config["NUM_UPDATES"]),
+                    )
 
                     def store_and_eval_ckpt(args):
                         ckpt_arr, rng, cidx, _, _ = args
                         new_ckpt_arr = jax.tree.map(
                             lambda c_arr, p: c_arr.at[cidx].set(p),
-                            ckpt_arr, train_state.params
+                            ckpt_arr,
+                            train_state.params,
                         )
 
                         # Eval trained agent against all params in the pool
-                        xp_eval_returns = jax.tree.map(lambda x: x.mean(axis=(-2, -1)),
+                        xp_eval_returns = jax.tree.map(
+                            lambda x: x.mean(axis=(-2, -1)),
                             jax.vmap(per_id_run_episode_fixed_rng, in_axes=(None, 0))(
-                                train_state.params, jnp.arange(config["POP_SIZE"])))
+                                train_state.params, jnp.arange(config["POP_SIZE"])
+                            ),
+                        )
                         # Eval trained agent against itself
-                        sp_eval_returns = jax.tree.map(lambda x: x.mean(), run_episodes(
-                            eval_rng, env,
-                            agent_0_param=train_state.params, agent_0_policy=policy,
-                            agent_1_param=train_state.params, agent_1_policy=policy,
-                            max_episode_steps=config["ROLLOUT_LENGTH"],
-                            num_eps=config["NUM_EVAL_EPISODES"]
-                        ))
-                        return (new_ckpt_arr, rng, cidx + 1, xp_eval_returns, sp_eval_returns)
+                        sp_eval_returns = jax.tree.map(
+                            lambda x: x.mean(),
+                            run_episodes(
+                                eval_rng,
+                                env,
+                                agent_0_param=train_state.params,
+                                agent_0_policy=policy,
+                                agent_1_param=train_state.params,
+                                agent_1_policy=policy,
+                                max_episode_steps=config["ROLLOUT_LENGTH"],
+                                num_eps=config["NUM_EVAL_EPISODES"],
+                            ),
+                        )
+                        return (
+                            new_ckpt_arr,
+                            rng,
+                            cidx + 1,
+                            xp_eval_returns,
+                            sp_eval_returns,
+                        )
 
                     def skip_ckpt(args):
                         return args
 
                     rng, store_and_eval_rng = jax.random.split(rng, 2)
-                    (checkpoint_array, store_and_eval_rng, ckpt_idx, xp_eval_returns, sp_eval_returns) = jax.lax.cond(
+                    (
+                        checkpoint_array,
+                        store_and_eval_rng,
+                        ckpt_idx,
+                        xp_eval_returns,
+                        sp_eval_returns,
+                    ) = jax.lax.cond(
                         to_store,
                         store_and_eval_ckpt,
                         skip_ckpt,
-                        (checkpoint_array, store_and_eval_rng, ckpt_idx, xp_eval_returns, sp_eval_returns)
+                        (
+                            checkpoint_array,
+                            store_and_eval_rng,
+                            ckpt_idx,
+                            xp_eval_returns,
+                            sp_eval_returns,
+                        ),
                     )
 
-                    return (new_update_runner_state, checkpoint_array,
-                            ckpt_idx, xp_eval_returns, sp_eval_returns), (metric, xp_eval_returns, sp_eval_returns)
+                    return (
+                        new_update_runner_state,
+                        checkpoint_array,
+                        ckpt_idx,
+                        xp_eval_returns,
+                        sp_eval_returns,
+                    ), (metric, xp_eval_returns, sp_eval_returns)
 
-                new_update_with_ckpt_runner_state, (metric, xp_eval_returns, sp_eval_returns) = jax.lax.scan(
+                (
+                    new_update_with_ckpt_runner_state,
+                    (metric, xp_eval_returns, sp_eval_returns),
+                ) = jax.lax.scan(
                     _update_step_with_ckpt,
                     update_with_ckpt_runner_state,
                     xs=None,
                     length=config["NUM_UPDATES"],
                 )
-                new_update_runner_state, new_checkpoint_array, _, _, _ = new_update_with_ckpt_runner_state
+                new_update_runner_state, new_checkpoint_array, _, _, _ = (
+                    new_update_with_ckpt_runner_state
+                )
                 final_train_state = new_update_runner_state[0]
 
                 # Add newly trained agent i to the population buffer (default score, updated below)
-                updated_pop_buffer = partner_population.add_agent(pop_buffer, final_train_state.params)
+                updated_pop_buffer = partner_population.add_agent(
+                    pop_buffer, final_train_state.params
+                )
 
                 # ------------------------------------------------------------------
                 # Update XP matrix for agent i (= num_existing_agents).
@@ -919,8 +1340,8 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         lambda x: jnp.squeeze(x, 0),
                         partner_population.gather_agent_params(
                             updated_pop_buffer,
-                            agent_indices=j_idx * jnp.ones((1,), dtype=jnp.int32)
-                        )
+                            agent_indices=j_idx * jnp.ones((1,), dtype=jnp.int32),
+                        ),
                     )
                     return eval_pair_ij(final_train_state.params, agent_j_param)
 
@@ -930,14 +1351,14 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         lambda x: jnp.squeeze(x, 0),
                         partner_population.gather_agent_params(
                             updated_pop_buffer,
-                            agent_indices=j_idx * jnp.ones((1,), dtype=jnp.int32)
-                        )
+                            agent_indices=j_idx * jnp.ones((1,), dtype=jnp.int32),
+                        ),
                     )
                     return eval_pair_ij(agent_j_param, final_train_state.params)
 
                 # Evaluate over all population slots (masking of invalid entries done via xp_matrix)
-                row_i_returns = jax.vmap(eval_i_vs_j)(all_indices)   # shape (POP_SIZE,)
-                col_i_returns = jax.vmap(eval_j_vs_i)(all_indices)   # shape (POP_SIZE,)
+                row_i_returns = jax.vmap(eval_i_vs_j)(all_indices)  # shape (POP_SIZE,)
+                col_i_returns = jax.vmap(eval_j_vs_i)(all_indices)  # shape (POP_SIZE,)
 
                 # Write into xp_matrix
                 # Entries for untrained agents will be 0 and are masked by metasolve
@@ -946,12 +1367,19 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                 xp_matrix = xp_matrix.at[:, new_agent_i].set(col_i_returns)
 
                 checkpoints = new_checkpoint_array
-                return (updated_pop_buffer, xp_matrix, num_existing_agents + 1), \
-                    (checkpoints, metric, xp_eval_returns, sp_eval_returns)
+                return (updated_pop_buffer, xp_matrix, num_existing_agents + 1), (
+                    checkpoints,
+                    metric,
+                    xp_eval_returns,
+                    sp_eval_returns,
+                )
 
             rngs = jax.random.split(rng, config["PARTNER_POP_SIZE"] - 1)
             num_existing_agents = 1
-            (final_population_buffer, final_xp_matrix, _), (checkpoints, metric, xp_eval_returns, sp_eval_returns) = jax.lax.scan(
+            (
+                (final_population_buffer, final_xp_matrix, _),
+                (checkpoints, metric, xp_eval_returns, sp_eval_returns),
+            ) = jax.lax.scan(
                 add_policy, (population_buffer, xp_matrix, num_existing_agents), rngs
             )
 
@@ -961,15 +1389,17 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                 "checkpoints": checkpoints,
                 "metrics": metric,
                 "last_ep_infos_xp": xp_eval_returns,
-                "last_ep_infos_sp": sp_eval_returns
+                "last_ep_infos_sp": sp_eval_returns,
             }
 
             return out
+
         return train
 
     train_fn = make_cole_agents(config)
     out = train_fn(train_rng)
     return out
+
 
 def select_best_agent(
     payoff: jnp.ndarray,
@@ -993,8 +1423,8 @@ def select_best_agent(
     N = payoff.shape[0]
 
     # Pre-compute all row and column means
-    s0_all = jnp.mean(payoff, axis=1)   # (N,) — row means: how well i does as agent_0
-    s1_all = jnp.mean(payoff, axis=0)   # (N,) — col means: how well i does as agent_1
+    s0_all = jnp.mean(payoff, axis=1)  # (N,) — row means: how well i does as agent_0
+    s1_all = jnp.mean(payoff, axis=0)  # (N,) — col means: how well i does as agent_1
 
     def scan_body(carry, i):
         best_i, best_s0, best_s1 = carry
@@ -1002,9 +1432,9 @@ def select_best_agent(
         s1_i = s1_all[i]
         # Only update if the candidate strictly improves BOTH criteria.
         improves_both = (s0_i > best_s0) & (s1_i > best_s1)
-        best_i  = jnp.where(improves_both, i,     best_i)
-        best_s0 = jnp.where(improves_both, s0_i,  best_s0)
-        best_s1 = jnp.where(improves_both, s1_i,  best_s1)
+        best_i = jnp.where(improves_both, i, best_i)
+        best_s0 = jnp.where(improves_both, s0_i, best_s0)
+        best_s1 = jnp.where(improves_both, s1_i, best_s1)
         return (best_i, best_s0, best_s1), None
 
     # Initialise with final agent, then scan over agents 0 .. N-2.
@@ -1012,7 +1442,7 @@ def select_best_agent(
     # some other agent Pareto-dominates it.
     init_carry = (jnp.int32(-1), s0_all[-1], s1_all[-1])
     (best_i, best_s0, best_s1), _ = jax.lax.scan(
-        scan_body, init_carry, jnp.arange(0, N-1, dtype=jnp.int32)
+        scan_body, init_carry, jnp.arange(0, N - 1, dtype=jnp.int32)
     )
     return best_i, best_s0, best_s1
 
@@ -1022,7 +1452,7 @@ def get_cole_population(config, out, env):
     cole_pop_size = config["algorithm"]["PARTNER_POP_SIZE"]
 
     # partner_params has shape (num_seeds, cole_pop_size, ...)
-    partner_params = out['final_params']
+    partner_params = out["final_params"]
 
     rng = jax.random.PRNGKey(0)  # dummy key; only used for parameter shape
     partner_policy, _ = initialize_agent(
@@ -1031,11 +1461,11 @@ def get_cole_population(config, out, env):
 
     # Create partner population
     partner_population = AgentPopulation(
-        pop_size=cole_pop_size,
-        policy_cls=partner_policy
+        pop_size=cole_pop_size, policy_cls=partner_policy
     )
 
     return partner_params, partner_population
+
 
 def run_cole(config, wandb_logger):
     algorithm_config = dict(config["algorithm"])
@@ -1067,11 +1497,13 @@ def run_cole(config, wandb_logger):
     with jax.disable_jit(False):
         vmapped_train_fn = jax.jit(
             jax.vmap(
-                partial(train_cole_partners, 
-                        wandb_logger=wandb_logger,
-                        env=env, 
-                        config=algorithm_config,
-                        progress_callback=update_progress_bar)
+                partial(
+                    train_cole_partners,
+                    wandb_logger=wandb_logger,
+                    env=env,
+                    config=algorithm_config,
+                    progress_callback=update_progress_bar,
+                )
             )
         )
         out = vmapped_train_fn(rngs)
@@ -1083,13 +1515,13 @@ def run_cole(config, wandb_logger):
     metric_names = get_metric_names(algorithm_config["ENV_NAME"])
 
     log_final_metrics(config, out, wandb_logger, metric_names)
-    
+
     dummy_env = make_env(algorithm_config["ENV_NAME"], algorithm_config["ENV_KWARGS"])
     ego_policy, init_ego_params = initialize_agent(
         algorithm_config["ACTOR_TYPE"], algorithm_config, dummy_env, eval_rng
     )
 
-    # Select the best agent from each seed's population using 
+    # Select the best agent from each seed's population using
     # the final XP matrix and Pareto-improvement criterion
     # out["final_xp_matrix"] has shape (num_seeds, POP_SIZE, POP_SIZE).
     best_is, best_s0s, best_s1s = jax.vmap(select_best_agent)(out["final_xp_matrix"])
@@ -1098,10 +1530,11 @@ def run_cole(config, wandb_logger):
     log.info(f"Best col-mean (s1) per seed:      {np.array(best_s1s)}")
     best_ego_params = jax.tree.map(
         lambda x: x[jnp.arange(algorithm_config["NUM_SEEDS"]), best_is],
-        out["final_params"]
+        out["final_params"],
     )
-    
+
     return ego_policy, best_ego_params, init_ego_params
+
 
 def log_metrics_intermediate(metric, logger):
     """Log one update step's metrics to wandb in real time.
@@ -1122,9 +1555,12 @@ def log_metrics_intermediate(metric, logger):
 
     # Loss/entropy keys – mean over epochs and minibatches
     loss_keys = [
-        "value_loss_xp", "value_loss_sp",
-        "pg_loss_xp", "pg_loss_sp",
-        "entropy_xp", "entropy_sp",
+        "value_loss_xp",
+        "value_loss_sp",
+        "pg_loss_xp",
+        "pg_loss_sp",
+        "entropy_xp",
+        "entropy_sp",
     ]
     for k in loss_keys:
         if k in metric:
@@ -1142,25 +1578,31 @@ def log_metrics_intermediate(metric, logger):
     # Shape is (ROLLOUT_LENGTH, NUM_ENVS); only log completed-episode returns
     for k, v in metric.items():
         v_np = np.array(v)
-        logger.log_item(f"Train/{k}", float(np.mean(v_np)), train_step=step, commit=False)
+        logger.log_item(
+            f"Train/{k}", float(np.mean(v_np)), train_step=step, commit=False
+        )
 
     logger.commit()
 
+
 def log_final_metrics(config, outs, logger, metric_names: tuple):
-    """Log post-hoc evaluation metrics and save artifacts.
-    """
+    """Log post-hoc evaluation metrics and save artifacts."""
     metrics = outs["metrics"]
     # trained_pop_size excludes the initial policy, so it's pop_size - 1
-    num_seeds, trained_pop_size, num_updates = metrics["pg_loss_sp"].shape
+    _num_seeds, trained_pop_size, num_updates = metrics["pg_loss_sp"].shape
 
     ### Log last XP matrix
-    final_xp_matrix = np.asarray(outs["final_xp_matrix"]).mean(axis=0)  # shape (pop_size, pop_size)
+    final_xp_matrix = np.asarray(outs["final_xp_matrix"]).mean(
+        axis=0
+    )  # shape (pop_size, pop_size)
     logger.log_xp_matrix("Eval/LastXPMatrix", final_xp_matrix)
 
     ### Log XP and SP eval return curves
     # xp_eval_returns and sp_eval_returns logged at each evaluation only.
     algorithm_config = config["algorithm"]
-    ckpt_and_eval_interval = num_updates // max(1, algorithm_config["NUM_CHECKPOINTS"] - 1)
+    ckpt_and_eval_interval = num_updates // max(
+        1, algorithm_config["NUM_CHECKPOINTS"] - 1
+    )
     # Steps at which store_and_eval_ckpt were run
     eval_steps = list(range(0, num_updates, ckpt_and_eval_interval))
     if (num_updates - 1) not in eval_steps:
@@ -1172,8 +1614,10 @@ def log_final_metrics(config, outs, logger, metric_names: tuple):
     all_returns_xp = np.asarray(outs["last_ep_infos_xp"]["returned_episode_returns"])
 
     # Average over seeds only (eval episodes and agents already averaged inside scan)
-    sp_return_curve = all_returns_sp.mean(axis=0) # shape (pop_size - 1, num_updates)
-    xp_return_curve = all_returns_xp.mean(axis=0) #  shape (pop_size - 1, num_updates, pop_size)
+    sp_return_curve = all_returns_sp.mean(axis=0)  # shape (pop_size - 1, num_updates)
+    xp_return_curve = all_returns_xp.mean(
+        axis=0
+    )  #  shape (pop_size - 1, num_updates, pop_size)
 
     for num_add_policies in range(trained_pop_size):
         for update_step in eval_steps:
@@ -1182,14 +1626,16 @@ def log_final_metrics(config, outs, logger, metric_names: tuple):
             logger.log_item(
                 "Eval/AvgSPReturnCurve",
                 sp_return_curve[num_add_policies, update_step],
-                train_step=global_step
-                )
-            mean_xp_returns = xp_return_curve[num_add_policies, :, :(num_add_policies+1)].mean(axis=-1)
+                train_step=global_step,
+            )
+            mean_xp_returns = xp_return_curve[
+                num_add_policies, :, : (num_add_policies + 1)
+            ].mean(axis=-1)
             logger.log_item(
                 "Eval/AvgXPReturnCurve",
                 mean_xp_returns[update_step],
-                train_step=global_step
-                )
+                train_step=global_step,
+            )
     logger.commit()
 
     ### Log artifacts
@@ -1197,9 +1643,10 @@ def log_final_metrics(config, outs, logger, metric_names: tuple):
     # Save train run output and log to wandb as artifact
     out_savepath = save_train_run(outs, savedir, savename="saved_train_run")
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="saved_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="saved_train_run", path=out_savepath, type_name="train_run"
+        )
 
     # Cleanup locally logged out files
     if not config["local_logger"]["save_train_out"]:
         shutil.rmtree(out_savepath)
-

--- a/open_ended_training/open_ended_minimax.py
+++ b/open_ended_training/open_ended_minimax.py
@@ -145,7 +145,8 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                     log_prob=logp_0,
                     obs=obs_0,
                     info=info_0,
-                    avail_actions=avail_actions_0
+                    avail_actions=avail_actions_0,
+                    prev_done=last_dones["agent_0"]
                 )
                 new_runner_state = (train_state_conf, env_state_next, obs_next, done, new_conf_h, new_ego_h, rng)
                 return new_runner_state, transition
@@ -184,7 +185,7 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                         _, value_ego, pi_ego, _ = confederate_policy.get_action_value_policy(
                             params=params,
                             obs=traj_batch_ego.obs,
-                            done=traj_batch_ego.done,
+                            done=traj_batch_ego.prev_done,
                             avail_actions=traj_batch_ego.avail_actions,
                             hstate=init_conf_hstate,
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here

--- a/open_ended_training/open_ended_minimax.py
+++ b/open_ended_training/open_ended_minimax.py
@@ -1,38 +1,42 @@
+import copy
+import logging
 import shutil
 import time
-import logging
-import copy
+from functools import partial
+
 import hydra
 import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
 from flax.training.train_state import TrainState
-from functools import partial
 
+from agents.initialize_agents import initialize_s5_agent
 from agents.mlp_actor_critic_agent import MLPActorCriticPolicy
 from agents.population_interface import AgentPopulation
-from agents.initialize_agents import initialize_s5_agent
-from common.plot_utils import get_stats, get_metric_names
-from common.save_load_utils import save_train_run
+from common.plot_utils import get_metric_names
 from common.run_episodes import run_episodes
-from marl.ppo_utils import Transition, unbatchify
+from common.save_load_utils import save_train_run
+from ego_agent_training.ppo_ego import train_ppo_ego_agent
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from ego_agent_training.ppo_ego import train_ppo_ego_agent
+from marl.ppo_utils import Transition, unbatchify
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
 def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
-    '''
+    """
     Train confederate that minimizes the given ego agent using IPPO.
     Return model checkpoints and metrics.
-    '''
+    """
+
     def make_minimax_partner_train(config):
         num_agents = env.num_agents
-        assert num_agents == 2, "This code assumes the environment has exactly 2 agents."
+        assert num_agents == 2, (
+            "This code assumes the environment has exactly 2 agents."
+        )
 
         config["NUM_ACTORS"] = num_agents * config["NUM_ENVS"]
 
@@ -40,18 +44,26 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
         config["NUM_CONTROLLED_ACTORS"] = config["NUM_ENVS"]
         config["NUM_UNCONTROLLED_AGENTS"] = config["NUM_ENVS"]
 
-        config["NUM_UPDATES"] = config["TIMESTEPS_PER_ITER_PARTNER"] // (config["ROLLOUT_LENGTH"] * config["NUM_ENVS"] * config["PARTNER_POP_SIZE"])
-        config["MINIBATCH_SIZE"] = (config["NUM_ACTORS"] * config["ROLLOUT_LENGTH"]) // config["NUM_MINIBATCHES"]
+        config["NUM_UPDATES"] = config["TIMESTEPS_PER_ITER_PARTNER"] // (
+            config["ROLLOUT_LENGTH"] * config["NUM_ENVS"] * config["PARTNER_POP_SIZE"]
+        )
+        config["MINIBATCH_SIZE"] = (
+            config["NUM_ACTORS"] * config["ROLLOUT_LENGTH"]
+        ) // config["NUM_MINIBATCHES"]
 
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng):
             # Initialize confederate policy using ActorWithDoubleCriticPolicy
             confederate_policy = MLPActorCriticPolicy(
                 action_dim=env.action_space(env.agents[0]).n,
-                obs_dim=env.observation_space(env.agents[0]).shape[0]
+                obs_dim=env.observation_space(env.agents[0]).shape[0],
             )
 
             rng, init_conf_rng = jax.random.split(rng, 2)
@@ -62,8 +74,12 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
             # Define optimizers for both confederate and BR policy
             tx = optax.chain(
                 optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"],
-                eps=1e-5),
+                optax.adam(
+                    learning_rate=linear_schedule
+                    if config["ANNEAL_LR"]
+                    else config["LR"],
+                    eps=1e-5,
+                ),
             )
             train_state_conf = TrainState.create(
                 apply_fn=confederate_policy.network.apply,
@@ -78,6 +94,7 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
             reset_rngs_ego = jax.random.split(reset_rng_ego, config["NUM_ENVS"])
 
             obsv_ego, env_state_ego = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_ego)
+
             # --------------------------
             # 3c) Define env step
             # --------------------------
@@ -86,7 +103,15 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                 agent_0 = confederate, agent_1 = ego
                 Returns updated runner_state, and a Transition for agent_0.
                 """
-                train_state_conf, env_state, last_obs, last_dones, last_conf_h, last_ego_h, rng = runner_state
+                (
+                    train_state_conf,
+                    env_state,
+                    last_obs,
+                    last_dones,
+                    last_conf_h,
+                    last_ego_h,
+                    rng,
+                ) = runner_state
                 rng, act_rng, partner_rng, step_rng = jax.random.split(rng, 4)
 
                 obs_0 = last_obs["agent_0"]
@@ -98,13 +123,17 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                 avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
                 # Agent_0 (confederate) action using policy interface
-                act_0, val_0, pi_0, new_conf_h = confederate_policy.get_action_value_policy(
-                    params=train_state_conf.params,
-                    obs=obs_0.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),  # confederate has same done status
-                    avail_actions=jax.lax.stop_gradient(avail_actions_0),
-                    hstate=last_conf_h,
-                    rng=act_rng
+                act_0, val_0, pi_0, new_conf_h = (
+                    confederate_policy.get_action_value_policy(
+                        params=train_state_conf.params,
+                        obs=obs_0.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
+                        done=last_dones["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"]
+                        ),  # confederate has same done status
+                        avail_actions=jax.lax.stop_gradient(avail_actions_0),
+                        hstate=last_conf_h,
+                        rng=act_rng,
+                    )
                 )
                 logp_0 = pi_0.log_prob(act_0)
 
@@ -116,23 +145,29 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                 act_1, _, _, new_ego_h = ego_policy.get_action_value_policy(
                     params=ego_params,
                     obs=obs_1.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones["agent_1"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
+                    done=last_dones["agent_1"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"]
+                    ),
                     avail_actions=jax.lax.stop_gradient(avail_actions_1),
                     hstate=last_ego_h,
-                    rng=partner_rng
+                    rng=partner_rng,
                 )
                 act_1 = act_1.squeeze()
 
                 # Combine actions into the env format
-                combined_actions = jnp.concatenate([act_0, act_1], axis=0)  # shape (2*num_envs,)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                combined_actions = jnp.concatenate(
+                    [act_0, act_1], axis=0
+                )  # shape (2*num_envs,)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
 
                 # Step env
                 step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state, env_act
-                )
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 # note that num_actors = num_envs * num_agents
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
 
@@ -146,9 +181,17 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                     obs=obs_0,
                     info=info_0,
                     avail_actions=avail_actions_0,
-                    prev_done=last_dones["agent_0"]
+                    prev_done=last_dones["agent_0"],
                 )
-                new_runner_state = (train_state_conf, env_state_next, obs_next, done, new_conf_h, new_ego_h, rng)
+                new_runner_state = (
+                    train_state_conf,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_conf_h,
+                    new_ego_h,
+                    rng,
+                )
                 return new_runner_state, transition
 
             def _calculate_gae(traj_batch, last_val):
@@ -179,67 +222,93 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                 def _update_minbatch(train_state_conf, minibatch_ego):
                     traj_batch_ego, advantages_ego, returns_ego = minibatch_ego
 
-                    init_conf_hstate = confederate_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
+                    init_conf_hstate = confederate_policy.init_hstate(
+                        config["NUM_CONTROLLED_ACTORS"]
+                    )
 
                     def _loss_fn(params, traj_batch_ego, gae_ego, target_v_ego):
-                        _, value_ego, pi_ego, _ = confederate_policy.get_action_value_policy(
-                            params=params,
-                            obs=traj_batch_ego.obs,
-                            done=traj_batch_ego.prev_done,
-                            avail_actions=traj_batch_ego.avail_actions,
-                            hstate=init_conf_hstate,
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
+                        _, value_ego, pi_ego, _ = (
+                            confederate_policy.get_action_value_policy(
+                                params=params,
+                                obs=traj_batch_ego.obs,
+                                done=traj_batch_ego.prev_done,
+                                avail_actions=traj_batch_ego.avail_actions,
+                                hstate=init_conf_hstate,
+                                rng=jax.random.PRNGKey(
+                                    0
+                                ),  # only used for action sampling, which is not used here
+                            )
                         )
                         log_prob_ego = pi_ego.log_prob(traj_batch_ego.action)
 
                         # Value loss for interaction with ego agent
                         value_pred_ego_clipped = traj_batch_ego.value + (
                             value_ego - traj_batch_ego.value
-                            ).clip(
-                            -config["CLIP_EPS"], config["CLIP_EPS"])
+                        ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                         value_losses_ego = jnp.square(value_ego - target_v_ego)
-                        value_losses_clipped_ego = jnp.square(value_pred_ego_clipped - target_v_ego)
-                        value_loss_ego = jnp.maximum(value_losses_ego, value_losses_clipped_ego).mean()
+                        value_losses_clipped_ego = jnp.square(
+                            value_pred_ego_clipped - target_v_ego
+                        )
+                        value_loss_ego = jnp.maximum(
+                            value_losses_ego, value_losses_clipped_ego
+                        ).mean()
 
                         # Policy gradient loss for interaction with ego agent
                         ratio_ego = jnp.exp(log_prob_ego - traj_batch_ego.log_prob)
-                        gae_norm_ego = (gae_ego - gae_ego.mean()) / (gae_ego.std() + 1e-8)
+                        gae_norm_ego = (gae_ego - gae_ego.mean()) / (
+                            gae_ego.std() + 1e-8
+                        )
                         pg_loss_1_ego = ratio_ego * gae_norm_ego
-                        pg_loss_2_ego = jnp.clip(
-                            ratio_ego,
-                            1.0 - config["CLIP_EPS"],
-                            1.0 + config["CLIP_EPS"]) * gae_norm_ego
-                        pg_loss_ego = -jnp.mean(jnp.minimum(pg_loss_1_ego, pg_loss_2_ego))
+                        pg_loss_2_ego = (
+                            jnp.clip(
+                                ratio_ego,
+                                1.0 - config["CLIP_EPS"],
+                                1.0 + config["CLIP_EPS"],
+                            )
+                            * gae_norm_ego
+                        )
+                        pg_loss_ego = -jnp.mean(
+                            jnp.minimum(pg_loss_1_ego, pg_loss_2_ego)
+                        )
 
                         # Entropy for interaction with ego agent
                         entropy_ego = jnp.mean(pi_ego.entropy())
 
                         # We negate the pg loss to minimize the ego agent's objective
-                        total_loss = -pg_loss_ego + config["VF_COEF"] * value_loss_ego - config["ENT_COEF"] * entropy_ego
+                        total_loss = (
+                            -pg_loss_ego
+                            + config["VF_COEF"] * value_loss_ego
+                            - config["ENT_COEF"] * entropy_ego
+                        )
                         return total_loss, (value_loss_ego, pg_loss_ego, entropy_ego)
 
                     grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
                     (loss_val, aux_vals), grads = grad_fn(
                         train_state_conf.params,
-                        traj_batch_ego, advantages_ego, returns_ego)
+                        traj_batch_ego,
+                        advantages_ego,
+                        returns_ego,
+                    )
                     train_state_conf = train_state_conf.apply_gradients(grads=grads)
                     return train_state_conf, (loss_val, aux_vals)
-
 
                 (
                     train_state_conf,
                     traj_batch_ego,
                     advantages_conf_ego,
                     targets_conf_ego,
-                    rng_ego
+                    rng_ego,
                 ) = update_state
 
                 rng_ego, perm_rng_ego = jax.random.split(rng_ego, 2)
 
                 # Divide batch size by TWO because we are only training on data of agent_0
-                batch_size_ego = config["MINIBATCH_SIZE"] * config["NUM_MINIBATCHES"] // 2
+                batch_size_ego = (
+                    config["MINIBATCH_SIZE"] * config["NUM_MINIBATCHES"] // 2
+                )
                 assert (
-                    batch_size_ego == config["ROLLOUT_LENGTH"] * config["NUM_ACTORS"] // 2
+                    batch_size_ego
+                    == config["ROLLOUT_LENGTH"] * config["NUM_ACTORS"] // 2
                 ), "batch size must be equal to number of steps * number of actors"
 
                 permutation_ego = jax.random.permutation(perm_rng_ego, batch_size_ego)
@@ -265,11 +334,13 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                     _update_minbatch, train_state_conf, minibatches_ego
                 )
 
-                update_state = (train_state_conf,
+                update_state = (
+                    train_state_conf,
                     traj_batch_ego,
                     advantages_conf_ego,
                     targets_conf_ego,
-                    rng_ego)
+                    rng_ego,
+                )
                 return update_state, (total_loss, aux_vals)
 
             def _update_step(update_runner_state, unused):
@@ -281,35 +352,61 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                 (
                     train_state_conf,
                     env_state_ego,
-                    last_obs_ego, last_dones_ego,
-                    conf_hstate_ego, ego_hstate,
-                    rng_ego, update_steps
+                    last_obs_ego,
+                    last_dones_ego,
+                    conf_hstate_ego,
+                    ego_hstate,
+                    rng_ego,
+                    update_steps,
                 ) = update_runner_state
 
                 # 1) rollout for interactions against ego agent
-                runner_state_ego = (train_state_conf, env_state_ego, last_obs_ego, last_dones_ego,
-                                    conf_hstate_ego, ego_hstate, rng_ego)
+                runner_state_ego = (
+                    train_state_conf,
+                    env_state_ego,
+                    last_obs_ego,
+                    last_dones_ego,
+                    conf_hstate_ego,
+                    ego_hstate,
+                    rng_ego,
+                )
                 runner_state_ego, traj_batch_ego = jax.lax.scan(
-                    _env_step, runner_state_ego, None, config["ROLLOUT_LENGTH"])
-                (train_state_conf, env_state_ego, last_obs_ego, last_dones_ego,
-                 conf_hstate_ego, ego_hstate, rng_ego) = runner_state_ego
+                    _env_step, runner_state_ego, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    train_state_conf,
+                    env_state_ego,
+                    last_obs_ego,
+                    last_dones_ego,
+                    conf_hstate_ego,
+                    ego_hstate,
+                    rng_ego,
+                ) = runner_state_ego
 
                 # 2) compute advantage for confederate agent from interaction with ego agent
 
                 # Get available actions for agent 0 from environment state
-                avail_actions_0_ego = jax.vmap(env.get_avail_actions)(env_state_ego.env_state)["agent_0"].astype(jnp.float32)
+                avail_actions_0_ego = jax.vmap(env.get_avail_actions)(
+                    env_state_ego.env_state
+                )["agent_0"].astype(jnp.float32)
 
                 # Get last value
                 _, last_val_0_ego, _, _ = confederate_policy.get_action_value_policy(
                     params=train_state_conf.params,
-                    obs=last_obs_ego["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones_ego["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
+                    obs=last_obs_ego["agent_0"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"], -1
+                    ),
+                    done=last_dones_ego["agent_0"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"]
+                    ),
                     avail_actions=jax.lax.stop_gradient(avail_actions_0_ego),
                     hstate=conf_hstate_ego,
-                    rng=jax.random.PRNGKey(0)  # dummy key as we don't sample actions
+                    rng=jax.random.PRNGKey(0),  # dummy key as we don't sample actions
                 )
                 last_val_0_ego = last_val_0_ego.squeeze()
-                advantages_conf_ego, targets_conf_ego = _calculate_gae(traj_batch_ego, last_val_0_ego)
+                advantages_conf_ego, targets_conf_ego = _calculate_gae(
+                    traj_batch_ego, last_val_0_ego
+                )
 
                 # 3) PPO update
                 update_state = (
@@ -317,10 +414,11 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                     traj_batch_ego,
                     advantages_conf_ego,
                     targets_conf_ego,
-                    rng_ego
+                    rng_ego,
                 )
-                update_state, (total_loss, aux_vals) = jax.lax.scan(
-                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                update_state, (_total_loss, aux_vals) = jax.lax.scan(
+                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                )
                 train_state_conf = update_state[0]
                 value_loss_ego, pg_loss_ego, entropy_ego = aux_vals
 
@@ -328,8 +426,12 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                 def mask_and_mean(x, mask):
                     return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
 
-                mask = traj_batch_ego.info.get("returned_episode", jnp.ones_like(traj_batch_ego.reward))
-                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_ego.info)
+                mask = traj_batch_ego.info.get(
+                    "returned_episode", jnp.ones_like(traj_batch_ego.reward)
+                )
+                metric = jax.tree.map(
+                    lambda x: mask_and_mean(x, mask), traj_batch_ego.info
+                )
                 metric["update_steps"] = update_steps
                 metric["value_loss_conf_against_ego"] = value_loss_ego.mean()
                 metric["pg_loss_conf_against_ego"] = pg_loss_ego.mean()
@@ -337,69 +439,104 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                 metric["average_rewards_ego"] = jnp.mean(traj_batch_ego.reward)
 
                 new_runner_state = (
-                    train_state_conf, env_state_ego,
-                    last_obs_ego, last_dones_ego,
-                    conf_hstate_ego, ego_hstate,
-                    rng_ego, update_steps + 1
+                    train_state_conf,
+                    env_state_ego,
+                    last_obs_ego,
+                    last_dones_ego,
+                    conf_hstate_ego,
+                    ego_hstate,
+                    rng_ego,
+                    update_steps + 1,
                 )
                 return (new_runner_state, metric)
 
             # --------------------------
             # PPO Update and Checkpoint saving
             # --------------------------
-            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)  # -1 because we store a ckpt at the last update
+            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                1, config["NUM_CHECKPOINTS"] - 1
+            )  # -1 because we store a ckpt at the last update
             num_ckpts = config["NUM_CHECKPOINTS"]
 
             # Build a PyTree that holds parameters for all conf agent checkpoints
             def init_ckpt_array(params_pytree):
                 return jax.tree.map(
-                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype),
-                    params_pytree)
+                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
+                )
 
             def _update_step_with_ckpt(state_with_ckpt, unused):
-                ((
-                    train_state_conf, env_state_ego,
-                    last_obs_ego, last_dones_ego,
-                    conf_hstate_ego, ego_hstate,
-                    rng_ego, update_steps
-                ), checkpoint_array_conf, ckpt_idx,
-                    eval_info_ego) = state_with_ckpt
+                (
+                    (
+                        train_state_conf,
+                        env_state_ego,
+                        last_obs_ego,
+                        last_dones_ego,
+                        conf_hstate_ego,
+                        ego_hstate,
+                        rng_ego,
+                        update_steps,
+                    ),
+                    checkpoint_array_conf,
+                    ckpt_idx,
+                    eval_info_ego,
+                ) = state_with_ckpt
 
                 # Single PPO update
                 (new_runner_state, metric) = _update_step(
-                    (train_state_conf, env_state_ego,
-                    last_obs_ego, last_dones_ego,
-                    conf_hstate_ego, ego_hstate,
-                    rng_ego, update_steps),
-                    None
+                    (
+                        train_state_conf,
+                        env_state_ego,
+                        last_obs_ego,
+                        last_dones_ego,
+                        conf_hstate_ego,
+                        ego_hstate,
+                        rng_ego,
+                        update_steps,
+                    ),
+                    None,
                 )
 
                 (
-                    train_state_conf, env_state_ego,
-                    last_obs_ego, last_dones_ego,
-                    conf_hstate_ego, ego_hstate,
-                    rng_ego, update_steps
+                    train_state_conf,
+                    env_state_ego,
+                    last_obs_ego,
+                    last_dones_ego,
+                    conf_hstate_ego,
+                    ego_hstate,
+                    rng_ego,
+                    update_steps,
                 ) = new_runner_state
 
                 # Decide if we store a checkpoint
                 # update steps is 1-indexed because it was incremented at the end of the update step
-                to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                        jnp.equal(update_steps, config["NUM_UPDATES"]))
+                to_store = jnp.logical_or(
+                    jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
+                )
 
                 def store_and_eval_ckpt(args):
                     ckpt_arr_and_ep_infos, rng, cidx = args
-                    ckpt_arr_conf, prev_ep_infos_ego = ckpt_arr_and_ep_infos
+                    ckpt_arr_conf, _prev_ep_infos_ego = ckpt_arr_and_ep_infos
                     new_ckpt_arr_conf = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_conf, train_state_conf.params
+                        ckpt_arr_conf,
+                        train_state_conf.params,
                     )
                     # run eval episodes
-                    rng, eval_rng, = jax.random.split(rng)
+                    (
+                        rng,
+                        eval_rng,
+                    ) = jax.random.split(rng)
                     # conf vs ego
-                    last_ep_info_with_ego = run_episodes(eval_rng, env,
-                        agent_0_param=train_state_conf.params, agent_0_policy=confederate_policy,
-                        agent_1_param=ego_params, agent_1_policy=ego_policy,
-                        max_episode_steps=config["ROLLOUT_LENGTH"], num_eps=config["NUM_EVAL_EPISODES"]
+                    last_ep_info_with_ego = run_episodes(
+                        eval_rng,
+                        env,
+                        agent_0_param=train_state_conf.params,
+                        agent_0_policy=confederate_policy,
+                        agent_1_param=ego_params,
+                        agent_1_policy=ego_policy,
+                        max_episode_steps=config["ROLLOUT_LENGTH"],
+                        num_eps=config["NUM_EVAL_EPISODES"],
                     )
 
                     return ((new_ckpt_arr_conf, last_ep_info_with_ego), rng, cidx + 1)
@@ -411,18 +548,27 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
                     to_store,
                     store_and_eval_ckpt,
                     skip_ckpt,
-                    ((checkpoint_array_conf, eval_info_ego), rng_ego, ckpt_idx)
+                    ((checkpoint_array_conf, eval_info_ego), rng_ego, ckpt_idx),
                 )
                 checkpoint_array_conf, ep_info_ego = checkpoint_array_and_infos
 
                 metric["eval_ep_last_info_ego"] = ep_info_ego
 
-                return ((train_state_conf, env_state_ego,
-                         last_obs_ego, last_dones_ego,
-                         conf_hstate_ego, ego_hstate,
-                         rng_ego, update_steps),
-                         checkpoint_array_conf, ckpt_idx,
-                         ep_info_ego), metric
+                return (
+                    (
+                        train_state_conf,
+                        env_state_ego,
+                        last_obs_ego,
+                        last_dones_ego,
+                        conf_hstate_ego,
+                        ego_hstate,
+                        rng_ego,
+                        update_steps,
+                    ),
+                    checkpoint_array_conf,
+                    ckpt_idx,
+                    ep_info_ego,
+                ), metric
 
             # init checkpoint array
             checkpoint_array_conf = init_ckpt_array(train_state_conf.params)
@@ -431,40 +577,58 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
             # initial state for scan over _update_step_with_ckpt
             update_steps = 0
             rng, rng_eval_ego = jax.random.split(rng, 2)
-            ep_infos_ego = run_episodes(rng_eval_ego, env,
-                agent_0_param=train_state_conf.params, agent_0_policy=confederate_policy,
-                agent_1_param=ego_params, agent_1_policy=ego_policy,
-                max_episode_steps=config["ROLLOUT_LENGTH"], num_eps=config["NUM_EVAL_EPISODES"]
+            ep_infos_ego = run_episodes(
+                rng_eval_ego,
+                env,
+                agent_0_param=train_state_conf.params,
+                agent_0_policy=confederate_policy,
+                agent_1_param=ego_params,
+                agent_1_policy=ego_policy,
+                max_episode_steps=config["ROLLOUT_LENGTH"],
+                num_eps=config["NUM_EVAL_EPISODES"],
             )
 
             # Initialize hidden states
             init_ego_hstate = ego_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
-            init_conf_hstate_ego = confederate_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
+            init_conf_hstate_ego = confederate_policy.init_hstate(
+                config["NUM_CONTROLLED_ACTORS"]
+            )
 
             # Initialize done flags
-            init_dones_ego = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
+            init_dones_ego = {
+                k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                for k in env.agents + ["__all__"]
+            }
 
             rng, rng_ego = jax.random.split(rng, 2)
             update_runner_state = (
-                train_state_conf, env_state_ego,
-                obsv_ego, init_dones_ego,
-                init_conf_hstate_ego, init_ego_hstate,
-                rng_ego, update_steps
+                train_state_conf,
+                env_state_ego,
+                obsv_ego,
+                init_dones_ego,
+                init_conf_hstate_ego,
+                init_ego_hstate,
+                rng_ego,
+                update_steps,
             )
             state_with_ckpt = (
-                update_runner_state, checkpoint_array_conf,
-                ckpt_idx, ep_infos_ego
+                update_runner_state,
+                checkpoint_array_conf,
+                ckpt_idx,
+                ep_infos_ego,
             )
             # run training
             state_with_ckpt, metrics = jax.lax.scan(
                 _update_step_with_ckpt,
                 state_with_ckpt,
                 xs=None,
-                length=config["NUM_UPDATES"]
+                length=config["NUM_UPDATES"],
             )
             (
-                final_runner_state, checkpoint_array_conf,
-                final_ckpt_idx, last_ep_infos_ego
+                final_runner_state,
+                checkpoint_array_conf,
+                _final_ckpt_idx,
+                _last_ep_infos_ego,
             ) = state_with_ckpt
 
             out = {
@@ -475,6 +639,7 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
             return out
 
         return train
+
     # ------------------------------
     # Actually run the teammate training
     # ------------------------------
@@ -483,15 +648,18 @@ def train_minimax_partners(config, ego_params, ego_policy, env, partner_rng):
     out = train_fn(rngs)
     return out
 
+
 def open_ended_training_step(carry, ego_policy, partner_population, config, env):
-    '''
+    """
     Train the ego agent against the adversarial partner.
-    '''
+    """
     prev_ego_params, rng = carry
     rng, partner_rng, ego_rng = jax.random.split(rng, 3)
 
     # Train partner agents with ego_policy
-    train_out = train_minimax_partners(config, prev_ego_params, ego_policy, env, partner_rng)
+    train_out = train_minimax_partners(
+        config, prev_ego_params, ego_policy, env, partner_rng
+    )
     train_partner_params = train_out["final_params"]
 
     # Train ego agent using train_ppo_ego_agent
@@ -504,15 +672,18 @@ def open_ended_training_step(carry, ego_policy, partner_population, config, env)
         init_ego_params=prev_ego_params,
         n_ego_train_seeds=1,
         partner_population=partner_population,
-        partner_params=train_partner_params
+        partner_params=train_partner_params,
     )
 
     updated_ego_parameters = ego_out["final_params"]
     # remove initial dimension of 1, to ensure that input and output carry have the same dimension
-    updated_ego_parameters = jax.tree.map(lambda x: x.squeeze(axis=0), updated_ego_parameters)
+    updated_ego_parameters = jax.tree.map(
+        lambda x: x.squeeze(axis=0), updated_ego_parameters
+    )
 
     carry = (updated_ego_parameters, rng)
     return carry, (train_out, ego_out)
+
 
 def train_minimax(rng, env, algorithm_config, partner_population, ego_config):
     rng, init_rng, train_rng = jax.random.split(rng, 3)
@@ -522,16 +693,19 @@ def train_minimax(rng, env, algorithm_config, partner_population, ego_config):
 
     @jax.jit
     def open_ended_step_fn(carry, unused):
-        return open_ended_training_step(carry, ego_policy, partner_population, algorithm_config, env)
+        return open_ended_training_step(
+            carry, ego_policy, partner_population, algorithm_config, env
+        )
 
     init_carry = (init_ego_params, train_rng)
-    final_carry, outs = jax.lax.scan(
+    _final_carry, outs = jax.lax.scan(
         open_ended_step_fn,
         init_carry,
         xs=None,
-        length=algorithm_config["NUM_OPEN_ENDED_ITERS"]
+        length=algorithm_config["NUM_OPEN_ENDED_ITERS"],
     )
     return outs
+
 
 def run_minimax(config, wandb_logger):
     algorithm_config = dict(config["algorithm"])
@@ -547,13 +721,12 @@ def run_minimax(config, wandb_logger):
     # Initialize partner policy once - reused for all iterations
     partner_policy = MLPActorCriticPolicy(
         action_dim=env.action_space(env.agents[1]).n,
-        obs_dim=env.observation_space(env.agents[1]).shape[0]
+        obs_dim=env.observation_space(env.agents[1]).shape[0],
     )
 
     # Create partner population
     partner_population = AgentPopulation(
-        pop_size=algorithm_config["PARTNER_POP_SIZE"],
-        policy_cls=partner_policy
+        pop_size=algorithm_config["PARTNER_POP_SIZE"], policy_cls=partner_policy
     )
 
     # initialize ego config
@@ -567,27 +740,38 @@ def run_minimax(config, wandb_logger):
 
     DEBUG = False
     with jax.disable_jit(DEBUG):
-        train_fn = jax.jit(jax.vmap(partial(train_minimax,
-                env=env, algorithm_config=algorithm_config,
-                partner_population=partner_population,
-                ego_config=ego_config
+        train_fn = jax.jit(
+            jax.vmap(
+                partial(
+                    train_minimax,
+                    env=env,
+                    algorithm_config=algorithm_config,
+                    partner_population=partner_population,
+                    ego_config=ego_config,
                 )
             )
         )
         outs = train_fn(rngs)
 
     end_time = time.time()
-    log.info(f"Open-ended minimax training completed in {end_time - start_time} seconds.")
+    log.info(
+        f"Open-ended minimax training completed in {end_time - start_time} seconds."
+    )
 
     # Prepare return values for heldout evaluation
-    _ , ego_outs = outs
-    ego_params = jax.tree.map(lambda x: x[:, :, 0], ego_outs["final_params"]) # shape (num_seeds, num_open_ended_iters, 1, num_ckpts, leaf_dim)
-    ego_policy, init_ego_params = initialize_s5_agent(algorithm_config, env, init_ego_rng)
+    _, ego_outs = outs
+    ego_params = jax.tree.map(
+        lambda x: x[:, :, 0], ego_outs["final_params"]
+    )  # shape (num_seeds, num_open_ended_iters, 1, num_ckpts, leaf_dim)
+    ego_policy, init_ego_params = initialize_s5_agent(
+        algorithm_config, env, init_ego_rng
+    )
 
     # Log metrics
     metric_names = get_metric_names(algorithm_config["ENV_NAME"])
     log_metrics(config, wandb_logger, outs, metric_names)
     return ego_policy, ego_params, init_ego_params
+
 
 def log_metrics(config, logger, outs, metric_names: tuple):
     """Process training metrics and log them using the provided logger.
@@ -599,10 +783,10 @@ def log_metrics(config, logger, outs, metric_names: tuple):
         metric_names: tuple, names of metrics to extract from training logs
     """
     teammate_outs, ego_outs = outs
-    teammate_metrics = teammate_outs["metrics"] # conf vs ego
+    teammate_metrics = teammate_outs["metrics"]  # conf vs ego
     ego_metrics = ego_outs["metrics"]
 
-    num_seeds = teammate_metrics["returned_episode_returns"].shape[0]
+    teammate_metrics["returned_episode_returns"].shape[0]
     num_open_ended_iters = ego_metrics["returned_episode_returns"].shape[1]
     num_partner_updates = teammate_metrics["returned_episode_returns"].shape[3]
     num_ego_updates = ego_metrics["returned_episode_returns"].shape[3]
@@ -625,20 +809,32 @@ def log_metrics(config, logger, outs, metric_names: tuple):
 
     # Process/extract minimax-specific losses
     # shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_updates, num_eval_episodes, num_agents_per_env)
-    avg_teammate_xp_returns = np.asarray(teammate_metrics["eval_ep_last_info_ego"]["returned_episode_returns"]).mean(axis=(0, 2, 4, 5))
+    avg_teammate_xp_returns = np.asarray(
+        teammate_metrics["eval_ep_last_info_ego"]["returned_episode_returns"]
+    ).mean(axis=(0, 2, 4, 5))
 
     # Conf vs ego losses
     #  shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_updates)
-    avg_value_losses_teammate_against_ego = np.asarray(teammate_metrics["value_loss_conf_against_ego"]).mean(axis=(0, 2))
-    avg_actor_losses_teammate_against_ego = np.asarray(teammate_metrics["pg_loss_conf_against_ego"]).mean(axis=(0, 2))
-    avg_entropy_losses_teammate_against_ego = np.asarray(teammate_metrics["entropy_conf_against_ego"]).mean(axis=(0, 2))
+    avg_value_losses_teammate_against_ego = np.asarray(
+        teammate_metrics["value_loss_conf_against_ego"]
+    ).mean(axis=(0, 2))
+    avg_actor_losses_teammate_against_ego = np.asarray(
+        teammate_metrics["pg_loss_conf_against_ego"]
+    ).mean(axis=(0, 2))
+    avg_entropy_losses_teammate_against_ego = np.asarray(
+        teammate_metrics["entropy_conf_against_ego"]
+    ).mean(axis=(0, 2))
 
     # shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_updates)
-    avg_rewards_teammate_against_ego = np.asarray(teammate_metrics["average_rewards_ego"]).mean(axis=(0, 2))
+    avg_rewards_teammate_against_ego = np.asarray(
+        teammate_metrics["average_rewards_ego"]
+    ).mean(axis=(0, 2))
 
     # Process ego-specific metrics
     # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_updates, num_partners, num_eval_episodes, num_agents_per_env)
-    avg_ego_returns = np.asarray(ego_metrics["eval_ep_last_info"]["returned_episode_returns"]).mean(axis=(0, 2, 4, 5, 6))
+    avg_ego_returns = np.asarray(
+        ego_metrics["eval_ep_last_info"]["returned_episode_returns"]
+    ).mean(axis=(0, 2, 4, 5, 6))
 
     # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_updates)
     avg_ego_value_losses = np.asarray(ego_metrics["value_loss"]).mean(axis=(0, 2))
@@ -652,40 +848,90 @@ def log_metrics(config, logger, outs, metric_names: tuple):
 
             # Log standard partner stats from get_stats
             for stat_name, stat_data in teammate_stat_means.items():
-                logger.log_item(f"Train/Conf-Against-Ego_{stat_name}", stat_data[iter_idx, step], train_step=global_step)
+                logger.log_item(
+                    f"Train/Conf-Against-Ego_{stat_name}",
+                    stat_data[iter_idx, step],
+                    train_step=global_step,
+                )
 
             # Minimax partner eval metrics
-            logger.log_item("Eval/ConfReturn-Against-Ego", avg_teammate_xp_returns[iter_idx][step], train_step=global_step)
+            logger.log_item(
+                "Eval/ConfReturn-Against-Ego",
+                avg_teammate_xp_returns[iter_idx][step],
+                train_step=global_step,
+            )
 
             # Confederate losses
-            logger.log_item("Losses/ConfValLoss-Against-Ego", avg_value_losses_teammate_against_ego[iter_idx][step], train_step=global_step)
-            logger.log_item("Losses/ConfActorLoss-Against-Ego", avg_actor_losses_teammate_against_ego[iter_idx][step], train_step=global_step)
-            logger.log_item("Losses/ConfEntropy-Against-Ego", avg_entropy_losses_teammate_against_ego[iter_idx][step], train_step=global_step)
+            logger.log_item(
+                "Losses/ConfValLoss-Against-Ego",
+                avg_value_losses_teammate_against_ego[iter_idx][step],
+                train_step=global_step,
+            )
+            logger.log_item(
+                "Losses/ConfActorLoss-Against-Ego",
+                avg_actor_losses_teammate_against_ego[iter_idx][step],
+                train_step=global_step,
+            )
+            logger.log_item(
+                "Losses/ConfEntropy-Against-Ego",
+                avg_entropy_losses_teammate_against_ego[iter_idx][step],
+                train_step=global_step,
+            )
 
             # Rewards
-            logger.log_item("Losses/AvgConfEgoRewards", avg_rewards_teammate_against_ego[iter_idx][step], train_step=global_step)
+            logger.log_item(
+                "Losses/AvgConfEgoRewards",
+                avg_rewards_teammate_against_ego[iter_idx][step],
+                train_step=global_step,
+            )
 
         ### Ego metrics processing
         for step in range(num_ego_updates):
             global_step = iter_idx * num_ego_updates + step
             # Standard ego stats from get_stats
             for stat_name, stat_data in ego_stat_means.items():
-                logger.log_item(f"Train/Ego_{stat_name}", stat_data[iter_idx, step], train_step=global_step)
+                logger.log_item(
+                    f"Train/Ego_{stat_name}",
+                    stat_data[iter_idx, step],
+                    train_step=global_step,
+                )
 
             # Ego eval metrics
-            logger.log_item("Eval/EgoReturn-Against-Conf", avg_ego_returns[iter_idx][step], train_step=global_step)
+            logger.log_item(
+                "Eval/EgoReturn-Against-Conf",
+                avg_ego_returns[iter_idx][step],
+                train_step=global_step,
+            )
             # Ego agent losses
-            logger.log_item("Losses/EgoValueLoss", avg_ego_value_losses[iter_idx][step], train_step=global_step)
-            logger.log_item("Losses/EgoActorLoss", avg_ego_actor_losses[iter_idx][step], train_step=global_step)
-            logger.log_item("Losses/EgoEntropyLoss", avg_ego_entropy_losses[iter_idx][step], train_step=global_step)
-            logger.log_item("Losses/EgoGradNorm", avg_ego_grad_norms[iter_idx][step], train_step=global_step)
+            logger.log_item(
+                "Losses/EgoValueLoss",
+                avg_ego_value_losses[iter_idx][step],
+                train_step=global_step,
+            )
+            logger.log_item(
+                "Losses/EgoActorLoss",
+                avg_ego_actor_losses[iter_idx][step],
+                train_step=global_step,
+            )
+            logger.log_item(
+                "Losses/EgoEntropyLoss",
+                avg_ego_entropy_losses[iter_idx][step],
+                train_step=global_step,
+            )
+            logger.log_item(
+                "Losses/EgoGradNorm",
+                avg_ego_grad_norms[iter_idx][step],
+                train_step=global_step,
+            )
     logger.commit()
 
     # Saving artifacts
     savedir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
     out_savepath = save_train_run(outs, savedir, savename="saved_train_run")
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="saved_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="saved_train_run", path=out_savepath, type_name="train_run"
+        )
 
     # Cleanup locally logged out file
     if not config["local_logger"]["save_train_out"]:

--- a/open_ended_training/paired.py
+++ b/open_ended_training/paired.py
@@ -181,7 +181,8 @@ def train_paired(config, env, partner_rng):
                     log_prob=logp_0,
                     obs=obs_0,
                     info=info_0,
-                    avail_actions=avail_actions_0
+                    avail_actions=avail_actions_0,
+                    prev_done=last_dones["agent_0"]
                 )
 
                 # Store agent_1 (ego) data in transition
@@ -193,7 +194,8 @@ def train_paired(config, env, partner_rng):
                     log_prob=logp_1,
                     obs=obs_1,
                     info=info_1,
-                    avail_actions=avail_actions_1
+                    avail_actions=avail_actions_1,
+                    prev_done=last_dones["agent_1"]
                 )
 
                 new_runner_state = (train_state_conf, train_state_ego, env_state_next, obs_next, done, new_conf_h, new_ego_h, rng)
@@ -266,7 +268,8 @@ def train_paired(config, env, partner_rng):
                     log_prob=logp_0,
                     obs=obs_0,
                     info=info_0,
-                    avail_actions=avail_actions_0
+                    avail_actions=avail_actions_0,
+                    prev_done=last_dones["agent_0"]
                 )
                 # Store agent_1 (best response) data in transition
                 transition_1 = Transition(
@@ -277,7 +280,8 @@ def train_paired(config, env, partner_rng):
                     log_prob=logp_1,
                     obs=obs_1,
                     info=info_1,
-                    avail_actions=avail_actions_1
+                    avail_actions=avail_actions_1,
+                    prev_done=last_dones["agent_1"]
                 )
                 new_runner_state = (train_state_conf, train_state_br, env_state_next, obs_next, done, new_conf_h, new_br_h, rng)
                 return new_runner_state, (transition_0, transition_1)
@@ -323,7 +327,7 @@ def train_paired(config, env, partner_rng):
                         _, (value_conf_ego, _), pi_conf_ego, _ = confederate_policy.get_action_value_policy(
                             params=params,
                             obs=traj_batch_conf_ego.obs,
-                            done=traj_batch_conf_ego.done,
+                            done=traj_batch_conf_ego.prev_done,
                             avail_actions=traj_batch_conf_ego.avail_actions,
                             hstate=init_hstate_conf_ego,
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
@@ -331,7 +335,7 @@ def train_paired(config, env, partner_rng):
                         _, (_, value_conf_br), pi_conf_br, _ = confederate_policy.get_action_value_policy(
                             params=params,
                             obs=traj_batch_conf_br.obs,
-                            done=traj_batch_conf_br.done,
+                            done=traj_batch_conf_br.prev_done,
                             avail_actions=traj_batch_conf_br.avail_actions,
                             hstate=init_hstate_conf_br,
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
@@ -404,7 +408,7 @@ def train_paired(config, env, partner_rng):
                         _, value, pi, _ = br_policy.get_action_value_policy(
                             params=params,
                             obs=traj_batch_br.obs,
-                            done=traj_batch_br.done,
+                            done=traj_batch_br.prev_done,
                             avail_actions=traj_batch_br.avail_actions,
                             hstate=init_hstate_br,
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
@@ -448,7 +452,7 @@ def train_paired(config, env, partner_rng):
                         _, value, pi, _ = ego_policy.get_action_value_policy(
                             params=params, # (64,)
                             obs=traj_batch_ego.obs, # (512, 15)
-                            done=traj_batch_ego.done, # (512,)
+                            done=traj_batch_ego.prev_done, # (512,)
                             avail_actions=traj_batch_ego.avail_actions, # (512, 6)
                             hstate=init_hstate_ego, # (1, 16, 8)
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here

--- a/open_ended_training/paired.py
+++ b/open_ended_training/paired.py
@@ -1,7 +1,8 @@
-'''Implemented to be as faithful to the original PAIRED as possible.'''
+"""Implemented to be as faithful to the original PAIRED as possible."""
+
+import logging
 import shutil
 import time
-import logging
 
 import hydra
 import jax
@@ -10,38 +11,54 @@ import numpy as np
 import optax
 from flax.training.train_state import TrainState
 
-from agents.mlp_actor_critic_agent import ActorWithDoubleCriticPolicy, MLPActorCriticPolicy
 from agents.initialize_agents import initialize_s5_agent
-from common.plot_utils import get_stats, get_metric_names
-from common.save_load_utils import save_train_run
+from agents.mlp_actor_critic_agent import (
+    ActorWithDoubleCriticPolicy,
+    MLPActorCriticPolicy,
+)
+from common.plot_utils import get_metric_names, get_stats
 from common.run_episodes import run_episodes
-from marl.ppo_utils import Transition, unbatchify, _create_minibatches
+from common.save_load_utils import save_train_run
 from envs import make_env
 from envs.log_wrapper import LogWrapper
+from marl.ppo_utils import Transition, _create_minibatches, unbatchify
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
 def train_paired(config, env, partner_rng):
-    '''
+    """
     Train regret-maximizing confederate/best-response pairs, and an ego agent.
     Return model checkpoints and metrics.
-    '''
+    """
+
     def make_train(config):
         num_agents = env.num_agents
-        assert num_agents == 2, "This code assumes the environment has exactly 2 agents."
+        assert num_agents == 2, (
+            "This code assumes the environment has exactly 2 agents."
+        )
 
         # Right now assume control of just 1 agent
         config["NUM_CONTROLLED_ACTORS"] = config["NUM_ENVS"]
         config["NUM_UNCONTROLLED_AGENTS"] = config["NUM_ENVS"]
 
-        config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // (config["ROLLOUT_LENGTH"] *3 * config["NUM_ENVS"])
-        assert config["NUM_CONTROLLED_ACTORS"] % config["NUM_MINIBATCHES"] == 0, "NUM_CONTROLLED_ACTORS must be divisible by NUM_MINIBATCHES"
-        assert config["NUM_CONTROLLED_ACTORS"] >= config["NUM_MINIBATCHES"], "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // (
+            config["ROLLOUT_LENGTH"] * 3 * config["NUM_ENVS"]
+        )
+        assert config["NUM_CONTROLLED_ACTORS"] % config["NUM_MINIBATCHES"] == 0, (
+            "NUM_CONTROLLED_ACTORS must be divisible by NUM_MINIBATCHES"
+        )
+        assert config["NUM_CONTROLLED_ACTORS"] >= config["NUM_MINIBATCHES"], (
+            "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        )
 
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng):
@@ -54,13 +71,13 @@ def train_paired(config, env, partner_rng):
             # Initialize confederate policy using ActorWithDoubleCriticPolicy
             confederate_policy = ActorWithDoubleCriticPolicy(
                 action_dim=env.action_space(env.agents[0]).n,
-                obs_dim=env.observation_space(env.agents[0]).shape[0]
+                obs_dim=env.observation_space(env.agents[0]).shape[0],
             )
 
             # Initialize best response policy using MLPActorCriticPolicy
             br_policy = MLPActorCriticPolicy(
                 action_dim=env.action_space(env.agents[1]).n,
-                obs_dim=env.observation_space(env.agents[1]).shape[0]
+                obs_dim=env.observation_space(env.agents[1]).shape[0],
             )
 
             # Initialize parameters using the policy interfaces
@@ -70,16 +87,30 @@ def train_paired(config, env, partner_rng):
             # Define optimizers for all three policies
             tx = optax.chain(
                 optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"],
-                eps=1e-5),
+                optax.adam(
+                    learning_rate=linear_schedule
+                    if config["ANNEAL_LR"]
+                    else config["LR"],
+                    eps=1e-5,
+                ),
             )
             tx_br = optax.chain(
                 optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"], eps=1e-5),
+                optax.adam(
+                    learning_rate=linear_schedule
+                    if config["ANNEAL_LR"]
+                    else config["LR"],
+                    eps=1e-5,
+                ),
             )
             tx_ego = optax.chain(
                 optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"], eps=1e-5),
+                optax.adam(
+                    learning_rate=linear_schedule
+                    if config["ANNEAL_LR"]
+                    else config["LR"],
+                    eps=1e-5,
+                ),
             )
 
             train_state_conf = TrainState.create(
@@ -109,6 +140,7 @@ def train_paired(config, env, partner_rng):
 
             obsv_ego, env_state_ego = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_ego)
             obsv_br, env_state_br = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_br)
+
             # --------------------------
             # 3c) Define env step
             # --------------------------
@@ -117,7 +149,16 @@ def train_paired(config, env, partner_rng):
                 agent_0 = confederate, agent_1 = ego
                 Returns updated runner_state, and two Transitions: one for agent_0 (confederate) and one for agent_1 (ego).
                 """
-                train_state_conf, train_state_ego, env_state, last_obs, last_dones, last_conf_h, last_ego_h, rng = runner_state
+                (
+                    train_state_conf,
+                    train_state_ego,
+                    env_state,
+                    last_obs,
+                    last_dones,
+                    last_conf_h,
+                    last_ego_h,
+                    rng,
+                ) = runner_state
                 rng, act_rng, ego_rng, step_rng = jax.random.split(rng, 4)
 
                 obs_0 = last_obs["agent_0"]
@@ -129,13 +170,17 @@ def train_paired(config, env, partner_rng):
                 avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
                 # Agent_0 (confederate) action using policy interface
-                act_0, (val_0, _), pi_0, new_conf_h = confederate_policy.get_action_value_policy(
-                    params=train_state_conf.params,
-                    obs=obs_0.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),  # confederate has same done status
-                    avail_actions=jax.lax.stop_gradient(avail_actions_0),
-                    hstate=last_conf_h,
-                    rng=act_rng
+                act_0, (val_0, _), pi_0, new_conf_h = (
+                    confederate_policy.get_action_value_policy(
+                        params=train_state_conf.params,
+                        obs=obs_0.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
+                        done=last_dones["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"]
+                        ),  # confederate has same done status
+                        avail_actions=jax.lax.stop_gradient(avail_actions_0),
+                        hstate=last_conf_h,
+                        rng=act_rng,
+                    )
                 )
                 logp_0 = pi_0.log_prob(act_0)
 
@@ -147,10 +192,12 @@ def train_paired(config, env, partner_rng):
                 act_1, val_1, pi_1, new_ego_h = ego_policy.get_action_value_policy(
                     params=train_state_ego.params,
                     obs=obs_1.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones["agent_1"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
+                    done=last_dones["agent_1"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"]
+                    ),
                     avail_actions=jax.lax.stop_gradient(avail_actions_1),
                     hstate=last_ego_h,
-                    rng=ego_rng
+                    rng=ego_rng,
                 )
                 logp_1 = pi_1.log_prob(act_1)
 
@@ -159,15 +206,19 @@ def train_paired(config, env, partner_rng):
                 val_1 = val_1.squeeze()
 
                 # Combine actions into the env format
-                combined_actions = jnp.concatenate([act_0, act_1], axis=0)  # shape (2*num_envs,)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                combined_actions = jnp.concatenate(
+                    [act_0, act_1], axis=0
+                )  # shape (2*num_envs,)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
 
                 # Step env
                 step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state, env_act
-                )
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 # note that num_actors = num_envs * num_agents
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
                 info_1 = jax.tree.map(lambda x: x[:, 1], info)
@@ -182,7 +233,7 @@ def train_paired(config, env, partner_rng):
                     obs=obs_0,
                     info=info_0,
                     avail_actions=avail_actions_0,
-                    prev_done=last_dones["agent_0"]
+                    prev_done=last_dones["agent_0"],
                 )
 
                 # Store agent_1 (ego) data in transition
@@ -195,10 +246,19 @@ def train_paired(config, env, partner_rng):
                     obs=obs_1,
                     info=info_1,
                     avail_actions=avail_actions_1,
-                    prev_done=last_dones["agent_1"]
+                    prev_done=last_dones["agent_1"],
                 )
 
-                new_runner_state = (train_state_conf, train_state_ego, env_state_next, obs_next, done, new_conf_h, new_ego_h, rng)
+                new_runner_state = (
+                    train_state_conf,
+                    train_state_ego,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_conf_h,
+                    new_ego_h,
+                    rng,
+                )
                 return new_runner_state, (transition_0, transition_1)
 
             def _env_step_br(runner_state, unused):
@@ -206,7 +266,16 @@ def train_paired(config, env, partner_rng):
                 agent_0 = confederate, agent_1 = best response
                 Returns updated runner_state, and two Transitions: one for agent_0 (confederate) and one for agent_1 (best response).
                 """
-                train_state_conf, train_state_br, env_state, last_obs, last_dones, last_conf_h, last_br_h, rng = runner_state
+                (
+                    train_state_conf,
+                    train_state_br,
+                    env_state,
+                    last_obs,
+                    last_dones,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
+                ) = runner_state
                 rng, conf_rng, br_rng, step_rng = jax.random.split(rng, 4)
 
                 obs_0 = last_obs["agent_0"]
@@ -218,13 +287,17 @@ def train_paired(config, env, partner_rng):
                 avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
                 # Agent_0 (confederate) action
-                act_0, (_, val_0), pi_0, new_conf_h = confederate_policy.get_action_value_policy(
-                    params=train_state_conf.params,
-                    obs=obs_0.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),  # Get done flag with right shape
-                    avail_actions=jax.lax.stop_gradient(avail_actions_0),
-                    hstate=last_conf_h,
-                    rng=conf_rng
+                act_0, (_, val_0), pi_0, new_conf_h = (
+                    confederate_policy.get_action_value_policy(
+                        params=train_state_conf.params,
+                        obs=obs_0.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
+                        done=last_dones["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"]
+                        ),  # Get done flag with right shape
+                        avail_actions=jax.lax.stop_gradient(avail_actions_0),
+                        hstate=last_conf_h,
+                        rng=conf_rng,
+                    )
                 )
                 logp_0 = pi_0.log_prob(act_0)
 
@@ -236,10 +309,12 @@ def train_paired(config, env, partner_rng):
                 act_1, val_1, pi_1, new_br_h = br_policy.get_action_value_policy(
                     params=train_state_br.params,
                     obs=obs_1.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones["agent_1"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),  # Get done flag with right shape
+                    done=last_dones["agent_1"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"]
+                    ),  # Get done flag with right shape
                     avail_actions=jax.lax.stop_gradient(avail_actions_1),
                     hstate=last_br_h,
-                    rng=br_rng
+                    rng=br_rng,
                 )
                 logp_1 = pi_1.log_prob(act_1)
 
@@ -247,15 +322,19 @@ def train_paired(config, env, partner_rng):
                 logp_1 = logp_1.squeeze()
                 val_1 = val_1.squeeze()
                 # Combine actions into the env format
-                combined_actions = jnp.concatenate([act_0, act_1], axis=0)  # shape (2*num_envs,)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                combined_actions = jnp.concatenate(
+                    [act_0, act_1], axis=0
+                )  # shape (2*num_envs,)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
 
                 # Step env
                 step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state, env_act
-                )
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
                 info_1 = jax.tree.map(lambda x: x[:, 1], info)
 
@@ -269,7 +348,7 @@ def train_paired(config, env, partner_rng):
                     obs=obs_0,
                     info=info_0,
                     avail_actions=avail_actions_0,
-                    prev_done=last_dones["agent_0"]
+                    prev_done=last_dones["agent_0"],
                 )
                 # Store agent_1 (best response) data in transition
                 transition_1 = Transition(
@@ -281,9 +360,18 @@ def train_paired(config, env, partner_rng):
                     obs=obs_1,
                     info=info_1,
                     avail_actions=avail_actions_1,
-                    prev_done=last_dones["agent_1"]
+                    prev_done=last_dones["agent_1"],
                 )
-                new_runner_state = (train_state_conf, train_state_br, env_state_next, obs_next, done, new_conf_h, new_br_h, rng)
+                new_runner_state = (
+                    train_state_conf,
+                    train_state_br,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_conf_h,
+                    new_br_h,
+                    rng,
+                )
                 return new_runner_state, (transition_0, transition_1)
 
             # --------------------------
@@ -316,71 +404,131 @@ def train_paired(config, env, partner_rng):
             def _update_epoch(update_state, unused):
                 def _update_minbatch_conf(train_state_conf, batch_infos):
                     minbatch_conf_ego, minbatch_conf_br = batch_infos
-                    init_hstate_conf_ego, traj_batch_conf_ego, advantages_conf_ego, returns_conf_ego = minbatch_conf_ego
-                    init_hstate_conf_br, traj_batch_conf_br, advantages_conf_br, returns_conf_br = minbatch_conf_br
+                    (
+                        init_hstate_conf_ego,
+                        traj_batch_conf_ego,
+                        advantages_conf_ego,
+                        returns_conf_ego,
+                    ) = minbatch_conf_ego
+                    (
+                        init_hstate_conf_br,
+                        traj_batch_conf_br,
+                        advantages_conf_br,
+                        returns_conf_br,
+                    ) = minbatch_conf_br
 
-                    def _loss_fn_conf(params,
-                        init_hstate_conf_ego, traj_batch_conf_ego, gae_conf_ego, target_v_conf_ego,
-                        init_hstate_conf_br, traj_batch_conf_br, gae_conf_br, target_v_conf_br):
+                    def _loss_fn_conf(
+                        params,
+                        init_hstate_conf_ego,
+                        traj_batch_conf_ego,
+                        gae_conf_ego,
+                        target_v_conf_ego,
+                        init_hstate_conf_br,
+                        traj_batch_conf_br,
+                        gae_conf_br,
+                        target_v_conf_br,
+                    ):
                         # get policy and value of confederate versus ego and best response agents respectively
 
-                        _, (value_conf_ego, _), pi_conf_ego, _ = confederate_policy.get_action_value_policy(
-                            params=params,
-                            obs=traj_batch_conf_ego.obs,
-                            done=traj_batch_conf_ego.prev_done,
-                            avail_actions=traj_batch_conf_ego.avail_actions,
-                            hstate=init_hstate_conf_ego,
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
+                        _, (value_conf_ego, _), pi_conf_ego, _ = (
+                            confederate_policy.get_action_value_policy(
+                                params=params,
+                                obs=traj_batch_conf_ego.obs,
+                                done=traj_batch_conf_ego.prev_done,
+                                avail_actions=traj_batch_conf_ego.avail_actions,
+                                hstate=init_hstate_conf_ego,
+                                rng=jax.random.PRNGKey(
+                                    0
+                                ),  # only used for action sampling, which is not used here
+                            )
                         )
-                        _, (_, value_conf_br), pi_conf_br, _ = confederate_policy.get_action_value_policy(
-                            params=params,
-                            obs=traj_batch_conf_br.obs,
-                            done=traj_batch_conf_br.prev_done,
-                            avail_actions=traj_batch_conf_br.avail_actions,
-                            hstate=init_hstate_conf_br,
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
+                        _, (_, value_conf_br), pi_conf_br, _ = (
+                            confederate_policy.get_action_value_policy(
+                                params=params,
+                                obs=traj_batch_conf_br.obs,
+                                done=traj_batch_conf_br.prev_done,
+                                avail_actions=traj_batch_conf_br.avail_actions,
+                                hstate=init_hstate_conf_br,
+                                rng=jax.random.PRNGKey(
+                                    0
+                                ),  # only used for action sampling, which is not used here
+                            )
                         )
 
-                        log_prob_conf_ego = pi_conf_ego.log_prob(traj_batch_conf_ego.action)
-                        log_prob_conf_br = pi_conf_br.log_prob(traj_batch_conf_br.action)
+                        log_prob_conf_ego = pi_conf_ego.log_prob(
+                            traj_batch_conf_ego.action
+                        )
+                        log_prob_conf_br = pi_conf_br.log_prob(
+                            traj_batch_conf_br.action
+                        )
 
                         # Value loss for interaction with ego agent
                         value_pred_conf_ego_clipped = traj_batch_conf_ego.value + (
                             value_conf_ego - traj_batch_conf_ego.value
-                            ).clip(
-                            -config["CLIP_EPS"], config["CLIP_EPS"])
-                        value_losses_conf_ego = jnp.square(value_conf_ego - target_v_conf_ego)
-                        value_losses_clipped_conf_ego = jnp.square(value_pred_conf_ego_clipped - target_v_conf_ego)
-                        value_loss_conf_ego = jnp.maximum(value_losses_conf_ego, value_losses_clipped_conf_ego).mean()
+                        ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
+                        value_losses_conf_ego = jnp.square(
+                            value_conf_ego - target_v_conf_ego
+                        )
+                        value_losses_clipped_conf_ego = jnp.square(
+                            value_pred_conf_ego_clipped - target_v_conf_ego
+                        )
+                        value_loss_conf_ego = jnp.maximum(
+                            value_losses_conf_ego, value_losses_clipped_conf_ego
+                        ).mean()
 
                         # Value loss for interaction with best response agent
                         value_pred_conf_br_clipped = traj_batch_conf_br.value + (
                             value_conf_br - traj_batch_conf_br.value
-                            ).clip(
-                            -config["CLIP_EPS"], config["CLIP_EPS"])
-                        value_losses_conf_br = jnp.square(value_conf_br - target_v_conf_br)
-                        value_losses_clipped_conf_br = jnp.square(value_pred_conf_br_clipped - target_v_conf_br)
-                        value_loss_conf_br = jnp.maximum(value_losses_conf_br, value_losses_clipped_conf_br).mean()
+                        ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
+                        value_losses_conf_br = jnp.square(
+                            value_conf_br - target_v_conf_br
+                        )
+                        value_losses_clipped_conf_br = jnp.square(
+                            value_pred_conf_br_clipped - target_v_conf_br
+                        )
+                        value_loss_conf_br = jnp.maximum(
+                            value_losses_conf_br, value_losses_clipped_conf_br
+                        ).mean()
 
                         # Policy gradient loss for interaction with ego agent
-                        ratio_conf_ego = jnp.exp(log_prob_conf_ego - traj_batch_conf_ego.log_prob)
-                        gae_norm_conf_ego = (gae_conf_ego - gae_conf_ego.mean()) / (gae_conf_ego.std() + 1e-8)
+                        ratio_conf_ego = jnp.exp(
+                            log_prob_conf_ego - traj_batch_conf_ego.log_prob
+                        )
+                        gae_norm_conf_ego = (gae_conf_ego - gae_conf_ego.mean()) / (
+                            gae_conf_ego.std() + 1e-8
+                        )
                         pg_loss_1_conf_ego = ratio_conf_ego * gae_norm_conf_ego
-                        pg_loss_2_conf_ego = jnp.clip(
-                            ratio_conf_ego,
-                            1.0 - config["CLIP_EPS"],
-                            1.0 + config["CLIP_EPS"]) * gae_norm_conf_ego
-                        pg_loss_conf_ego = -jnp.mean(jnp.minimum(pg_loss_1_conf_ego, pg_loss_2_conf_ego))
+                        pg_loss_2_conf_ego = (
+                            jnp.clip(
+                                ratio_conf_ego,
+                                1.0 - config["CLIP_EPS"],
+                                1.0 + config["CLIP_EPS"],
+                            )
+                            * gae_norm_conf_ego
+                        )
+                        pg_loss_conf_ego = -jnp.mean(
+                            jnp.minimum(pg_loss_1_conf_ego, pg_loss_2_conf_ego)
+                        )
 
                         # Policy gradient loss for interaction with best response agent
-                        ratio_conf_br = jnp.exp(log_prob_conf_br - traj_batch_conf_br.log_prob)
-                        gae_norm_conf_br = (gae_conf_br - gae_conf_br.mean()) / (gae_conf_br.std() + 1e-8)
+                        ratio_conf_br = jnp.exp(
+                            log_prob_conf_br - traj_batch_conf_br.log_prob
+                        )
+                        gae_norm_conf_br = (gae_conf_br - gae_conf_br.mean()) / (
+                            gae_conf_br.std() + 1e-8
+                        )
                         pg_loss_1_conf_br = ratio_conf_br * gae_norm_conf_br
-                        pg_loss_2_conf_br = jnp.clip(
-                            ratio_conf_br,
-                            1.0 - config["CLIP_EPS"],
-                            1.0 + config["CLIP_EPS"]) * gae_norm_conf_br
-                        pg_loss_conf_br = -jnp.mean(jnp.minimum(pg_loss_1_conf_br, pg_loss_2_conf_br))
+                        pg_loss_2_conf_br = (
+                            jnp.clip(
+                                ratio_conf_br,
+                                1.0 - config["CLIP_EPS"],
+                                1.0 + config["CLIP_EPS"],
+                            )
+                            * gae_norm_conf_br
+                        )
+                        pg_loss_conf_br = -jnp.mean(
+                            jnp.minimum(pg_loss_1_conf_br, pg_loss_2_conf_br)
+                        )
 
                         # Entropy for interaction with ego agent
                         entropy_conf_ego = jnp.mean(pi_conf_ego.entropy())
@@ -389,144 +537,248 @@ def train_paired(config, env, partner_rng):
                         entropy_conf_br = jnp.mean(pi_conf_br.entropy())
 
                         # We negate the pg_loss_conf_ego to minimize the ego agent's objective
-                        conf_ego_loss = - pg_loss_conf_ego + config["VF_COEF"] * value_loss_conf_ego - config["ENT_COEF"] * entropy_conf_ego
-                        conf_br_loss = pg_loss_conf_br + config["VF_COEF"] * value_loss_conf_br - config["ENT_COEF"] * entropy_conf_br
+                        conf_ego_loss = (
+                            -pg_loss_conf_ego
+                            + config["VF_COEF"] * value_loss_conf_ego
+                            - config["ENT_COEF"] * entropy_conf_ego
+                        )
+                        conf_br_loss = (
+                            pg_loss_conf_br
+                            + config["VF_COEF"] * value_loss_conf_br
+                            - config["ENT_COEF"] * entropy_conf_br
+                        )
                         total_loss = conf_ego_loss + conf_br_loss
-                        return total_loss, (value_loss_conf_ego, value_loss_conf_br, pg_loss_conf_ego, pg_loss_conf_br, entropy_conf_ego, entropy_conf_br)
+                        return total_loss, (
+                            value_loss_conf_ego,
+                            value_loss_conf_br,
+                            pg_loss_conf_ego,
+                            pg_loss_conf_br,
+                            entropy_conf_ego,
+                            entropy_conf_br,
+                        )
 
                     grad_fn = jax.value_and_grad(_loss_fn_conf, has_aux=True)
                     (loss_val, aux_vals), grads = grad_fn(
                         train_state_conf.params,
-                        init_hstate_conf_ego, traj_batch_conf_ego, advantages_conf_ego, returns_conf_ego,
-                        init_hstate_conf_br, traj_batch_conf_br, advantages_conf_br, returns_conf_br)
+                        init_hstate_conf_ego,
+                        traj_batch_conf_ego,
+                        advantages_conf_ego,
+                        returns_conf_ego,
+                        init_hstate_conf_br,
+                        traj_batch_conf_br,
+                        advantages_conf_br,
+                        returns_conf_br,
+                    )
                     train_state_conf = train_state_conf.apply_gradients(grads=grads)
                     return train_state_conf, (loss_val, aux_vals)
 
                 def _update_minbatch_br(train_state_br, batch_info):
                     init_hstate_br, traj_batch_br, advantages, returns = batch_info
-                    def _loss_fn_br(params, init_hstate_br, traj_batch_br, gae, target_v):
+
+                    def _loss_fn_br(
+                        params, init_hstate_br, traj_batch_br, gae, target_v
+                    ):
                         _, value, pi, _ = br_policy.get_action_value_policy(
                             params=params,
                             obs=traj_batch_br.obs,
                             done=traj_batch_br.prev_done,
                             avail_actions=traj_batch_br.avail_actions,
                             hstate=init_hstate_br,
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
+                            rng=jax.random.PRNGKey(
+                                0
+                            ),  # only used for action sampling, which is not used here
                         )
                         log_prob = pi.log_prob(traj_batch_br.action)
 
                         # Value loss
                         value_pred_clipped = traj_batch_br.value + (
                             value - traj_batch_br.value
-                            ).clip(
-                            -config["CLIP_EPS"], config["CLIP_EPS"])
+                        ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                         value_losses = jnp.square(value - target_v)
                         value_losses_clipped = jnp.square(value_pred_clipped - target_v)
-                        value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
+                        value_loss = jnp.maximum(
+                            value_losses, value_losses_clipped
+                        ).mean()
 
                         # Policy gradient loss
                         ratio = jnp.exp(log_prob - traj_batch_br.log_prob)
                         gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                         pg_loss_1 = ratio * gae_norm
-                        pg_loss_2 = jnp.clip(
-                            ratio,
-                            1.0 - config["CLIP_EPS"],
-                            1.0 + config["CLIP_EPS"]) * gae_norm
+                        pg_loss_2 = (
+                            jnp.clip(
+                                ratio,
+                                1.0 - config["CLIP_EPS"],
+                                1.0 + config["CLIP_EPS"],
+                            )
+                            * gae_norm
+                        )
                         pg_loss = -jnp.mean(jnp.minimum(pg_loss_1, pg_loss_2))
 
                         # Entropy
                         entropy = jnp.mean(pi.entropy())
 
-                        total_loss = pg_loss + config["VF_COEF"] * value_loss - config["ENT_COEF"] * entropy
+                        total_loss = (
+                            pg_loss
+                            + config["VF_COEF"] * value_loss
+                            - config["ENT_COEF"] * entropy
+                        )
                         return total_loss, (value_loss, pg_loss, entropy)
 
                     grad_fn = jax.value_and_grad(_loss_fn_br, has_aux=True)
                     (loss_val, aux_vals), grads = grad_fn(
-                        train_state_br.params, init_hstate_br, traj_batch_br, advantages, returns)
+                        train_state_br.params,
+                        init_hstate_br,
+                        traj_batch_br,
+                        advantages,
+                        returns,
+                    )
                     train_state_br = train_state_br.apply_gradients(grads=grads)
                     return train_state_br, (loss_val, aux_vals)
 
                 def _update_minbatch_ego(train_state_ego, batch_info):
                     init_hstate_ego, traj_batch_ego, advantages, returns = batch_info
-                    def _loss_fn_ego(params, init_hstate_ego, traj_batch_ego, gae, target_v):
+
+                    def _loss_fn_ego(
+                        params, init_hstate_ego, traj_batch_ego, gae, target_v
+                    ):
                         _, value, pi, _ = ego_policy.get_action_value_policy(
-                            params=params, # (64,)
-                            obs=traj_batch_ego.obs, # (512, 15)
-                            done=traj_batch_ego.prev_done, # (512,)
-                            avail_actions=traj_batch_ego.avail_actions, # (512, 6)
-                            hstate=init_hstate_ego, # (1, 16, 8)
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
+                            params=params,  # (64,)
+                            obs=traj_batch_ego.obs,  # (512, 15)
+                            done=traj_batch_ego.prev_done,  # (512,)
+                            avail_actions=traj_batch_ego.avail_actions,  # (512, 6)
+                            hstate=init_hstate_ego,  # (1, 16, 8)
+                            rng=jax.random.PRNGKey(
+                                0
+                            ),  # only used for action sampling, which is not used here
                         )
                         log_prob = pi.log_prob(traj_batch_ego.action)
 
                         # Value loss
                         value_pred_clipped = traj_batch_ego.value + (
                             value - traj_batch_ego.value
-                            ).clip(
-                            -config["CLIP_EPS"], config["CLIP_EPS"])
+                        ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                         value_losses = jnp.square(value - target_v)
                         value_losses_clipped = jnp.square(value_pred_clipped - target_v)
-                        value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
+                        value_loss = jnp.maximum(
+                            value_losses, value_losses_clipped
+                        ).mean()
 
                         # Policy gradient loss
                         ratio = jnp.exp(log_prob - traj_batch_ego.log_prob)
                         gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                         pg_loss_1 = ratio * gae_norm
-                        pg_loss_2 = jnp.clip(
-                            ratio,
-                            1.0 - config["CLIP_EPS"],
-                            1.0 + config["CLIP_EPS"]) * gae_norm
+                        pg_loss_2 = (
+                            jnp.clip(
+                                ratio,
+                                1.0 - config["CLIP_EPS"],
+                                1.0 + config["CLIP_EPS"],
+                            )
+                            * gae_norm
+                        )
                         pg_loss = -jnp.mean(jnp.minimum(pg_loss_1, pg_loss_2))
 
                         # Entropy
                         entropy = jnp.mean(pi.entropy())
 
-                        total_loss = pg_loss + config["VF_COEF"] * value_loss - config["ENT_COEF"] * entropy
+                        total_loss = (
+                            pg_loss
+                            + config["VF_COEF"] * value_loss
+                            - config["ENT_COEF"] * entropy
+                        )
                         return total_loss, (value_loss, pg_loss, entropy)
 
                     grad_fn = jax.value_and_grad(_loss_fn_ego, has_aux=True)
                     (loss_val, aux_vals), grads = grad_fn(
-                        train_state_ego.params, init_hstate_ego, traj_batch_ego, advantages, returns)
+                        train_state_ego.params,
+                        init_hstate_ego,
+                        traj_batch_ego,
+                        advantages,
+                        returns,
+                    )
                     train_state_ego = train_state_ego.apply_gradients(grads=grads)
                     return train_state_ego, (loss_val, aux_vals)
 
                 (
-                    train_state_conf, train_state_br, train_state_ego,
-                    traj_batch_conf_ego, traj_batch_ego, traj_batch_conf_br, traj_batch_br,
-                    advantages_conf, advantages_ego, advantages_conf_br, advantages_br,
-                    targets_conf, targets_ego, targets_conf_br, targets_br,
-                    rng_ego, rng_br
+                    train_state_conf,
+                    train_state_br,
+                    train_state_ego,
+                    traj_batch_conf_ego,
+                    traj_batch_ego,
+                    traj_batch_conf_br,
+                    traj_batch_br,
+                    advantages_conf,
+                    advantages_ego,
+                    advantages_conf_br,
+                    advantages_br,
+                    targets_conf,
+                    targets_ego,
+                    targets_conf_br,
+                    targets_br,
+                    rng_ego,
+                    rng_br,
                 ) = update_state
 
-                init_hstate_ego = ego_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
+                init_hstate_ego = ego_policy.init_hstate(
+                    config["NUM_CONTROLLED_ACTORS"]
+                )
                 init_hstate_br = br_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
-                init_hstate_conf = confederate_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
+                init_hstate_conf = confederate_policy.init_hstate(
+                    config["NUM_CONTROLLED_ACTORS"]
+                )
 
-                rng_ego, perm_rng_conf_ego, perm_rng_ego, perm_rng_conf_br, perm_rng_br = jax.random.split(rng_ego, 5)
+                (
+                    rng_ego,
+                    perm_rng_conf_ego,
+                    perm_rng_ego,
+                    perm_rng_conf_br,
+                    perm_rng_br,
+                ) = jax.random.split(rng_ego, 5)
                 # Create minibatches for each agent and interaction type
                 minibatches_conf_ego = _create_minibatches(
-                    traj_batch_conf_ego, advantages_conf, targets_conf, init_hstate_conf,
-                    config["NUM_CONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_conf_ego
+                    traj_batch_conf_ego,
+                    advantages_conf,
+                    targets_conf,
+                    init_hstate_conf,
+                    config["NUM_CONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_conf_ego,
                 )
 
                 minibatches_ego = _create_minibatches(
-                    traj_batch_ego, advantages_ego, targets_ego, init_hstate_ego,
-                    config["NUM_CONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_ego
+                    traj_batch_ego,
+                    advantages_ego,
+                    targets_ego,
+                    init_hstate_ego,
+                    config["NUM_CONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_ego,
                 )
 
                 minibatches_conf_br = _create_minibatches(
-                    traj_batch_conf_br, advantages_conf_br, targets_conf_br, init_hstate_conf,
-                    config["NUM_CONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_conf_br
+                    traj_batch_conf_br,
+                    advantages_conf_br,
+                    targets_conf_br,
+                    init_hstate_conf,
+                    config["NUM_CONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_conf_br,
                 )
 
                 minibatches_br = _create_minibatches(
-                    traj_batch_br, advantages_br, targets_br, init_hstate_br,
-                    config["NUM_CONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_br
+                    traj_batch_br,
+                    advantages_br,
+                    targets_br,
+                    init_hstate_br,
+                    config["NUM_CONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_br,
                 )
 
                 # Update confederate based on interaction with ego and br
                 train_state_conf, all_losses_conf = jax.lax.scan(
-                    _update_minbatch_conf, train_state_conf, (minibatches_conf_ego, minibatches_conf_br)
+                    _update_minbatch_conf,
+                    train_state_conf,
+                    (minibatches_conf_ego, minibatches_conf_br),
                 )
 
                 # Update best response
@@ -540,11 +792,23 @@ def train_paired(config, env, partner_rng):
                 )
 
                 update_state = (
-                    train_state_conf, train_state_br, train_state_ego,
-                    traj_batch_conf_ego, traj_batch_ego, traj_batch_conf_br, traj_batch_br,
-                    advantages_conf, advantages_ego, advantages_conf_br, advantages_br,
-                    targets_conf, targets_ego, targets_conf_br, targets_br,
-                    rng_ego, rng_br
+                    train_state_conf,
+                    train_state_br,
+                    train_state_ego,
+                    traj_batch_conf_ego,
+                    traj_batch_ego,
+                    traj_batch_conf_br,
+                    traj_batch_br,
+                    advantages_conf,
+                    advantages_ego,
+                    advantages_conf_br,
+                    advantages_br,
+                    targets_conf,
+                    targets_ego,
+                    targets_conf_br,
+                    targets_br,
+                    rng_ego,
+                    rng_br,
                 )
                 return update_state, (all_losses_conf, all_losses_br, all_losses_ego)
 
@@ -556,106 +820,202 @@ def train_paired(config, env, partner_rng):
                 4. PPO updates for best response and confederate policies.
                 """
                 (
-                    train_state_conf, train_state_br, train_state_ego,
-                    env_state_ego, env_state_br,
-                    last_obs_ego, last_obs_br,
-                    last_dones_ego, last_dones_br,
-                    conf_hstate_ego, ego_hstate,
-                    conf_hstate_br, br_hstate,
-                    rng_ego, rng_br, update_steps
+                    train_state_conf,
+                    train_state_br,
+                    train_state_ego,
+                    env_state_ego,
+                    env_state_br,
+                    last_obs_ego,
+                    last_obs_br,
+                    last_dones_ego,
+                    last_dones_br,
+                    conf_hstate_ego,
+                    ego_hstate,
+                    conf_hstate_br,
+                    br_hstate,
+                    rng_ego,
+                    rng_br,
+                    update_steps,
                 ) = update_runner_state
 
                 # 1) rollout for interactions of confederate against ego agent
-                runner_state_ego = (train_state_conf, train_state_ego, env_state_ego, last_obs_ego, last_dones_ego,
-                                    conf_hstate_ego, ego_hstate, rng_ego)
+                runner_state_ego = (
+                    train_state_conf,
+                    train_state_ego,
+                    env_state_ego,
+                    last_obs_ego,
+                    last_dones_ego,
+                    conf_hstate_ego,
+                    ego_hstate,
+                    rng_ego,
+                )
                 runner_state_ego, (traj_batch_conf_ego, traj_batch_ego) = jax.lax.scan(
-                    _env_step_ego, runner_state_ego, None, config["ROLLOUT_LENGTH"])
-                (train_state_conf, train_state_ego, env_state_ego, last_obs_ego, last_dones_ego,
-                 conf_hstate_ego, ego_hstate, rng_ego) = runner_state_ego
+                    _env_step_ego, runner_state_ego, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    train_state_conf,
+                    train_state_ego,
+                    env_state_ego,
+                    last_obs_ego,
+                    last_dones_ego,
+                    conf_hstate_ego,
+                    ego_hstate,
+                    rng_ego,
+                ) = runner_state_ego
 
                 # 2) rollout for interactions of confederate against br agent
-                runner_state_br = (train_state_conf, train_state_br, env_state_br, last_obs_br,
-                                   last_dones_br, conf_hstate_br, br_hstate, rng_br)
+                runner_state_br = (
+                    train_state_conf,
+                    train_state_br,
+                    env_state_br,
+                    last_obs_br,
+                    last_dones_br,
+                    conf_hstate_br,
+                    br_hstate,
+                    rng_br,
+                )
                 runner_state_br, (traj_batch_conf_br, traj_batch_br) = jax.lax.scan(
-                    _env_step_br, runner_state_br, None, config["ROLLOUT_LENGTH"])
-                (train_state_conf, train_state_br, env_state_br, last_obs_br, last_dones_br,
-                conf_hstate_br, br_hstate, rng_br) = runner_state_br
+                    _env_step_br, runner_state_br, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    train_state_conf,
+                    train_state_br,
+                    env_state_br,
+                    last_obs_br,
+                    last_dones_br,
+                    conf_hstate_br,
+                    br_hstate,
+                    rng_br,
+                ) = runner_state_br
 
                 # 3a) compute advantage for confederate agent from interaction with ego agent
 
                 # Get available actions for agent 0 from environment state
-                avail_actions_0_ego = jax.vmap(env.get_avail_actions)(env_state_ego.env_state)["agent_0"].astype(jnp.float32)
+                avail_actions_0_ego = jax.vmap(env.get_avail_actions)(
+                    env_state_ego.env_state
+                )["agent_0"].astype(jnp.float32)
 
                 # Get last value for confederate
-                _, (last_val_0_conf_ego, _), _, _ = confederate_policy.get_action_value_policy(
-                    params=train_state_conf.params,
-                    obs=last_obs_ego["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones_ego["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
-                    avail_actions=jax.lax.stop_gradient(avail_actions_0_ego),
-                    hstate=conf_hstate_ego,
-                    rng=jax.random.PRNGKey(0)  # dummy key as we don't sample actions
+                _, (last_val_0_conf_ego, _), _, _ = (
+                    confederate_policy.get_action_value_policy(
+                        params=train_state_conf.params,
+                        obs=last_obs_ego["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"], -1
+                        ),
+                        done=last_dones_ego["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"]
+                        ),
+                        avail_actions=jax.lax.stop_gradient(avail_actions_0_ego),
+                        hstate=conf_hstate_ego,
+                        rng=jax.random.PRNGKey(
+                            0
+                        ),  # dummy key as we don't sample actions
+                    )
                 )
                 last_val_0_conf_ego = last_val_0_conf_ego.squeeze()
-                advantages_conf, targets_conf = _calculate_gae(traj_batch_conf_ego, last_val_0_conf_ego)
+                advantages_conf, targets_conf = _calculate_gae(
+                    traj_batch_conf_ego, last_val_0_conf_ego
+                )
 
                 # 3b) compute advantage for ego agent from interaction with confederate
 
                 # Get available actions for agent 1 from environment state
-                avail_actions_1_ego = jax.vmap(env.get_avail_actions)(env_state_ego.env_state)["agent_1"].astype(jnp.float32)
+                avail_actions_1_ego = jax.vmap(env.get_avail_actions)(
+                    env_state_ego.env_state
+                )["agent_1"].astype(jnp.float32)
 
                 # Get last value for ego agent
                 _, last_val_1_ego, _, _ = ego_policy.get_action_value_policy(
                     params=train_state_ego.params,
-                    obs=last_obs_ego["agent_1"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones_ego["agent_1"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
+                    obs=last_obs_ego["agent_1"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"], -1
+                    ),
+                    done=last_dones_ego["agent_1"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"]
+                    ),
                     avail_actions=jax.lax.stop_gradient(avail_actions_1_ego),
                     hstate=ego_hstate,
-                    rng=jax.random.PRNGKey(0)  # dummy key as we don't sample actions
+                    rng=jax.random.PRNGKey(0),  # dummy key as we don't sample actions
                 )
                 last_val_1_ego = last_val_1_ego.squeeze()
-                advantages_ego, targets_ego = _calculate_gae(traj_batch_ego, last_val_1_ego)
+                advantages_ego, targets_ego = _calculate_gae(
+                    traj_batch_ego, last_val_1_ego
+                )
 
                 # 3c) compute advantage for confederate agent from interaction with br policy
 
                 # Get available actions for agent 0 from environment state
-                avail_actions_0_br = jax.vmap(env.get_avail_actions)(env_state_br.env_state)["agent_0"].astype(jnp.float32)
+                avail_actions_0_br = jax.vmap(env.get_avail_actions)(
+                    env_state_br.env_state
+                )["agent_0"].astype(jnp.float32)
 
                 # Get last value using agent interface
-                _, (_, last_val_0_br), _, _ = confederate_policy.get_action_value_policy(
-                    params=train_state_conf.params,
-                    obs=last_obs_br["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones_br["agent_0"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
-                    avail_actions=jax.lax.stop_gradient(avail_actions_0_br),
-                    hstate=conf_hstate_br,
-                    rng=jax.random.PRNGKey(0)  # dummy key as we don't sample actions
+                _, (_, last_val_0_br), _, _ = (
+                    confederate_policy.get_action_value_policy(
+                        params=train_state_conf.params,
+                        obs=last_obs_br["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"], -1
+                        ),
+                        done=last_dones_br["agent_0"].reshape(
+                            1, config["NUM_CONTROLLED_ACTORS"]
+                        ),
+                        avail_actions=jax.lax.stop_gradient(avail_actions_0_br),
+                        hstate=conf_hstate_br,
+                        rng=jax.random.PRNGKey(
+                            0
+                        ),  # dummy key as we don't sample actions
+                    )
                 )
                 last_val_0_br = last_val_0_br.squeeze()
-                advantages_conf_br, targets_conf_br = _calculate_gae(traj_batch_conf_br, last_val_0_br)
+                advantages_conf_br, targets_conf_br = _calculate_gae(
+                    traj_batch_conf_br, last_val_0_br
+                )
 
                 # 3d) compute advantage for br policy from interaction with confederate agent
-                avail_actions_1_br = jax.vmap(env.get_avail_actions)(env_state_br.env_state)["agent_1"].astype(jnp.float32)
+                avail_actions_1_br = jax.vmap(env.get_avail_actions)(
+                    env_state_br.env_state
+                )["agent_1"].astype(jnp.float32)
                 # Get last value using agent interface
                 _, last_val_1_br, _, _ = br_policy.get_action_value_policy(
                     params=train_state_br.params,
-                    obs=last_obs_br["agent_1"].reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=last_dones_br["agent_1"].reshape(1, config["NUM_CONTROLLED_ACTORS"]),
+                    obs=last_obs_br["agent_1"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"], -1
+                    ),
+                    done=last_dones_br["agent_1"].reshape(
+                        1, config["NUM_CONTROLLED_ACTORS"]
+                    ),
                     avail_actions=jax.lax.stop_gradient(avail_actions_1_br),
                     hstate=br_hstate,
-                    rng=jax.random.PRNGKey(0)  # dummy key as we don't sample actions
+                    rng=jax.random.PRNGKey(0),  # dummy key as we don't sample actions
                 )
                 last_val_1_br = last_val_1_br.squeeze()
                 advantages_br, targets_br = _calculate_gae(traj_batch_br, last_val_1_br)
 
                 # 3) PPO update
                 update_state = (
-                    train_state_conf, train_state_br, train_state_ego,
-                    traj_batch_conf_ego, traj_batch_ego, traj_batch_conf_br, traj_batch_br,
-                    advantages_conf, advantages_ego, advantages_conf_br, advantages_br,
-                    targets_conf, targets_ego, targets_conf_br, targets_br,
-                    rng_ego, rng_br
+                    train_state_conf,
+                    train_state_br,
+                    train_state_ego,
+                    traj_batch_conf_ego,
+                    traj_batch_ego,
+                    traj_batch_conf_br,
+                    traj_batch_br,
+                    advantages_conf,
+                    advantages_ego,
+                    advantages_conf_br,
+                    advantages_br,
+                    targets_conf,
+                    targets_ego,
+                    targets_conf_br,
+                    targets_br,
+                    rng_ego,
+                    rng_br,
                 )
-                update_state, (all_losses_conf, all_losses_br, all_losses_ego) = jax.lax.scan(
-                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                update_state, (all_losses_conf, all_losses_br, all_losses_ego) = (
+                    jax.lax.scan(
+                        _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                    )
+                )
                 train_state_conf = update_state[0]
                 train_state_br = update_state[1]
                 train_state_ego = update_state[2]
@@ -664,8 +1024,12 @@ def train_paired(config, env, partner_rng):
                 def mask_and_mean(x, mask):
                     return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
 
-                mask = traj_batch_ego.info.get("returned_episode", jnp.ones_like(traj_batch_ego.reward))
-                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_ego.info)
+                mask = traj_batch_ego.info.get(
+                    "returned_episode", jnp.ones_like(traj_batch_ego.reward)
+                )
+                metric = jax.tree.map(
+                    lambda x: mask_and_mean(x, mask), traj_batch_ego.info
+                )
                 metric["update_steps"] = update_steps
 
                 # Conf agent losses: value_loss_ego, value_loss_br, pg_loss_ego, pg_loss_br, entropy_ego, entropy_br
@@ -686,94 +1050,190 @@ def train_paired(config, env, partner_rng):
                 metric["pg_loss_br"] = all_losses_br[1][1].mean()
                 metric["entropy_loss_br"] = all_losses_br[1][2].mean()
 
-                metric["average_rewards_conf_against_ego"] = jnp.mean(traj_batch_conf_ego.reward)
-                metric["average_rewards_conf_against_br"] = jnp.mean(traj_batch_conf_br.reward) # redundant with br reward
+                metric["average_rewards_conf_against_ego"] = jnp.mean(
+                    traj_batch_conf_ego.reward
+                )
+                metric["average_rewards_conf_against_br"] = jnp.mean(
+                    traj_batch_conf_br.reward
+                )  # redundant with br reward
                 metric["average_rewards_ego"] = jnp.mean(traj_batch_ego.reward)
                 metric["average_rewards_br"] = jnp.mean(traj_batch_br.reward)
 
-
                 new_runner_state = (
-                    train_state_conf, train_state_br, train_state_ego, env_state_ego, env_state_br,
-                    last_obs_ego, last_obs_br, last_dones_ego, last_dones_br,
-                    conf_hstate_ego, ego_hstate, conf_hstate_br, br_hstate,
-                    rng_ego, rng_br, update_steps + 1
+                    train_state_conf,
+                    train_state_br,
+                    train_state_ego,
+                    env_state_ego,
+                    env_state_br,
+                    last_obs_ego,
+                    last_obs_br,
+                    last_dones_ego,
+                    last_dones_br,
+                    conf_hstate_ego,
+                    ego_hstate,
+                    conf_hstate_br,
+                    br_hstate,
+                    rng_ego,
+                    rng_br,
+                    update_steps + 1,
                 )
                 return (new_runner_state, metric)
 
             # --------------------------
             # PPO Update and Checkpoint saving
             # --------------------------
-            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)  # -1 because we store a ckpt at the last update
+            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                1, config["NUM_CHECKPOINTS"] - 1
+            )  # -1 because we store a ckpt at the last update
             num_ckpts = config["NUM_CHECKPOINTS"]
 
             # Build a PyTree that holds parameters for all conf agent checkpoints
             def init_ckpt_array(params_pytree):
                 return jax.tree.map(
-                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype),
-                    params_pytree)
+                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
+                )
 
             def _update_step_with_ckpt(state_with_ckpt, unused):
-                ((
-                    train_state_conf, train_state_br, train_state_ego, env_state_ego, env_state_br,
-                    last_obs_ego, last_obs_br , last_dones_ego, last_dones_br,
-                    conf_hstate_ego, ego_hstate, conf_hstate_br, br_hstate,
-                    rng_ego, rng_br, update_steps
-                ), checkpoint_array_conf, checkpoint_array_br, checkpoint_array_ego, ckpt_idx,
-                    eval_info_br, eval_info_ego) = state_with_ckpt
+                (
+                    (
+                        train_state_conf,
+                        train_state_br,
+                        train_state_ego,
+                        env_state_ego,
+                        env_state_br,
+                        last_obs_ego,
+                        last_obs_br,
+                        last_dones_ego,
+                        last_dones_br,
+                        conf_hstate_ego,
+                        ego_hstate,
+                        conf_hstate_br,
+                        br_hstate,
+                        rng_ego,
+                        rng_br,
+                        update_steps,
+                    ),
+                    checkpoint_array_conf,
+                    checkpoint_array_br,
+                    checkpoint_array_ego,
+                    ckpt_idx,
+                    eval_info_br,
+                    eval_info_ego,
+                ) = state_with_ckpt
 
                 # Single PPO update
                 (new_runner_state, metric) = _update_step(
-                    (train_state_conf, train_state_br, train_state_ego, env_state_ego, env_state_br,
-                    last_obs_ego, last_obs_br, last_dones_ego, last_dones_br,
-                    conf_hstate_ego, ego_hstate, conf_hstate_br, br_hstate,
-                    rng_ego, rng_br, update_steps),
-                    None
+                    (
+                        train_state_conf,
+                        train_state_br,
+                        train_state_ego,
+                        env_state_ego,
+                        env_state_br,
+                        last_obs_ego,
+                        last_obs_br,
+                        last_dones_ego,
+                        last_dones_br,
+                        conf_hstate_ego,
+                        ego_hstate,
+                        conf_hstate_br,
+                        br_hstate,
+                        rng_ego,
+                        rng_br,
+                        update_steps,
+                    ),
+                    None,
                 )
 
                 (
-                    train_state_conf, train_state_br, train_state_ego, env_state_ego, env_state_br,
-                    last_obs_ego, last_obs_br, last_dones_ego, last_dones_br,
-                    conf_hstate_ego, ego_hstate, conf_hstate_br, br_hstate,
-                    rng_ego, rng_br, update_steps
+                    train_state_conf,
+                    train_state_br,
+                    train_state_ego,
+                    env_state_ego,
+                    env_state_br,
+                    last_obs_ego,
+                    last_obs_br,
+                    last_dones_ego,
+                    last_dones_br,
+                    conf_hstate_ego,
+                    ego_hstate,
+                    conf_hstate_br,
+                    br_hstate,
+                    rng_ego,
+                    rng_br,
+                    update_steps,
                 ) = new_runner_state
 
                 # Decide if we store a checkpoint
                 # update steps is 1-indexed because it was incremented at the end of the update step
-                to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                        jnp.equal(update_steps, config["NUM_UPDATES"]))
+                to_store = jnp.logical_or(
+                    jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
+                )
 
                 def store_and_eval_ckpt(args):
                     ckpt_arr_and_ep_infos, rng, cidx = args
-                    ckpt_arr_conf, ckpt_arr_br, ckpt_arr_ego, prev_ep_infos_br, prev_ep_infos_ego = ckpt_arr_and_ep_infos
+                    (
+                        ckpt_arr_conf,
+                        ckpt_arr_br,
+                        ckpt_arr_ego,
+                        _prev_ep_infos_br,
+                        _prev_ep_infos_ego,
+                    ) = ckpt_arr_and_ep_infos
                     new_ckpt_arr_conf = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_conf, train_state_conf.params
+                        ckpt_arr_conf,
+                        train_state_conf.params,
                     )
                     new_ckpt_arr_br = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_br, train_state_br.params
+                        ckpt_arr_br,
+                        train_state_br.params,
                     )
                     new_ckpt_arr_ego = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_ego, train_state_ego.params
+                        ckpt_arr_ego,
+                        train_state_ego.params,
                     )
 
                     # run eval episodes
-                    rng, eval_rng, = jax.random.split(rng)
+                    (
+                        rng,
+                        eval_rng,
+                    ) = jax.random.split(rng)
                     # conf vs ego
-                    last_ep_info_with_ego = run_episodes(eval_rng, env,
-                        agent_0_param=train_state_conf.params, agent_0_policy=confederate_policy,
-                        agent_1_param=train_state_ego.params, agent_1_policy=ego_policy,
-                        max_episode_steps=config["ROLLOUT_LENGTH"], num_eps=config["NUM_EVAL_EPISODES"]
+                    last_ep_info_with_ego = run_episodes(
+                        eval_rng,
+                        env,
+                        agent_0_param=train_state_conf.params,
+                        agent_0_policy=confederate_policy,
+                        agent_1_param=train_state_ego.params,
+                        agent_1_policy=ego_policy,
+                        max_episode_steps=config["ROLLOUT_LENGTH"],
+                        num_eps=config["NUM_EVAL_EPISODES"],
                     )
                     # conf vs br
-                    last_ep_info_with_br = run_episodes(eval_rng, env,
-                        agent_0_param=train_state_br.params, agent_0_policy=br_policy,
-                        agent_1_param=train_state_conf.params, agent_1_policy=confederate_policy,
-                        max_episode_steps=config["ROLLOUT_LENGTH"], num_eps=config["NUM_EVAL_EPISODES"]
+                    last_ep_info_with_br = run_episodes(
+                        eval_rng,
+                        env,
+                        agent_0_param=train_state_br.params,
+                        agent_0_policy=br_policy,
+                        agent_1_param=train_state_conf.params,
+                        agent_1_policy=confederate_policy,
+                        max_episode_steps=config["ROLLOUT_LENGTH"],
+                        num_eps=config["NUM_EVAL_EPISODES"],
                     )
 
-                    return ((new_ckpt_arr_conf, new_ckpt_arr_br, new_ckpt_arr_ego, last_ep_info_with_br, last_ep_info_with_ego), rng, cidx + 1)
+                    return (
+                        (
+                            new_ckpt_arr_conf,
+                            new_ckpt_arr_br,
+                            new_ckpt_arr_ego,
+                            last_ep_info_with_br,
+                            last_ep_info_with_ego,
+                        ),
+                        rng,
+                        cidx + 1,
+                    )
 
                 def skip_ckpt(args):
                     return args
@@ -782,19 +1242,55 @@ def train_paired(config, env, partner_rng):
                     to_store,
                     store_and_eval_ckpt,
                     skip_ckpt,
-                    ((checkpoint_array_conf, checkpoint_array_br, checkpoint_array_ego, eval_info_br, eval_info_ego), rng_ego, ckpt_idx)
+                    (
+                        (
+                            checkpoint_array_conf,
+                            checkpoint_array_br,
+                            checkpoint_array_ego,
+                            eval_info_br,
+                            eval_info_ego,
+                        ),
+                        rng_ego,
+                        ckpt_idx,
+                    ),
                 )
-                checkpoint_array_conf, checkpoint_array_br, checkpoint_array_ego, ep_info_br, ep_info_ego = checkpoint_array_and_infos
+                (
+                    checkpoint_array_conf,
+                    checkpoint_array_br,
+                    checkpoint_array_ego,
+                    ep_info_br,
+                    ep_info_ego,
+                ) = checkpoint_array_and_infos
 
                 metric["eval_ep_last_info_br"] = ep_info_br
                 metric["eval_ep_last_info_ego"] = ep_info_ego
 
-                return ((train_state_conf, train_state_br, train_state_ego, env_state_ego, env_state_br,
-                         last_obs_ego, last_obs_br, last_dones_ego, last_dones_br,
-                         conf_hstate_ego, ego_hstate, conf_hstate_br, br_hstate,
-                         rng_ego, rng_br, update_steps),
-                         checkpoint_array_conf, checkpoint_array_br, checkpoint_array_ego, ckpt_idx,
-                         ep_info_br, ep_info_ego), metric
+                return (
+                    (
+                        train_state_conf,
+                        train_state_br,
+                        train_state_ego,
+                        env_state_ego,
+                        env_state_br,
+                        last_obs_ego,
+                        last_obs_br,
+                        last_dones_ego,
+                        last_dones_br,
+                        conf_hstate_ego,
+                        ego_hstate,
+                        conf_hstate_br,
+                        br_hstate,
+                        rng_ego,
+                        rng_br,
+                        update_steps,
+                    ),
+                    checkpoint_array_conf,
+                    checkpoint_array_br,
+                    checkpoint_array_ego,
+                    ckpt_idx,
+                    ep_info_br,
+                    ep_info_ego,
+                ), metric
 
             # init checkpoint array
             checkpoint_array_conf = init_ckpt_array(train_state_conf.params)
@@ -805,48 +1301,90 @@ def train_paired(config, env, partner_rng):
             # initial state for scan over _update_step_with_ckpt
             update_steps = 0
             rng, rng_eval_ego, rng_eval_br = jax.random.split(rng, 3)
-            ep_infos_ego = run_episodes(rng_eval_ego, env,
-                agent_0_param=train_state_conf.params, agent_0_policy=confederate_policy,
-                agent_1_param=train_state_ego.params, agent_1_policy=ego_policy,
-                max_episode_steps=config["ROLLOUT_LENGTH"], num_eps=config["NUM_EVAL_EPISODES"]
+            ep_infos_ego = run_episodes(
+                rng_eval_ego,
+                env,
+                agent_0_param=train_state_conf.params,
+                agent_0_policy=confederate_policy,
+                agent_1_param=train_state_ego.params,
+                agent_1_policy=ego_policy,
+                max_episode_steps=config["ROLLOUT_LENGTH"],
+                num_eps=config["NUM_EVAL_EPISODES"],
             )
-            ep_infos_br = run_episodes(rng_eval_br, env,
-                agent_0_param=train_state_br.params, agent_0_policy=br_policy,
-                agent_1_param=train_state_ego.params, agent_1_policy=ego_policy,
-                max_episode_steps=config["ROLLOUT_LENGTH"], num_eps=config["NUM_EVAL_EPISODES"])
+            ep_infos_br = run_episodes(
+                rng_eval_br,
+                env,
+                agent_0_param=train_state_br.params,
+                agent_0_policy=br_policy,
+                agent_1_param=train_state_ego.params,
+                agent_1_policy=ego_policy,
+                max_episode_steps=config["ROLLOUT_LENGTH"],
+                num_eps=config["NUM_EVAL_EPISODES"],
+            )
 
             # Initialize hidden states
             init_ego_hstate = ego_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
-            init_conf_hstate_ego = confederate_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
-            init_conf_hstate_br = confederate_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
+            init_conf_hstate_ego = confederate_policy.init_hstate(
+                config["NUM_CONTROLLED_ACTORS"]
+            )
+            init_conf_hstate_br = confederate_policy.init_hstate(
+                config["NUM_CONTROLLED_ACTORS"]
+            )
             init_br_hstate = br_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
 
-
             # Initialize done flags
-            init_dones_ego = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
-            init_dones_br = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
+            init_dones_ego = {
+                k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                for k in env.agents + ["__all__"]
+            }
+            init_dones_br = {
+                k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                for k in env.agents + ["__all__"]
+            }
 
             rng, rng_ego, rng_br = jax.random.split(rng, 3)
             update_runner_state = (
-                train_state_conf, train_state_br, train_state_ego, env_state_ego, env_state_br,
-                obsv_ego, obsv_br, init_dones_ego, init_dones_br,
-                init_conf_hstate_ego, init_ego_hstate, init_conf_hstate_br, init_br_hstate,
-                rng_ego, rng_br, update_steps
+                train_state_conf,
+                train_state_br,
+                train_state_ego,
+                env_state_ego,
+                env_state_br,
+                obsv_ego,
+                obsv_br,
+                init_dones_ego,
+                init_dones_br,
+                init_conf_hstate_ego,
+                init_ego_hstate,
+                init_conf_hstate_br,
+                init_br_hstate,
+                rng_ego,
+                rng_br,
+                update_steps,
             )
             state_with_ckpt = (
-                update_runner_state, checkpoint_array_conf, checkpoint_array_br, checkpoint_array_ego,
-                ckpt_idx, ep_infos_br, ep_infos_ego
+                update_runner_state,
+                checkpoint_array_conf,
+                checkpoint_array_br,
+                checkpoint_array_ego,
+                ckpt_idx,
+                ep_infos_br,
+                ep_infos_ego,
             )
             # run training
             state_with_ckpt, metrics = jax.lax.scan(
                 _update_step_with_ckpt,
                 state_with_ckpt,
                 xs=None,
-                length=config["NUM_UPDATES"]
+                length=config["NUM_UPDATES"],
             )
             (
-                final_runner_state, checkpoint_array_conf, checkpoint_array_br, checkpoint_array_ego,
-                final_ckpt_idx, last_ep_infos_br, last_ep_infos_ego
+                final_runner_state,
+                checkpoint_array_conf,
+                checkpoint_array_br,
+                checkpoint_array_ego,
+                _final_ckpt_idx,
+                _last_ep_infos_br,
+                _last_ep_infos_ego,
             ) = state_with_ckpt
 
             out = {
@@ -861,6 +1399,7 @@ def train_paired(config, env, partner_rng):
             return out
 
         return train
+
     # ------------------------------
     # Actually run the adversarial teammate training
     # ------------------------------
@@ -883,34 +1422,54 @@ def log_metrics(config, logger, outs, metric_names: tuple):
 
     # Extract metrics for all agents
     # shape (num_seeds, num_updates, num_eval_episodes, num_agents_per_env)
-    avg_conf_returns_vs_ego = np.asarray(metrics["eval_ep_last_info_ego"]["returned_episode_returns"]).mean(axis=(0, 2, 3))
-    avg_conf_returns_vs_br = np.asarray(metrics["eval_ep_last_info_br"]["returned_episode_returns"]).mean(axis=(0, 2, 3))
+    avg_conf_returns_vs_ego = np.asarray(
+        metrics["eval_ep_last_info_ego"]["returned_episode_returns"]
+    ).mean(axis=(0, 2, 3))
+    avg_conf_returns_vs_br = np.asarray(
+        metrics["eval_ep_last_info_br"]["returned_episode_returns"]
+    ).mean(axis=(0, 2, 3))
 
     # Value losses
     # shape (num_seeds, num_updates)
-    avg_value_losses_conf_vs_ego = np.asarray(metrics["value_loss_conf_against_ego"]).mean(axis=0)
-    avg_value_losses_conf_vs_br = np.asarray(metrics["value_loss_conf_against_br"]).mean(axis=0)
+    avg_value_losses_conf_vs_ego = np.asarray(
+        metrics["value_loss_conf_against_ego"]
+    ).mean(axis=0)
+    avg_value_losses_conf_vs_br = np.asarray(
+        metrics["value_loss_conf_against_br"]
+    ).mean(axis=0)
     avg_value_losses_br = np.asarray(metrics["value_loss_br"]).mean(axis=0)
     avg_value_losses_ego = np.asarray(metrics["value_loss_ego"]).mean(axis=0)
 
     # Actor losses
     # shape (num_seeds, num_updates)
-    avg_actor_losses_conf_vs_ego = np.asarray(metrics["pg_loss_conf_against_ego"]).mean(axis=0)
-    avg_actor_losses_conf_vs_br = np.asarray(metrics["pg_loss_conf_against_br"]).mean(axis=0)
+    avg_actor_losses_conf_vs_ego = np.asarray(metrics["pg_loss_conf_against_ego"]).mean(
+        axis=0
+    )
+    avg_actor_losses_conf_vs_br = np.asarray(metrics["pg_loss_conf_against_br"]).mean(
+        axis=0
+    )
     avg_actor_losses_br = np.asarray(metrics["pg_loss_br"]).mean(axis=0)
     avg_actor_losses_ego = np.asarray(metrics["pg_loss_ego"]).mean(axis=0)
 
     # Entropy losses
     #  shape (num_seeds, num_updates)
-    avg_entropy_losses_conf_vs_ego = np.asarray(metrics["entropy_conf_against_ego"]).mean(axis=0)
-    avg_entropy_losses_conf_vs_br = np.asarray(metrics["entropy_conf_against_br"]).mean(axis=0)
+    avg_entropy_losses_conf_vs_ego = np.asarray(
+        metrics["entropy_conf_against_ego"]
+    ).mean(axis=0)
+    avg_entropy_losses_conf_vs_br = np.asarray(metrics["entropy_conf_against_br"]).mean(
+        axis=0
+    )
     avg_entropy_losses_br = np.asarray(metrics["entropy_loss_br"]).mean(axis=0)
     avg_entropy_losses_ego = np.asarray(metrics["entropy_loss_ego"]).mean(axis=0)
 
     # Rewards
     # shape (num_seeds, num_updates)
-    avg_rewards_conf_vs_br = np.asarray(metrics["average_rewards_conf_against_br"]).mean(axis=0)
-    avg_rewards_conf_vs_ego = np.asarray(metrics["average_rewards_conf_against_ego"]).mean(axis=0)
+    avg_rewards_conf_vs_br = np.asarray(
+        metrics["average_rewards_conf_against_br"]
+    ).mean(axis=0)
+    avg_rewards_conf_vs_ego = np.asarray(
+        metrics["average_rewards_conf_against_ego"]
+    ).mean(axis=0)
     avg_rewards_br = np.asarray(metrics["average_rewards_br"]).mean(axis=0)
     avg_rewards_ego = np.asarray(metrics["average_rewards_ego"]).mean(axis=0)
 
@@ -929,32 +1488,80 @@ def log_metrics(config, logger, outs, metric_names: tuple):
                 logger.log_item(f"Train/Ego_{stat_name}", stat_mean, train_step=step)
 
         # Log returns for different agent interactions
-        logger.log_item("Eval/ConfReturn-Against-Ego", avg_conf_returns_vs_ego[step], train_step=step)
-        logger.log_item("Eval/ConfReturn-Against-BR", avg_conf_returns_vs_br[step], train_step=step)
-        logger.log_item("Eval/EgoRegret", avg_conf_returns_vs_br[step] - avg_conf_returns_vs_ego[step], train_step=step)
+        logger.log_item(
+            "Eval/ConfReturn-Against-Ego",
+            avg_conf_returns_vs_ego[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Eval/ConfReturn-Against-BR", avg_conf_returns_vs_br[step], train_step=step
+        )
+        logger.log_item(
+            "Eval/EgoRegret",
+            avg_conf_returns_vs_br[step] - avg_conf_returns_vs_ego[step],
+            train_step=step,
+        )
 
         # Confederate losses
-        logger.log_item("Losses/ConfValLoss-Against-Ego", avg_value_losses_conf_vs_ego[step], train_step=step)
-        logger.log_item("Losses/ConfActorLoss-Against-Ego", avg_actor_losses_conf_vs_ego[step], train_step=step)
-        logger.log_item("Losses/ConfEntropy-Against-Ego", avg_entropy_losses_conf_vs_ego[step], train_step=step)
+        logger.log_item(
+            "Losses/ConfValLoss-Against-Ego",
+            avg_value_losses_conf_vs_ego[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/ConfActorLoss-Against-Ego",
+            avg_actor_losses_conf_vs_ego[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/ConfEntropy-Against-Ego",
+            avg_entropy_losses_conf_vs_ego[step],
+            train_step=step,
+        )
 
-        logger.log_item("Losses/ConfValLoss-Against-BR", avg_value_losses_conf_vs_br[step], train_step=step)
-        logger.log_item("Losses/ConfActorLoss-Against-BR", avg_actor_losses_conf_vs_br[step], train_step=step)
-        logger.log_item("Losses/ConfEntropy-Against-BR", avg_entropy_losses_conf_vs_br[step], train_step=step)
+        logger.log_item(
+            "Losses/ConfValLoss-Against-BR",
+            avg_value_losses_conf_vs_br[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/ConfActorLoss-Against-BR",
+            avg_actor_losses_conf_vs_br[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/ConfEntropy-Against-BR",
+            avg_entropy_losses_conf_vs_br[step],
+            train_step=step,
+        )
 
         # Best response losses
         logger.log_item("Losses/BRValLoss", avg_value_losses_br[step], train_step=step)
-        logger.log_item("Losses/BRActorLoss", avg_actor_losses_br[step], train_step=step)
-        logger.log_item("Losses/BREntropyLoss", avg_entropy_losses_br[step], train_step=step)
+        logger.log_item(
+            "Losses/BRActorLoss", avg_actor_losses_br[step], train_step=step
+        )
+        logger.log_item(
+            "Losses/BREntropyLoss", avg_entropy_losses_br[step], train_step=step
+        )
 
         # Ego agent losses
-        logger.log_item("Losses/EgoValLoss", avg_value_losses_ego[step], train_step=step)
-        logger.log_item("Losses/EgoActorLoss", avg_actor_losses_ego[step], train_step=step)
-        logger.log_item("Losses/EgoEntropyLoss", avg_entropy_losses_ego[step], train_step=step)
+        logger.log_item(
+            "Losses/EgoValLoss", avg_value_losses_ego[step], train_step=step
+        )
+        logger.log_item(
+            "Losses/EgoActorLoss", avg_actor_losses_ego[step], train_step=step
+        )
+        logger.log_item(
+            "Losses/EgoEntropyLoss", avg_entropy_losses_ego[step], train_step=step
+        )
 
         # Rewards
-        logger.log_item("Losses/AvgConfEgoRewards", avg_rewards_conf_vs_ego[step], train_step=step)
-        logger.log_item("Losses/AvgConfBRRewards", avg_rewards_conf_vs_br[step], train_step=step)
+        logger.log_item(
+            "Losses/AvgConfEgoRewards", avg_rewards_conf_vs_ego[step], train_step=step
+        )
+        logger.log_item(
+            "Losses/AvgConfBRRewards", avg_rewards_conf_vs_br[step], train_step=step
+        )
         logger.log_item("Losses/AvgBRRewards", avg_rewards_br[step], train_step=step)
         logger.log_item("Losses/AvgEgoRewards", avg_rewards_ego[step], train_step=step)
 
@@ -964,11 +1571,14 @@ def log_metrics(config, logger, outs, metric_names: tuple):
     savedir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
     out_savepath = save_train_run(outs, savedir, savename="saved_train_run")
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="saved_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="saved_train_run", path=out_savepath, type_name="train_run"
+        )
 
     # Cleanup locally logged out file
     if not config["local_logger"]["save_train_out"]:
         shutil.rmtree(out_savepath)
+
 
 def run_paired(config, wandb_logger):
     algorithm_config = dict(config["algorithm"])

--- a/open_ended_training/ppo_ego_with_buffer.py
+++ b/open_ended_training/ppo_ego_with_buffer.py
@@ -1,8 +1,9 @@
-'''
+"""
 Script for training a PPO ego agent against a BufferedPopulation of homogeneous partner agents.
 In comparison to ego_agent_training/ppo_ego.py, this script permits a (potentially nonstationary)
 sampling distribution over partners and a population of partners that potentially changes in size.
-'''
+"""
+
 import logging
 
 import jax
@@ -11,12 +12,14 @@ import optax
 from flax.training.train_state import TrainState
 
 from agents.population_buffer import BufferedPopulation, PopulationBuffer
-from marl.ppo_utils import Transition, unbatchify, _create_minibatches
-from common.run_episodes import run_episodes
 from common.n_agent_utils import (
-    get_ego_teammate_indices, augment_all_obs, augment_done, split_actions
+    augment_all_obs,
+    augment_done,
+    get_ego_teammate_indices,
+    split_actions,
 )
 from common.run_n_agent_episodes import run_n_agent_episodes
+from marl.ppo_utils import Transition, _create_minibatches
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -36,16 +39,24 @@ EGO_LIVE_LOSS_KEYS = {
 }
 EGO_LIVE_RETURNS_PREFIX = "Train/Ego/"
 
+
 def compute_ego_num_updates(cfg):
     return int(cfg["TOTAL_TIMESTEPS"] // (cfg["ROLLOUT_LENGTH"] * cfg["NUM_ENVS"]))
 
-def train_ppo_ego_agent_with_buffer(config, env, train_rng, 
-                           ego_policy, init_ego_params, n_ego_train_seeds,
-                           partner_population: BufferedPopulation, 
-                           population_buffer: PopulationBuffer,
-                           logger=None, progress_callback=None
-                           ):
-    '''
+
+def train_ppo_ego_agent_with_buffer(
+    config,
+    env,
+    train_rng,
+    ego_policy,
+    init_ego_params,
+    n_ego_train_seeds,
+    partner_population: BufferedPopulation,
+    population_buffer: PopulationBuffer,
+    logger=None,
+    progress_callback=None,
+):
+    """
     Train PPO ego agent using partners from the BufferedPopulation.
 
     Args:
@@ -57,30 +68,39 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
         n_ego_train_seeds: int, number of ego training seeds
         partner_population: BufferedPopulation, population manager for partner agents
         population_buffer: PopulationBuffer, buffer containing partner agents
-    '''
+    """
+
     # ------------------------------
     # Build the PPO training function
     # ------------------------------
     def make_ppo_train(config):
-        '''Ego agents occupy ego_indices slots; partner (buffered population) occupies teammate_indices slots.'''
+        """Ego agents occupy ego_indices slots; partner (buffered population) occupies teammate_indices slots."""
         num_agents = env.num_agents
         ego_indices, teammate_indices = get_ego_teammate_indices(config, env)
         n_ego = len(ego_indices)
         n_teammates = len(teammate_indices)
-        
+
         augment_obs = config.get("EGO_INDICES") is not None
 
         config["NUM_ACTORS"] = env.num_agents * config["NUM_ENVS"]
-        config["NUM_CONTROLLED_ACTORS"] = n_ego * config["NUM_ENVS"]        # ego
-        config["NUM_UNCONTROLLED_ACTORS"] = n_teammates * config["NUM_ENVS"] # partner
+        config["NUM_CONTROLLED_ACTORS"] = n_ego * config["NUM_ENVS"]  # ego
+        config["NUM_UNCONTROLLED_ACTORS"] = n_teammates * config["NUM_ENVS"]  # partner
         config["NUM_UPDATES"] = compute_ego_num_updates(config)
 
         config["NUM_ACTIONS"] = env.action_space(env.agents[0]).n
-        assert config["NUM_CONTROLLED_ACTORS"] % config["NUM_MINIBATCHES"] == 0, "NUM_CONTROLLED_ACTORS must be divisible by NUM_MINIBATCHES"
-        assert config["NUM_CONTROLLED_ACTORS"] >= config["NUM_MINIBATCHES"], "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        assert config["NUM_CONTROLLED_ACTORS"] % config["NUM_MINIBATCHES"] == 0, (
+            "NUM_CONTROLLED_ACTORS must be divisible by NUM_MINIBATCHES"
+        )
+        assert config["NUM_CONTROLLED_ACTORS"] >= config["NUM_MINIBATCHES"], (
+            "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        )
 
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng):
@@ -103,7 +123,9 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
 
             #  Init ego and partner hstates
             init_ego_hstate = ego_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
-            init_partner_hstate = partner_population.init_hstate(config["NUM_UNCONTROLLED_ACTORS"])
+            init_partner_hstate = partner_population.init_hstate(
+                config["NUM_UNCONTROLLED_ACTORS"]
+            )
 
             def _env_step(runner_state, unused):
                 """
@@ -111,53 +133,91 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                 - ego slots  (ego_indices)      -> shared ego policy
                 - partner slots (teammate_indices) -> BufferedPopulation
                 """
-                train_state, env_state, prev_obs, prev_done, ego_hstate, partner_hstate, population_buffer, partner_indices, rng = runner_state
-                rng, actor_rng, partner_rng, partner_sample_rng, step_rng = jax.random.split(rng, 5)
+                (
+                    train_state,
+                    env_state,
+                    prev_obs,
+                    prev_done,
+                    ego_hstate,
+                    partner_hstate,
+                    population_buffer,
+                    partner_indices,
+                    rng,
+                ) = runner_state
+                rng, actor_rng, partner_rng, partner_sample_rng, step_rng = (
+                    jax.random.split(rng, 5)
+                )
 
-                avail_actions_vmap = jax.vmap(env.get_avail_actions)(env_state.env_state)
+                avail_actions_vmap = jax.vmap(env.get_avail_actions)(
+                    env_state.env_state
+                )
                 avail_actions_vmap = jax.lax.stop_gradient(avail_actions_vmap)
 
                 # Stack obs/dones for ego and partner role groups (augmented with one-hot ID)
                 obs_ego, obs_partner = augment_all_obs(
-                    prev_obs, ego_indices, teammate_indices, num_agents, config["NUM_ENVS"], augment_obs=augment_obs)
+                    prev_obs,
+                    ego_indices,
+                    teammate_indices,
+                    num_agents,
+                    config["NUM_ENVS"],
+                    augment_obs=augment_obs,
+                )
                 dones_ego = augment_done(prev_done, ego_indices, config["NUM_ENVS"])
-                dones_partner = augment_done(prev_done, teammate_indices, config["NUM_ENVS"])
+                dones_partner = augment_done(
+                    prev_done, teammate_indices, config["NUM_ENVS"]
+                )
 
                 avail_actions_ego = jnp.concatenate(
-                    [avail_actions_vmap[f'agent_{i}'].astype(jnp.float32) for i in ego_indices], axis=0)
+                    [
+                        avail_actions_vmap[f"agent_{i}"].astype(jnp.float32)
+                        for i in ego_indices
+                    ],
+                    axis=0,
+                )
                 avail_actions_partner = jnp.concatenate(
-                    [avail_actions_vmap[f'agent_{i}'].astype(jnp.float32) for i in teammate_indices], axis=0)
+                    [
+                        avail_actions_vmap[f"agent_{i}"].astype(jnp.float32)
+                        for i in teammate_indices
+                    ],
+                    axis=0,
+                )
 
                 # Conditionally resample partners on episode end
                 needs_resample = prev_done["__all__"]
-                sampled_indices_all, updated_buffer = partner_population.sample_agent_indices(
-                    population_buffer,
-                    config["NUM_UNCONTROLLED_ACTORS"],
-                    partner_sample_rng,
-                    needs_resample_mask=needs_resample
+                sampled_indices_all, updated_buffer = (
+                    partner_population.sample_agent_indices(
+                        population_buffer,
+                        config["NUM_UNCONTROLLED_ACTORS"],
+                        partner_sample_rng,
+                        needs_resample_mask=needs_resample,
+                    )
                 )
 
                 # Determine final indices based on whether resampling was needed for each env
                 # needs_resample is (NUM_ENVS,); partner_indices is (NUM_UNCONTROLLED_ACTORS,).
                 # Tile so all teammate slots for an env reset together.
-                needs_resample_tiled = jnp.tile(needs_resample, n_teammates)  # (NUM_UNCONTROLLED_ACTORS,)
+                needs_resample_tiled = jnp.tile(
+                    needs_resample, n_teammates
+                )  # (NUM_UNCONTROLLED_ACTORS,)
                 updated_partner_indices = jnp.where(
                     needs_resample_tiled,
-                    sampled_indices_all,    # Use newly sampled index if True
-                    partner_indices         # Else, keep index from previous step
+                    sampled_indices_all,  # Use newly sampled index if True
+                    partner_indices,  # Else, keep index from previous step
                 )
 
                 # Note that we do not need to reset the hiden states for both the ego and partner agents
                 # as the recurrent states are automatically reset when done is True, and the partner indices are only reset when done is True.
 
                 # Ego action (parameter sharing over n_ego slots)
-                act_ego, val_ego, pi_ego, new_ego_hstate = ego_policy.get_action_value_policy(
-                    params=train_state.params,
-                    obs=obs_ego.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
-                    done=dones_ego.reshape(1, config["NUM_CONTROLLED_ACTORS"]),
-                    avail_actions=avail_actions_ego,
-                    hstate=ego_hstate,
-                    rng=actor_rng
+                act_ego, val_ego, pi_ego, new_ego_hstate = (
+                    ego_policy.get_action_value_policy(
+                        params=train_state.params,
+                        obs=obs_ego.reshape(1, config["NUM_CONTROLLED_ACTORS"], -1),
+                        done=dones_ego.reshape(1, config["NUM_CONTROLLED_ACTORS"]),
+                        avail_actions=avail_actions_ego,
+                        hstate=ego_hstate,
+                        rng=actor_rng,
+                    )
                 )
                 logp_ego = pi_ego.log_prob(act_ego)
                 act_ego = act_ego.squeeze()
@@ -174,40 +234,57 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                     hstate=partner_hstate,
                     rng=partner_rng,
                     env_state=env_state,
-                    aux_obs=None
+                    aux_obs=None,
                 )
                 act_partner = act_partner.squeeze()
 
                 # Reconstruct action dict and step env
-                env_act = split_actions(act_ego, act_partner, ego_indices, teammate_indices, config["NUM_ENVS"])
-                step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0, 0, 0))(
-                    step_rngs, env_state, env_act
+                env_act = split_actions(
+                    act_ego,
+                    act_partner,
+                    ego_indices,
+                    teammate_indices,
+                    config["NUM_ENVS"],
                 )
+                step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 # Stack ego reward per slot: (n_ego * NUM_ENVS,) — one entry per ego slot
                 ego_reward_stacked = jnp.concatenate(
-                    [reward[f'agent_{i}'] for i in ego_indices], axis=0)  # (NUM_CONTROLLED_ACTORS,)
+                    [reward[f"agent_{i}"] for i in ego_indices], axis=0
+                )  # (NUM_CONTROLLED_ACTORS,)
                 info_ego = jax.tree.map(
-                    lambda x: jnp.concatenate([x[:, i] for i in ego_indices], axis=0), 
-                    info
+                    lambda x: jnp.concatenate([x[:, i] for i in ego_indices], axis=0),
+                    info,
                 )
 
                 # Store all NUM_CONTROLLED_ACTORS (n_ego * NUM_ENVS) ego data.
-                ego_done_stacked = augment_done(done, ego_indices, config["NUM_ENVS"])  # (NUM_CONTROLLED_ACTORS,)
+                ego_done_stacked = augment_done(
+                    done, ego_indices, config["NUM_ENVS"]
+                )  # (NUM_CONTROLLED_ACTORS,)
                 transition = Transition(
                     done=ego_done_stacked,
-                    action=act_ego,            # (NUM_CONTROLLED_ACTORS,)
-                    value=val_ego,             # (NUM_CONTROLLED_ACTORS,)
+                    action=act_ego,  # (NUM_CONTROLLED_ACTORS,)
+                    value=val_ego,  # (NUM_CONTROLLED_ACTORS,)
                     reward=ego_reward_stacked,
-                    log_prob=logp_ego,         # (NUM_CONTROLLED_ACTORS,)
-                    obs=obs_ego,               # (NUM_CONTROLLED_ACTORS, aug_obs_dim)
+                    log_prob=logp_ego,  # (NUM_CONTROLLED_ACTORS,)
+                    obs=obs_ego,  # (NUM_CONTROLLED_ACTORS, aug_obs_dim)
                     info=info_ego,
                     avail_actions=avail_actions_ego,  # (NUM_CONTROLLED_ACTORS, n_actions)
-                    prev_done=dones_ego                # (NUM_CONTROLLED_ACTORS,) pre-step done
+                    prev_done=dones_ego,  # (NUM_CONTROLLED_ACTORS,) pre-step done
                 )
-                new_runner_state = (train_state, env_state_next, obs_next, done,
-                                    new_ego_hstate, new_partner_hstate, updated_buffer,
-                                    updated_partner_indices, rng)
+                new_runner_state = (
+                    train_state,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_ego_hstate,
+                    new_partner_hstate,
+                    updated_buffer,
+                    updated_partner_indices,
+                    rng,
+                )
                 return new_runner_state, transition
 
             def _calculate_gae(traj_batch, last_val):
@@ -236,22 +313,24 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
 
             def _update_minbatch(train_state, batch_info):
                 init_ego_hstate, traj_batch, advantages, returns = batch_info
+
                 def _loss_fn(params, init_ego_hstate, traj_batch, gae, target_v):
                     _, value, pi, _ = ego_policy.get_action_value_policy(
-                        params=params, 
+                        params=params,
                         obs=traj_batch.obs,
                         done=traj_batch.prev_done,
                         avail_actions=traj_batch.avail_actions,
                         hstate=init_ego_hstate,
-                        rng=jax.random.PRNGKey(0) # only used for action sampling, which is unused here
+                        rng=jax.random.PRNGKey(
+                            0
+                        ),  # only used for action sampling, which is unused here
                     )
                     log_prob = pi.log_prob(traj_batch.action)
 
                     # Value loss
                     value_pred_clipped = traj_batch.value + (
                         value - traj_batch.value
-                        ).clip(
-                        -config["CLIP_EPS"], config["CLIP_EPS"])
+                    ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                     value_losses = jnp.square(value - target_v)
                     value_losses_clipped = jnp.square(value_pred_clipped - target_v)
                     value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
@@ -260,47 +339,65 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                     ratio = jnp.exp(log_prob - traj_batch.log_prob)
                     gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                     pg_loss_1 = ratio * gae_norm
-                    pg_loss_2 = jnp.clip(
-                        ratio, 
-                        1.0 - config["CLIP_EPS"], 
-                        1.0 + config["CLIP_EPS"]) * gae_norm
+                    pg_loss_2 = (
+                        jnp.clip(
+                            ratio, 1.0 - config["CLIP_EPS"], 1.0 + config["CLIP_EPS"]
+                        )
+                        * gae_norm
+                    )
                     pg_loss = -jnp.mean(jnp.minimum(pg_loss_1, pg_loss_2))
 
                     # Entropy
                     entropy = jnp.mean(pi.entropy())
 
-                    total_loss = pg_loss + config["VF_COEF"] * value_loss - config["ENT_COEF"] * entropy
+                    total_loss = (
+                        pg_loss
+                        + config["VF_COEF"] * value_loss
+                        - config["ENT_COEF"] * entropy
+                    )
                     return total_loss, (value_loss, pg_loss, entropy)
 
                 grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
                 (loss_val, aux_vals), grads = grad_fn(
-                    train_state.params, init_ego_hstate, traj_batch, advantages, returns)
+                    train_state.params, init_ego_hstate, traj_batch, advantages, returns
+                )
                 train_state = train_state.apply_gradients(grads=grads)
 
                 # compute average grad norm
-                grad_l2_norms = jax.tree.map(lambda g: jnp.linalg.norm(g.astype(jnp.float32)), grads)
+                grad_l2_norms = jax.tree.map(
+                    lambda g: jnp.linalg.norm(g.astype(jnp.float32)), grads
+                )
                 sum_of_grad_norms = jax.tree.reduce(lambda x, y: x + y, grad_l2_norms)
                 n_elements = len(jax.tree.leaves(grad_l2_norms))
                 avg_grad_norm = sum_of_grad_norms / n_elements
-                
+
                 return train_state, (loss_val, aux_vals, avg_grad_norm)
 
             def _update_epoch(update_state, unused):
-                train_state, init_ego_hstate, traj_batch, advantages, targets, rng = update_state
+                train_state, init_ego_hstate, traj_batch, advantages, targets, rng = (
+                    update_state
+                )
                 rng, perm_rng = jax.random.split(rng)
                 minibatches = _create_minibatches(
-                    traj_batch, 
-                    advantages, 
-                    targets, 
-                    init_ego_hstate, 
-                    config["NUM_CONTROLLED_ACTORS"], 
-                    config["NUM_MINIBATCHES"], 
-                    perm_rng
+                    traj_batch,
+                    advantages,
+                    targets,
+                    init_ego_hstate,
+                    config["NUM_CONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng,
                 )
                 train_state, losses_and_grads = jax.lax.scan(
                     _update_minbatch, train_state, minibatches
                 )
-                update_state = (train_state, init_ego_hstate, traj_batch, advantages, targets, rng)
+                update_state = (
+                    train_state,
+                    init_ego_hstate,
+                    traj_batch,
+                    advantages,
+                    targets,
+                    rng,
+                )
                 return update_state, losses_and_grads
 
             def _update_step(update_runner_state, unused):
@@ -315,27 +412,62 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                 rng, reset_rng, p_rng = jax.random.split(rng, 3)
                 reset_rngs = jax.random.split(reset_rng, config["NUM_ENVS"])
                 init_obs, init_env_state = jax.vmap(env.reset, in_axes=(0,))(reset_rngs)
-                init_done = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
+                init_done = {
+                    k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                    for k in env.agents + ["__all__"]
+                }
                 new_partner_indices, buffer = partner_population.sample_agent_indices(
-                    last_buffer, config["NUM_UNCONTROLLED_ACTORS"], p_rng)
+                    last_buffer, config["NUM_UNCONTROLLED_ACTORS"], p_rng
+                )
 
                 # 1) rollout
-                runner_state = (train_state, init_env_state, init_obs, init_done, 
-                                init_ego_hstate, init_partner_hstate, 
-                                buffer, new_partner_indices, rng)
+                runner_state = (
+                    train_state,
+                    init_env_state,
+                    init_obs,
+                    init_done,
+                    init_ego_hstate,
+                    init_partner_hstate,
+                    buffer,
+                    new_partner_indices,
+                    rng,
+                )
 
                 runner_state, traj_batch = jax.lax.scan(
-                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"])
-                (train_state, env_state, obs, done, ego_hstate, partner_hstate, 
-                 buffer, partner_indices, rng) = runner_state
+                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    train_state,
+                    env_state,
+                    obs,
+                    done,
+                    ego_hstate,
+                    _partner_hstate,
+                    buffer,
+                    _partner_indices,
+                    rng,
+                ) = runner_state
 
                 # 2) advantage
                 # Stack augmented ego obs for the last value estimate
-                obs_ego_last, _ = augment_all_obs(obs, ego_indices, teammate_indices, num_agents, config["NUM_ENVS"], augment_obs=augment_obs)
+                obs_ego_last, _ = augment_all_obs(
+                    obs,
+                    ego_indices,
+                    teammate_indices,
+                    num_agents,
+                    config["NUM_ENVS"],
+                    augment_obs=augment_obs,
+                )
                 dones_ego_last = augment_done(done, ego_indices, config["NUM_ENVS"])
                 avail_actions_ego_last = jnp.concatenate(
-                    [jax.vmap(env.get_avail_actions)(env_state.env_state)[f'agent_{i}'].astype(jnp.float32)
-                     for i in ego_indices], axis=0)
+                    [
+                        jax.vmap(env.get_avail_actions)(env_state.env_state)[
+                            f"agent_{i}"
+                        ].astype(jnp.float32)
+                        for i in ego_indices
+                    ],
+                    axis=0,
+                )
 
                 # Get final value estimate for completed trajectory
                 _, last_val, _, _ = ego_policy.get_action_value_policy(
@@ -344,7 +476,7 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                     done=dones_ego_last.reshape(1, config["NUM_CONTROLLED_ACTORS"]),
                     avail_actions=jax.lax.stop_gradient(avail_actions_ego_last),
                     hstate=ego_hstate,
-                    rng=jax.random.PRNGKey(0)
+                    rng=jax.random.PRNGKey(0),
                 )
                 last_val = last_val.squeeze()
                 advantages, targets = _calculate_gae(traj_batch, last_val)
@@ -352,14 +484,15 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                 # 3) PPO update
                 update_state = (
                     train_state,
-                    init_ego_hstate, # shape is (num_controlled_actors, gru_hidden_dim) with all-0s value
-                    traj_batch, # obs has shape (rollout_len, num_controlled_actors, -1)
+                    init_ego_hstate,  # shape is (num_controlled_actors, gru_hidden_dim) with all-0s value
+                    traj_batch,  # obs has shape (rollout_len, num_controlled_actors, -1)
                     advantages,
                     targets,
-                    rng
+                    rng,
                 )
                 update_state, losses_and_grads = jax.lax.scan(
-                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                )
                 train_state = update_state[0]
                 _, loss_terms, avg_grad_norm = losses_and_grads
 
@@ -367,7 +500,9 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                 def mask_and_mean(x, mask):
                     return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
 
-                mask = traj_batch.info.get("returned_episode", jnp.ones_like(traj_batch.reward))
+                mask = traj_batch.info.get(
+                    "returned_episode", jnp.ones_like(traj_batch.reward)
+                )
                 metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch.info)
                 metric["update_steps"] = update_steps
                 metric["actor_loss"] = loss_terms[1].mean()
@@ -385,75 +520,92 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                 return (new_runner_state, metric)
 
             # 3e) PPO Update and Checkpoint saving
-            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)  # -1 because we store a ckpt at the last update
+            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                1, config["NUM_CHECKPOINTS"] - 1
+            )  # -1 because we store a ckpt at the last update
             num_ckpts = config["NUM_CHECKPOINTS"]
 
             # Build a PyTree that holds parameters for all FCP checkpoints
             def init_ckpt_array(params_pytree):
                 return jax.tree.map(
-                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), 
-                    params_pytree)
+                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
+                )
 
             max_episode_steps = config["ROLLOUT_LENGTH"]
-            
+
             def _update_step_with_ckpt(state_with_ckpt, unused):
-                (update_state, checkpoint_array, ckpt_idx, init_eval_last_info) = state_with_ckpt
+                (update_state, checkpoint_array, ckpt_idx, init_eval_last_info) = (
+                    state_with_ckpt
+                )
 
                 # Single PPO update
-                (new_update_state, metric) = _update_step(
-                    update_state,
-                    None
-                )
+                (new_update_state, metric) = _update_step(update_state, None)
                 (train_state, buffer, rng, update_steps) = new_update_state
 
                 # Decide if we store a checkpoint
                 # update steps is 1-indexed because it was incremented at the end of the update step
-                to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                        jnp.equal(update_steps, config["NUM_UPDATES"]))
+                to_store = jnp.logical_or(
+                    jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
+                )
 
                 def store_and_eval_ckpt(args):
-                    ckpt_arr, cidx, rng, prev_eval_ret_info = args
+                    ckpt_arr, cidx, rng, _prev_eval_ret_info = args
                     new_ckpt_arr = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr, train_state.params
+                        ckpt_arr,
+                        train_state.params,
                     )
                     rng, eval_rng, partner_rng = jax.random.split(rng, 3)
-                    
+
                     # Sample partners from buffer for evaluation
                     # we do not return the updated buffer because we don't want evaluation to impact the buffer distribution
-                    partner_indices, eval_buffer = partner_population.sample_agent_indices(
-                        buffer, config["NUM_EVAL_EPISODES"], partner_rng
+                    partner_indices, eval_buffer = (
+                        partner_population.sample_agent_indices(
+                            buffer, config["NUM_EVAL_EPISODES"], partner_rng
+                        )
                     )
-                    
+
                     # Gather parameters for sampled partners
                     gathered_params = partner_population.gather_agent_params(
                         eval_buffer, partner_indices
                     )
-                    
+
                     # Run evaluation with sampled partners
                     eval_eps_last_infos = jax.vmap(
                         lambda partner_p: run_n_agent_episodes(
-                            eval_rng, env,
-                            ego_policy=ego_policy, ego_param=train_state.params,
-                            teammate_policy=partner_population.policy_cls, teammate_param=partner_p,
-                            ego_indices=ego_indices, teammate_indices=teammate_indices,
+                            eval_rng,
+                            env,
+                            ego_policy=ego_policy,
+                            ego_param=train_state.params,
+                            teammate_policy=partner_population.policy_cls,
+                            teammate_param=partner_p,
+                            ego_indices=ego_indices,
+                            teammate_indices=teammate_indices,
                             max_episode_steps=max_episode_steps,
-                            num_eps=config["NUM_EVAL_EPISODES"]
+                            num_eps=config["NUM_EVAL_EPISODES"],
                         )
                     )(gathered_params)
                     return (new_ckpt_arr, cidx + 1, rng, eval_eps_last_infos)
-                
+
                 def skip_ckpt(args):
                     return args
 
                 (checkpoint_array, ckpt_idx, rng, eval_last_infos) = jax.lax.cond(
-                    to_store, store_and_eval_ckpt, skip_ckpt, (checkpoint_array, ckpt_idx, rng, init_eval_last_info)
+                    to_store,
+                    store_and_eval_ckpt,
+                    skip_ckpt,
+                    (checkpoint_array, ckpt_idx, rng, init_eval_last_info),
                 )
                 # Add evaluation info to metrics
                 metric["eval_ep_last_info"] = eval_last_infos
 
-                return ((train_state, buffer, rng, update_steps),
-                         checkpoint_array, ckpt_idx, eval_last_infos), metric
+                return (
+                    (train_state, buffer, rng, update_steps),
+                    checkpoint_array,
+                    ckpt_idx,
+                    eval_last_infos,
+                ), metric
 
             # init checkpoint array
             checkpoint_array = init_ckpt_array(train_state.params)
@@ -461,26 +613,30 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
 
             # Init eval return infos
             rng, rng_eval, partner_rng, rng_train = jax.random.split(rng, 4)
-            
+
             # Sample partners for initial evaluation
             # we do not update the buffer because we don't want evaluation to impact the buffer distribution
             eval_partner_indices, eval_buffer = partner_population.sample_agent_indices(
                 population_buffer, config["NUM_EVAL_EPISODES"], partner_rng
             )
-            
+
             # Gather parameters for partners
             gathered_params = partner_population.gather_agent_params(
                 eval_buffer, eval_partner_indices
             )
-            
+
             eval_eps_last_infos = jax.vmap(
                 lambda partner_p: run_n_agent_episodes(
-                    rng_eval, env,
-                    ego_policy=ego_policy, ego_param=train_state.params,
-                    teammate_policy=partner_population.policy_cls, teammate_param=partner_p,
-                    ego_indices=ego_indices, teammate_indices=teammate_indices,
+                    rng_eval,
+                    env,
+                    ego_policy=ego_policy,
+                    ego_param=train_state.params,
+                    teammate_policy=partner_population.policy_cls,
+                    teammate_param=partner_p,
+                    ego_indices=ego_indices,
+                    teammate_indices=teammate_indices,
                     max_episode_steps=max_episode_steps,
-                    num_eps=config["NUM_EVAL_EPISODES"]
+                    num_eps=config["NUM_EVAL_EPISODES"],
                 )
             )(gathered_params)
 
@@ -490,18 +646,28 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                 train_state,
                 population_buffer,
                 rng_train,
-                update_steps
+                update_steps,
             )
-            state_with_ckpt = (update_runner_state, checkpoint_array, ckpt_idx, eval_eps_last_infos)
-            
+            state_with_ckpt = (
+                update_runner_state,
+                checkpoint_array,
+                ckpt_idx,
+                eval_eps_last_infos,
+            )
+
             # run training
             state_with_ckpt, metrics = jax.lax.scan(
                 _update_step_with_ckpt,
                 state_with_ckpt,
                 xs=None,
-                length=config["NUM_UPDATES"]
+                length=config["NUM_UPDATES"],
             )
-            (final_update_state, checkpoint_array, final_ckpt_idx, eval_eps_last_infos) = state_with_ckpt
+            (
+                final_update_state,
+                checkpoint_array,
+                _final_ckpt_idx,
+                eval_eps_last_infos,
+            ) = state_with_ckpt
             final_train_state, final_buffer, _, _ = final_update_state
             out = {
                 "final_params": final_train_state.params,
@@ -510,6 +676,7 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                 "final_buffer": final_buffer,
             }
             return out
+
         return train
 
     # ------------------------------
@@ -517,5 +684,5 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
     # ------------------------------
     rngs = jax.random.split(train_rng, n_ego_train_seeds)
     train_fn = jax.jit(jax.vmap(make_ppo_train(config)))
-    out = train_fn(rngs)    
-    return out 
+    out = train_fn(rngs)
+    return out

--- a/open_ended_training/ppo_ego_with_buffer.py
+++ b/open_ended_training/ppo_ego_with_buffer.py
@@ -202,7 +202,8 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                     log_prob=logp_ego,         # (NUM_CONTROLLED_ACTORS,)
                     obs=obs_ego,               # (NUM_CONTROLLED_ACTORS, aug_obs_dim)
                     info=info_ego,
-                    avail_actions=avail_actions_ego  # (NUM_CONTROLLED_ACTORS, n_actions)
+                    avail_actions=avail_actions_ego,  # (NUM_CONTROLLED_ACTORS, n_actions)
+                    prev_done=dones_ego                # (NUM_CONTROLLED_ACTORS,) pre-step done
                 )
                 new_runner_state = (train_state, env_state_next, obs_next, done,
                                     new_ego_hstate, new_partner_hstate, updated_buffer,
@@ -239,7 +240,7 @@ def train_ppo_ego_agent_with_buffer(config, env, train_rng,
                     _, value, pi, _ = ego_policy.get_action_value_policy(
                         params=params, 
                         obs=traj_batch.obs,
-                        done=traj_batch.done,
+                        done=traj_batch.prev_done,
                         avail_actions=traj_batch.avail_actions,
                         hstate=init_ego_hstate,
                         rng=jax.random.PRNGKey(0) # only used for action sampling, which is unused here

--- a/open_ended_training/rotate.py
+++ b/open_ended_training/rotate.py
@@ -1,4 +1,4 @@
-'''Implementation of the ROTATE algorithm (Wang et al. 2025)
+"""Implementation of the ROTATE algorithm (Wang et al. 2025)
 https://arxiv.org/abs/2505.23686
 
 Supports N-agent environments via EGO_INDICES in the task config. Belief-model
@@ -6,42 +6,61 @@ support for partial observability is not included.
 
 Suggested debug command:
 python open_ended_training/run.py algorithm=rotate/lbf/lbf_7x7_nolevels task=lbf label=test_rotate logger.mode=offline algorithm.NUM_OPEN_ENDED_ITERS=1 algorithm.TIMESTEPS_PER_ITER_PARTNER=1e5 algorithm.TIMESTEPS_PER_ITER_EGO=1e5
-'''
+"""
+
 import copy
-from functools import partial
 import logging
-from typing import NamedTuple
 import shutil
 import time
-from tqdm import tqdm
+from functools import partial
+from typing import NamedTuple
 
-import numpy as np
+import hydra
 import jax
 import jax.numpy as jnp
+import numpy as np
 import optax
 from flax.training.train_state import TrainState
-import hydra
+from tqdm import tqdm
 
-from agents.mlp_actor_critic_agent import ActorWithDoubleCriticPolicy, MLPActorCriticPolicy
-from agents.s5_actor_critic_agent import S5ActorCriticPolicy, S5ActorWithDoubleCriticPolicy
-from agents.population_buffer import BufferedPopulation, add_partners_to_buffer, get_final_buffer
-from agents.initialize_agents import initialize_s5_agent, initialize_mlp_agent, \
-    initialize_actor_with_double_critic, initialize_s5_actor_with_double_critic
-from common.n_agent_utils import (
-    get_ego_teammate_indices, augment_obs_with_id,
-    augment_all_obs, augment_done, split_actions
+from agents.initialize_agents import (
+    initialize_actor_with_double_critic,
+    initialize_mlp_agent,
+    initialize_s5_actor_with_double_critic,
+    initialize_s5_agent,
 )
-from common.run_n_agent_episodes import run_n_agent_episodes
+from agents.mlp_actor_critic_agent import (
+    ActorWithDoubleCriticPolicy,
+    MLPActorCriticPolicy,
+)
+from agents.population_buffer import (
+    BufferedPopulation,
+    add_partners_to_buffer,
+    get_final_buffer,
+)
+from agents.s5_actor_critic_agent import (
+    S5ActorCriticPolicy,
+    S5ActorWithDoubleCriticPolicy,
+)
 from common.live_log_utils import make_live_log_callback
+from common.n_agent_utils import (
+    augment_all_obs,
+    augment_done,
+    augment_obs_with_id,
+    get_ego_teammate_indices,
+    split_actions,
+)
 from common.plot_utils import get_metric_names
+from common.run_n_agent_episodes import run_n_agent_episodes
 from common.save_load_utils import save_train_run
-from marl.ppo_utils import Transition, _create_minibatches
 from envs import make_env
-from envs.log_wrapper import LogWrapper, LogEnvState
+from envs.log_wrapper import LogEnvState, LogWrapper
+from marl.ppo_utils import Transition, _create_minibatches
 from open_ended_training.ppo_ego_with_buffer import (
-    train_ppo_ego_agent_with_buffer,
+    EGO_LIVE_LOSS_KEYS,
+    EGO_LIVE_RETURNS_PREFIX,
     compute_ego_num_updates,
-    EGO_LIVE_LOSS_KEYS, EGO_LIVE_RETURNS_PREFIX
+    train_ppo_ego_agent_with_buffer,
 )
 
 log = logging.getLogger(__name__)
@@ -68,19 +87,21 @@ PARTNER_LIVE_RETURNS_PREFIX = "Train/ConfEgo"
 
 
 class ResetTransition(NamedTuple):
-    '''Stores extra information for resetting agents to a point in some trajectory.
-    
+    """Stores extra information for resetting agents to a point in some trajectory.
+
     conf_obs / partner_obs are stacked over all teammate/ego slots respectively,
     shape (n_role * NUM_ENVS, obs_dim+N) where N = num_agents.
     conf_done / partner_done are shape (n_role * NUM_ENVS,).
-    '''
+    """
+
     env_state: LogEnvState
-    conf_obs: jnp.ndarray    # shape (n_teammates * num_envs, aug_obs_dim)
-    partner_obs: jnp.ndarray # shape (n_ego * num_envs, aug_obs_dim)
-    conf_done: jnp.ndarray   # shape (n_teammates * num_envs,)
-    partner_done: jnp.ndarray # shape (n_ego * num_envs,)
+    conf_obs: jnp.ndarray  # shape (n_teammates * num_envs, aug_obs_dim)
+    partner_obs: jnp.ndarray  # shape (n_ego * num_envs, aug_obs_dim)
+    conf_done: jnp.ndarray  # shape (n_teammates * num_envs,)
+    partner_done: jnp.ndarray  # shape (n_ego * num_envs,)
     conf_hstate: jnp.ndarray
     partner_hstate: jnp.ndarray
+
 
 class ConfTransition(NamedTuple):
     done: jnp.ndarray
@@ -94,21 +115,32 @@ class ConfTransition(NamedTuple):
     avail_actions: jnp.ndarray
     prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
+
 def compute_partner_num_updates(cfg):
     return int(
         cfg["TIMESTEPS_PER_ITER_PARTNER"]
         // (cfg["ROLLOUT_LENGTH"] * 4 * cfg["NUM_ENVS"] * cfg["PARTNER_POP_SIZE"])
     )
 
-def train_regret_maximizing_partners(config, env, 
-                                     ego_params, ego_policy, 
-                                     conf_params, conf_policy, 
-                                     br_params, br_policy, partner_rng,
-                                     logger=None, progress_callback=None):
-    '''
+
+def train_regret_maximizing_partners(
+    config,
+    env,
+    ego_params,
+    ego_policy,
+    conf_params,
+    conf_policy,
+    br_params,
+    br_policy,
+    partner_rng,
+    logger=None,
+    progress_callback=None,
+):
+    """
     Train regret-maximizing confederate/best-response pairs using the given ego agent policy and IPPO.
-    Return model checkpoints and metrics. 
-    '''
+    Return model checkpoints and metrics.
+    """
+
     def make_regret_maximizing_partner_train(config):
         num_agents = env.num_agents
         ego_indices, teammate_indices = get_ego_teammate_indices(config, env)
@@ -122,32 +154,49 @@ def train_regret_maximizing_partners(config, env,
         config["NUM_CONTROLLED_ACTORS"] = n_ego * config["NUM_ENVS"]
         config["NUM_UNCONTROLLED_ACTORS"] = n_teammates * config["NUM_ENVS"]
 
-        # Divide by 4 because there are 4 types of rollouts 
+        # Divide by 4 because there are 4 types of rollouts
         config["NUM_UPDATES"] = compute_partner_num_updates(config)
         # Sanity-check minibatch sizes for both roles
-        for role, n_actors in [("conf (uncontrolled)", config["NUM_UNCONTROLLED_ACTORS"]),
-                               ("ego/BR (controlled)", config["NUM_CONTROLLED_ACTORS"])]:
-            assert n_actors % config["NUM_MINIBATCHES"] == 0, \
+        for role, n_actors in [
+            ("conf (uncontrolled)", config["NUM_UNCONTROLLED_ACTORS"]),
+            ("ego/BR (controlled)", config["NUM_CONTROLLED_ACTORS"]),
+        ]:
+            assert n_actors % config["NUM_MINIBATCHES"] == 0, (
                 f"{role}: NUM_ACTORS ({n_actors}) must be divisible by NUM_MINIBATCHES ({config['NUM_MINIBATCHES']})"
-            assert n_actors >= config["NUM_MINIBATCHES"], \
+            )
+            assert n_actors >= config["NUM_MINIBATCHES"], (
                 f"{role}: NUM_ACTORS ({n_actors}) must be >= NUM_MINIBATCHES ({config['NUM_MINIBATCHES']})"
+            )
 
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng, init_params_conf, init_params_br):
             confederate_policy = conf_policy
-            
+
             # Define optimizers for both confederate and BR policy
             tx = optax.chain(
                 optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"], 
-                eps=1e-5),
+                optax.adam(
+                    learning_rate=linear_schedule
+                    if config["ANNEAL_LR"]
+                    else config["LR"],
+                    eps=1e-5,
+                ),
             )
             tx_br = optax.chain(
                 optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"], eps=1e-5),
+                optax.adam(
+                    learning_rate=linear_schedule
+                    if config["ANNEAL_LR"]
+                    else config["LR"],
+                    eps=1e-5,
+                ),
             )
             train_state_conf = TrainState.create(
                 apply_fn=confederate_policy.network.apply,
@@ -161,165 +210,290 @@ def train_regret_maximizing_partners(config, env,
                 tx=tx_br,
             )
 
-            def _reset_to_states(reset_traj_batch, env_state, last_obs, last_dones, last_conf_h, last_partner_h,
-                                 init_partner_hstate, rng, partner_is_br: bool):
-                '''Resets the env_state and hstates to values in reset_traj_batch for done environments.
+            def _reset_to_states(
+                reset_traj_batch,
+                env_state,
+                last_obs,
+                last_dones,
+                last_conf_h,
+                last_partner_h,
+                init_partner_hstate,
+                rng,
+                partner_is_br: bool,
+            ):
+                """Resets the env_state and hstates to values in reset_traj_batch for done environments.
 
                 conf_obs / partner_obs in reset_traj_batch are stacked over role slots:
                   shape (ROLLOUT_LENGTH, n_role * NUM_ENVS, aug_obs_dim).
                 We sample a (timestep, env) pair and gather accordingly.
-                '''
+                """
 
                 def gather_sampled(data_pytree, flat_indices, first_nonbatch_dim: int):
-                    '''Sample from (ROLLOUT_LENGTH, NUM_ENVS, ...) using flat indices in [0, RL*NE).'''
+                    """Sample from (ROLLOUT_LENGTH, NUM_ENVS, ...) using flat indices in [0, RL*NE)."""
                     batch_size = config["ROLLOUT_LENGTH"] * config["NUM_ENVS"]
-                    flat_data = jax.tree.map(lambda x: x.reshape(batch_size, *x.shape[first_nonbatch_dim:]), data_pytree)
+                    flat_data = jax.tree.map(
+                        lambda x: x.reshape(batch_size, *x.shape[first_nonbatch_dim:]),
+                        data_pytree,
+                    )
                     sampled_data = jax.tree.map(lambda x: x[flat_indices], flat_data)
                     return sampled_data
 
                 def gather_role_obs(obs_array, flat_indices, n_role):
-                    '''Sample from (ROLLOUT_LENGTH, n_role * NUM_ENVS, aug_obs_dim)
+                    """Sample from (ROLLOUT_LENGTH, n_role * NUM_ENVS, aug_obs_dim)
                     using flat_indices in [0, ROLLOUT_LENGTH * NUM_ENVS).
 
                     Returns shape (NUM_ENVS, n_role, aug_obs_dim), then reshape to
                     (n_role * NUM_ENVS, aug_obs_dim) for direct use.
-                    '''
+                    """
                     rl = config["ROLLOUT_LENGTH"]
                     ne = config["NUM_ENVS"]
                     aug = obs_array.shape[-1]
                     # (rl, n_role * ne, aug) -> (rl, n_role, ne, aug) -> (rl, ne, n_role, aug)
-                    reshaped = obs_array.reshape(rl, n_role, ne, aug).transpose(0, 2, 1, 3)
+                    reshaped = obs_array.reshape(rl, n_role, ne, aug).transpose(
+                        0, 2, 1, 3
+                    )
                     # flatten (rl, ne) -> (rl*ne, n_role, aug), then gather
                     flat = reshaped.reshape(rl * ne, n_role, aug)
-                    sampled = flat[flat_indices]    # (ne, n_role, aug)
+                    sampled = flat[flat_indices]  # (ne, n_role, aug)
                     # transpose back to (n_role, ne, aug) to restore flat slot structure
                     return sampled.transpose(1, 0, 2).reshape(n_role * ne, aug)
 
                 def gather_role_done(done_array, flat_indices, n_role):
-                    '''Same as gather_role_obs but for 1-D done flags.
+                    """Same as gather_role_obs but for 1-D done flags.
                     done_array: (ROLLOUT_LENGTH, n_role * NUM_ENVS)
                     Returns: (n_role * NUM_ENVS,)
-                    '''
+                    """
                     rl = config["ROLLOUT_LENGTH"]
                     ne = config["NUM_ENVS"]
-                    reshaped = done_array.reshape(rl, n_role, ne).transpose(0, 2, 1)  # (rl, ne, n_role)
+                    reshaped = done_array.reshape(rl, n_role, ne).transpose(
+                        0, 2, 1
+                    )  # (rl, ne, n_role)
                     flat = reshaped.reshape(rl * ne, n_role)
-                    sampled = flat[flat_indices]    # (ne, n_role)
+                    sampled = flat[flat_indices]  # (ne, n_role)
                     # transpose back to (n_role, ne) to restore flat slot structure
                     return sampled.transpose(1, 0).reshape(n_role * ne)
 
                 def gather_role_hstate(hstate_pytree, flat_indices, n_role):
-                    '''Sample from (ROLLOUT_LENGTH, n_layers, n_role * NUM_ENVS, ssm_size)
-                    which is the S5 recurrent state topology. 
-                    '''
+                    """Sample from (ROLLOUT_LENGTH, n_layers, n_role * NUM_ENVS, ssm_size)
+                    which is the S5 recurrent state topology.
+                    """
                     rl = config["ROLLOUT_LENGTH"]
                     ne = config["NUM_ENVS"]
+
                     def _gather_h(h):
                         n_layers = h.shape[1]
                         ssm_size = h.shape[3]
                         # (rl, n_layers, n_role*ne, ssm) -> (rl, n_layers, n_role, ne, ssm) -> (rl, ne, n_layers, n_role, ssm)
-                        reshaped = h.reshape(rl, n_layers, n_role, ne, ssm_size).transpose(0, 3, 1, 2, 4)
+                        reshaped = h.reshape(
+                            rl, n_layers, n_role, ne, ssm_size
+                        ).transpose(0, 3, 1, 2, 4)
                         flat = reshaped.reshape(rl * ne, n_layers, n_role, ssm_size)
-                        sampled = flat[flat_indices] # (ne, n_layers, n_role, ssm_size)
+                        sampled = flat[flat_indices]  # (ne, n_layers, n_role, ssm_size)
                         # -> (n_layers, n_role, ne, ssm_size) to match original memory grouping semantics
                         sampled = sampled.transpose(1, 2, 0, 3)
                         return sampled.reshape(n_layers, n_role * ne, ssm_size)
+
                     return jax.tree.map(_gather_h, hstate_pytree)
 
                 rng, sample_rng = jax.random.split(rng)
                 needs_resample = last_dones["__all__"]  # (num_envs,)
 
                 total_reset_states = config["ROLLOUT_LENGTH"] * config["NUM_ENVS"]
-                sampled_indices = jax.random.randint(sample_rng, shape=(config["NUM_ENVS"],),
-                                                     minval=0, maxval=total_reset_states)
+                sampled_indices = jax.random.randint(
+                    sample_rng,
+                    shape=(config["NUM_ENVS"],),
+                    minval=0,
+                    maxval=total_reset_states,
+                )
 
-                sampled_env_state = gather_sampled(reset_traj_batch.env_state, sampled_indices, first_nonbatch_dim=2)
+                sampled_env_state = gather_sampled(
+                    reset_traj_batch.env_state, sampled_indices, first_nonbatch_dim=2
+                )
 
-                sampled_conf_obs = gather_role_obs(reset_traj_batch.conf_obs, sampled_indices, n_teammates)
-                sampled_partner_obs = gather_role_obs(reset_traj_batch.partner_obs, sampled_indices, n_ego)
-                sampled_conf_done = gather_role_done(reset_traj_batch.conf_done, sampled_indices, n_teammates)
-                sampled_partner_done = gather_role_done(reset_traj_batch.partner_done, sampled_indices, n_ego)
+                sampled_conf_obs = gather_role_obs(
+                    reset_traj_batch.conf_obs, sampled_indices, n_teammates
+                )
+                sampled_partner_obs = gather_role_obs(
+                    reset_traj_batch.partner_obs, sampled_indices, n_ego
+                )
+                sampled_conf_done = gather_role_done(
+                    reset_traj_batch.conf_done, sampled_indices, n_teammates
+                )
+                sampled_partner_done = gather_role_done(
+                    reset_traj_batch.partner_done, sampled_indices, n_ego
+                )
 
                 env_state = jax.tree.map(
                     lambda sampled, original: jnp.where(
                         needs_resample.reshape((-1,) + (1,) * (original.ndim - 1)),
-                        sampled, original
+                        sampled,
+                        original,
                     ),
                     sampled_env_state,
-                    env_state
+                    env_state,
                 )
 
                 # sampled_conf_obs: (n_tm * num_envs, aug_obs_dim) — already in the right layout
-                conf_needs = jnp.tile(needs_resample, n_teammates)  # (n_teammates * num_envs,)
-                obs_conf = jnp.where(conf_needs[:, jnp.newaxis], sampled_conf_obs, last_obs["__conf__"])
+                conf_needs = jnp.tile(
+                    needs_resample, n_teammates
+                )  # (n_teammates * num_envs,)
+                obs_conf = jnp.where(
+                    conf_needs[:, jnp.newaxis], sampled_conf_obs, last_obs["__conf__"]
+                )
 
                 ego_needs = jnp.tile(needs_resample, n_ego)  # (n_ego * num_envs,)
-                obs_ego = jnp.where(ego_needs[:, jnp.newaxis], sampled_partner_obs, last_obs["__ego__"])
+                obs_ego = jnp.where(
+                    ego_needs[:, jnp.newaxis], sampled_partner_obs, last_obs["__ego__"]
+                )
 
-                dones_conf = jnp.where(conf_needs, sampled_conf_done, last_dones["__conf__"])
-                dones_ego = jnp.where(ego_needs, sampled_partner_done, last_dones["__ego__"])
+                dones_conf = jnp.where(
+                    conf_needs, sampled_conf_done, last_dones["__conf__"]
+                )
+                dones_ego = jnp.where(
+                    ego_needs, sampled_partner_done, last_dones["__ego__"]
+                )
 
                 # Reconstruct last_obs and last_dones with __conf__ / __ego__ synthetic keys
                 last_obs = {**last_obs, "__conf__": obs_conf, "__ego__": obs_ego}
-                last_dones = {**last_dones, "__conf__": dones_conf, "__ego__": dones_ego}
+                last_dones = {
+                    **last_dones,
+                    "__conf__": dones_conf,
+                    "__ego__": dones_ego,
+                }
 
                 if last_conf_h is not None:
-                    sampled_conf_hstate = gather_role_hstate(reset_traj_batch.conf_hstate, sampled_indices, n_teammates)
-                    conf_needs_h = jnp.tile(needs_resample, n_teammates)  # (n_teammates * num_envs,)
-                    
+                    sampled_conf_hstate = gather_role_hstate(
+                        reset_traj_batch.conf_hstate, sampled_indices, n_teammates
+                    )
+                    conf_needs_h = jnp.tile(
+                        needs_resample, n_teammates
+                    )  # (n_teammates * num_envs,)
+
                     last_conf_h = jax.tree.map(
-                        lambda sampled, original: jnp.where(conf_needs_h[jnp.newaxis, :, jnp.newaxis], sampled, original),
-                        sampled_conf_hstate, last_conf_h)
+                        lambda sampled, original: jnp.where(
+                            conf_needs_h[jnp.newaxis, :, jnp.newaxis], sampled, original
+                        ),
+                        sampled_conf_hstate,
+                        last_conf_h,
+                    )
 
                 if last_partner_h is not None:
                     if config["REINIT_BR_TO_EGO"] and partner_is_br:
-                        sample_partner_hstate = gather_role_hstate(reset_traj_batch.partner_hstate, sampled_indices, n_ego)
+                        sample_partner_hstate = gather_role_hstate(
+                            reset_traj_batch.partner_hstate, sampled_indices, n_ego
+                        )
                     else:
                         sample_partner_hstate = init_partner_hstate
-                    partner_needs_h = jnp.tile(needs_resample, n_ego)  # (n_ego * num_envs,)
+                    partner_needs_h = jnp.tile(
+                        needs_resample, n_ego
+                    )  # (n_ego * num_envs,)
                     last_partner_h = jax.tree.map(
-                        lambda sampled, original: jnp.where(partner_needs_h[jnp.newaxis, :, jnp.newaxis], sampled, original),
-                        sample_partner_hstate, last_partner_h)
+                        lambda sampled, original: jnp.where(
+                            partner_needs_h[jnp.newaxis, :, jnp.newaxis],
+                            sampled,
+                            original,
+                        ),
+                        sample_partner_hstate,
+                        last_partner_h,
+                    )
 
-                return env_state, obs_conf, obs_ego, dones_conf, dones_ego, last_conf_h, last_partner_h
-            
+                return (
+                    env_state,
+                    obs_conf,
+                    obs_ego,
+                    dones_conf,
+                    dones_ego,
+                    last_conf_h,
+                    last_partner_h,
+                )
+
             def _env_step_conf_ego(runner_state, unused):
                 """
                 Teammate slots = confederate; ego slots = ego.
                 Returns updated runner_state, a ConfTransition for the confederate, and a ResetTransition.
                 """
-                train_state_conf, env_state, last_obs, last_dones, last_conf_h, last_ego_h, reset_traj_batch, rng = runner_state
+                (
+                    train_state_conf,
+                    env_state,
+                    last_obs,
+                    last_dones,
+                    last_conf_h,
+                    last_ego_h,
+                    reset_traj_batch,
+                    rng,
+                ) = runner_state
                 rng, act_rng, partner_rng, step_rng = jax.random.split(rng, 4)
 
                 # Reset from conf-br states if provided
                 if reset_traj_batch is not None:
-                    env_state, obs_conf, obs_ego, dones_conf, dones_ego, last_conf_h, last_ego_h = _reset_to_states(
-                        reset_traj_batch, env_state, last_obs, last_dones,
-                        last_conf_h, last_ego_h, init_ego_hstate, rng, partner_is_br=False)
+                    (
+                        env_state,
+                        obs_conf,
+                        obs_ego,
+                        dones_conf,
+                        dones_ego,
+                        last_conf_h,
+                        last_ego_h,
+                    ) = _reset_to_states(
+                        reset_traj_batch,
+                        env_state,
+                        last_obs,
+                        last_dones,
+                        last_conf_h,
+                        last_ego_h,
+                        init_ego_hstate,
+                        rng,
+                        partner_is_br=False,
+                    )
                 else:
-                    obs_ego, obs_conf = augment_all_obs(last_obs, ego_indices, teammate_indices, num_agents, config["NUM_ENVS"], augment_obs=augment_obs)
-                    dones_conf = augment_done(last_dones, teammate_indices, config["NUM_ENVS"])
-                    dones_ego = augment_done(last_dones, ego_indices, config["NUM_ENVS"])
+                    obs_ego, obs_conf = augment_all_obs(
+                        last_obs,
+                        ego_indices,
+                        teammate_indices,
+                        num_agents,
+                        config["NUM_ENVS"],
+                        augment_obs=augment_obs,
+                    )
+                    dones_conf = augment_done(
+                        last_dones, teammate_indices, config["NUM_ENVS"]
+                    )
+                    dones_ego = augment_done(
+                        last_dones, ego_indices, config["NUM_ENVS"]
+                    )
 
                 # Get available actions - use first teammate slot for conf avail_actions (same avail for all)
-                avail_actions_vmap = jax.vmap(env.get_avail_actions)(env_state.env_state)
+                avail_actions_vmap = jax.vmap(env.get_avail_actions)(
+                    env_state.env_state
+                )
                 # Stack avail_actions for conf slots: (n_teammates * num_envs, n_actions)
                 avail_actions_conf = jnp.concatenate(
-                    [avail_actions_vmap[f'agent_{i}'].astype(jnp.float32) for i in teammate_indices], axis=0)
+                    [
+                        avail_actions_vmap[f"agent_{i}"].astype(jnp.float32)
+                        for i in teammate_indices
+                    ],
+                    axis=0,
+                )
                 avail_actions_ego = jnp.concatenate(
-                    [avail_actions_vmap[f'agent_{i}'].astype(jnp.float32) for i in ego_indices], axis=0)
+                    [
+                        avail_actions_vmap[f"agent_{i}"].astype(jnp.float32)
+                        for i in ego_indices
+                    ],
+                    axis=0,
+                )
 
                 # Confederate action (controls all teammate slots via parameter sharing)
-                act_conf, (val_ego, val_br), pi_conf, new_conf_h = confederate_policy.get_action_value_policy(
-                    params=train_state_conf.params,
-                    obs=obs_conf.reshape(1, config["NUM_UNCONTROLLED_ACTORS"], -1),
-                    done=dones_conf.reshape(1, config["NUM_UNCONTROLLED_ACTORS"]),
-                    avail_actions=jax.lax.stop_gradient(avail_actions_conf),
-                    hstate=last_conf_h,
-                    rng=act_rng
+                act_conf, (val_ego, val_br), pi_conf, new_conf_h = (
+                    confederate_policy.get_action_value_policy(
+                        params=train_state_conf.params,
+                        obs=obs_conf.reshape(1, config["NUM_UNCONTROLLED_ACTORS"], -1),
+                        done=dones_conf.reshape(1, config["NUM_UNCONTROLLED_ACTORS"]),
+                        avail_actions=jax.lax.stop_gradient(avail_actions_conf),
+                        hstate=last_conf_h,
+                        rng=act_rng,
+                    )
                 )
                 logp_conf = pi_conf.log_prob(act_conf)
-                act_conf = act_conf.squeeze()       # (n_teammates * num_envs,)
+                act_conf = act_conf.squeeze()  # (n_teammates * num_envs,)
                 logp_conf = logp_conf.squeeze()
                 val_ego = val_ego.squeeze()
                 val_br = val_br.squeeze()
@@ -331,57 +505,89 @@ def train_regret_maximizing_partners(config, env,
                     done=dones_ego.reshape(1, config["NUM_CONTROLLED_ACTORS"]),
                     avail_actions=jax.lax.stop_gradient(avail_actions_ego),
                     hstate=last_ego_h,
-                    rng=partner_rng
+                    rng=partner_rng,
                 )
-                act_ego = act_ego.squeeze()         # (n_ego * num_envs,)
+                act_ego = act_ego.squeeze()  # (n_ego * num_envs,)
 
                 # Reconstruct action dict and step env
-                env_act = split_actions(act_ego, act_conf, ego_indices, teammate_indices, config["NUM_ENVS"])
-                step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0, 0, 0))(
-                    step_rngs, env_state, env_act
+                env_act = split_actions(
+                    act_ego, act_conf, ego_indices, teammate_indices, config["NUM_ENVS"]
                 )
+                step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 info_conf = jax.tree.map(
-                    lambda x: jnp.concatenate([x[:, i] for i in teammate_indices], axis=0), 
-                    info
+                    lambda x: jnp.concatenate(
+                        [x[:, i] for i in teammate_indices], axis=0
+                    ),
+                    info,
                 )
 
                 # Stack conf reward per slot: (n_teammates * num_envs,) — one entry per teammate slot
                 conf_reward_stacked = jnp.concatenate(
-                    [reward[f'agent_{i}'] for i in teammate_indices], axis=0)  # (NUM_UNCONTROLLED_ACTORS,)
+                    [reward[f"agent_{i}"] for i in teammate_indices], axis=0
+                )  # (NUM_UNCONTROLLED_ACTORS,)
 
                 # Store confederate data for all NUM_UNCONTROLLED_ACTORS (n_teammates * NUM_ENVS)
-                conf_done_stacked = augment_done(done, teammate_indices, config["NUM_ENVS"])  # (NUM_UNCONTROLLED_ACTORS,)
+                conf_done_stacked = augment_done(
+                    done, teammate_indices, config["NUM_ENVS"]
+                )  # (NUM_UNCONTROLLED_ACTORS,)
                 transition = ConfTransition(
                     done=conf_done_stacked,
-                    action=act_conf,            # (NUM_UNCONTROLLED_ACTORS,)
-                    value=val_ego,              # (NUM_UNCONTROLLED_ACTORS,)
-                    other_value=val_br,         # (NUM_UNCONTROLLED_ACTORS,)
-                    reward=conf_reward_stacked, # confederate objective: confederate's own reward
-                    log_prob=logp_conf,         # (NUM_UNCONTROLLED_ACTORS,)
-                    obs=obs_conf,               # (NUM_UNCONTROLLED_ACTORS, aug_obs_dim)
+                    action=act_conf,  # (NUM_UNCONTROLLED_ACTORS,)
+                    value=val_ego,  # (NUM_UNCONTROLLED_ACTORS,)
+                    other_value=val_br,  # (NUM_UNCONTROLLED_ACTORS,)
+                    reward=conf_reward_stacked,  # confederate objective: confederate's own reward
+                    log_prob=logp_conf,  # (NUM_UNCONTROLLED_ACTORS,)
+                    obs=obs_conf,  # (NUM_UNCONTROLLED_ACTORS, aug_obs_dim)
                     info=info_conf,
                     avail_actions=avail_actions_conf,  # (NUM_UNCONTROLLED_ACTORS, n_actions)
-                    prev_done=dones_conf               # (NUM_UNCONTROLLED_ACTORS,) pre-step done
+                    prev_done=dones_conf,  # (NUM_UNCONTROLLED_ACTORS,) pre-step done
                 )
                 reset_transition = ResetTransition(
                     env_state=env_state,
-                    conf_obs=obs_conf,      # (n_teammates * num_envs, aug_obs_dim)
-                    partner_obs=obs_ego,    # (n_ego * num_envs, aug_obs_dim)
-                    conf_done=dones_conf,   # (n_teammates * num_envs,)
-                    partner_done=dones_ego, # (n_ego * num_envs,)
+                    conf_obs=obs_conf,  # (n_teammates * num_envs, aug_obs_dim)
+                    partner_obs=obs_ego,  # (n_ego * num_envs, aug_obs_dim)
+                    conf_done=dones_conf,  # (n_teammates * num_envs,)
+                    partner_done=dones_ego,  # (n_ego * num_envs,)
                     conf_hstate=last_conf_h,
-                    partner_hstate=last_ego_h
+                    partner_hstate=last_ego_h,
                 )
                 # Store augmented stacked obs in obs_next for _reset_to_states compatibility
                 obs_next["__conf__"] = jnp.concatenate(
-                    [augment_obs_with_id(obs_next[f'agent_{i}'], i, num_agents, augment_obs) for i in teammate_indices], axis=0)
+                    [
+                        augment_obs_with_id(
+                            obs_next[f"agent_{i}"], i, num_agents, augment_obs
+                        )
+                        for i in teammate_indices
+                    ],
+                    axis=0,
+                )
                 obs_next["__ego__"] = jnp.concatenate(
-                    [augment_obs_with_id(obs_next[f'agent_{i}'], i, num_agents, augment_obs) for i in ego_indices], axis=0)
-                done["__conf__"] = augment_done(done, teammate_indices, config["NUM_ENVS"])
+                    [
+                        augment_obs_with_id(
+                            obs_next[f"agent_{i}"], i, num_agents, augment_obs
+                        )
+                        for i in ego_indices
+                    ],
+                    axis=0,
+                )
+                done["__conf__"] = augment_done(
+                    done, teammate_indices, config["NUM_ENVS"]
+                )
                 done["__ego__"] = augment_done(done, ego_indices, config["NUM_ENVS"])
 
-                new_runner_state = (train_state_conf, env_state_next, obs_next, done, new_conf_h, new_ego_h, reset_traj_batch, rng)
+                new_runner_state = (
+                    train_state_conf,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_conf_h,
+                    new_ego_h,
+                    reset_traj_batch,
+                    rng,
+                )
                 return new_runner_state, (transition, reset_transition)
 
             def _env_step_conf_br(runner_state, unused):
@@ -390,32 +596,80 @@ def train_regret_maximizing_partners(config, env,
                 Returns updated runner_state, ConfTransition for the confederate,
                 Transition for the best response, and a ResetTransition.
                 """
-                train_state_conf, train_state_br, env_state, last_obs, last_dones, \
-                    last_conf_h, last_br_h, reset_traj_batch, rng = runner_state
+                (
+                    train_state_conf,
+                    train_state_br,
+                    env_state,
+                    last_obs,
+                    last_dones,
+                    last_conf_h,
+                    last_br_h,
+                    reset_traj_batch,
+                    rng,
+                ) = runner_state
                 rng, conf_rng, br_rng, step_rng = jax.random.split(rng, 4)
 
                 if reset_traj_batch is not None:
-                    env_state, obs_conf, obs_br, dones_conf, dones_br, last_conf_h, last_br_h = _reset_to_states(
-                        reset_traj_batch, env_state, last_obs, last_dones,
-                        last_conf_h, last_br_h, init_br_hstate, rng, partner_is_br=True)
+                    (
+                        env_state,
+                        obs_conf,
+                        obs_br,
+                        dones_conf,
+                        dones_br,
+                        last_conf_h,
+                        last_br_h,
+                    ) = _reset_to_states(
+                        reset_traj_batch,
+                        env_state,
+                        last_obs,
+                        last_dones,
+                        last_conf_h,
+                        last_br_h,
+                        init_br_hstate,
+                        rng,
+                        partner_is_br=True,
+                    )
                 else:
-                    obs_br, obs_conf = augment_all_obs(last_obs, ego_indices, teammate_indices, num_agents, config["NUM_ENVS"], augment_obs=augment_obs)
-                    dones_conf = augment_done(last_dones, teammate_indices, config["NUM_ENVS"])
+                    obs_br, obs_conf = augment_all_obs(
+                        last_obs,
+                        ego_indices,
+                        teammate_indices,
+                        num_agents,
+                        config["NUM_ENVS"],
+                        augment_obs=augment_obs,
+                    )
+                    dones_conf = augment_done(
+                        last_dones, teammate_indices, config["NUM_ENVS"]
+                    )
                     dones_br = augment_done(last_dones, ego_indices, config["NUM_ENVS"])
 
-                avail_actions_vmap = jax.vmap(env.get_avail_actions)(env_state.env_state)
+                avail_actions_vmap = jax.vmap(env.get_avail_actions)(
+                    env_state.env_state
+                )
                 avail_actions_conf = jnp.concatenate(
-                    [avail_actions_vmap[f'agent_{i}'].astype(jnp.float32) for i in teammate_indices], axis=0)
+                    [
+                        avail_actions_vmap[f"agent_{i}"].astype(jnp.float32)
+                        for i in teammate_indices
+                    ],
+                    axis=0,
+                )
                 avail_actions_br = jnp.concatenate(
-                    [avail_actions_vmap[f'agent_{i}'].astype(jnp.float32) for i in ego_indices], axis=0)
+                    [
+                        avail_actions_vmap[f"agent_{i}"].astype(jnp.float32)
+                        for i in ego_indices
+                    ],
+                    axis=0,
+                )
 
-                act_conf, (val_ego, val_br), pi_conf, new_conf_h = confederate_policy.get_action_value_policy(
-                    params=train_state_conf.params,
-                    obs=obs_conf.reshape(1, config["NUM_UNCONTROLLED_ACTORS"], -1),
-                    done=dones_conf.reshape(1, config["NUM_UNCONTROLLED_ACTORS"]),
-                    avail_actions=jax.lax.stop_gradient(avail_actions_conf),
-                    hstate=last_conf_h,
-                    rng=conf_rng
+                act_conf, (val_ego, val_br), pi_conf, new_conf_h = (
+                    confederate_policy.get_action_value_policy(
+                        params=train_state_conf.params,
+                        obs=obs_conf.reshape(1, config["NUM_UNCONTROLLED_ACTORS"], -1),
+                        done=dones_conf.reshape(1, config["NUM_UNCONTROLLED_ACTORS"]),
+                        avail_actions=jax.lax.stop_gradient(avail_actions_conf),
+                        hstate=last_conf_h,
+                        rng=conf_rng,
+                    )
                 )
                 logp_conf = pi_conf.log_prob(act_conf)
                 act_conf = act_conf.squeeze()
@@ -429,58 +683,68 @@ def train_regret_maximizing_partners(config, env,
                     done=dones_br.reshape(1, config["NUM_CONTROLLED_ACTORS"]),
                     avail_actions=jax.lax.stop_gradient(avail_actions_br),
                     hstate=last_br_h,
-                    rng=br_rng
+                    rng=br_rng,
                 )
                 logp_br = pi_br.log_prob(act_br)
                 act_br = act_br.squeeze()
                 logp_br = logp_br.squeeze()
                 val_br_val = val_br_val.squeeze()
 
-                env_act = split_actions(act_br, act_conf, ego_indices, teammate_indices, config["NUM_ENVS"])
-                step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0, 0, 0))(
-                    step_rngs, env_state, env_act
+                env_act = split_actions(
+                    act_br, act_conf, ego_indices, teammate_indices, config["NUM_ENVS"]
                 )
+                step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 info_conf = jax.tree.map(
-                    lambda x: jnp.concatenate([x[:, i] for i in teammate_indices], axis=0), 
-                    info
+                    lambda x: jnp.concatenate(
+                        [x[:, i] for i in teammate_indices], axis=0
+                    ),
+                    info,
                 )
                 info_br = jax.tree.map(
-                    lambda x: jnp.concatenate([x[:, i] for i in ego_indices], axis=0), 
-                    info
+                    lambda x: jnp.concatenate([x[:, i] for i in ego_indices], axis=0),
+                    info,
                 )
 
                 # Stack rewards per slot
                 conf_reward_stacked = jnp.concatenate(
-                    [reward[f'agent_{i}'] for i in teammate_indices], axis=0)  # (NUM_UNCONTROLLED_ACTORS,)
+                    [reward[f"agent_{i}"] for i in teammate_indices], axis=0
+                )  # (NUM_UNCONTROLLED_ACTORS,)
                 br_reward_stacked = jnp.concatenate(
-                    [reward[f'agent_{i}'] for i in ego_indices], axis=0)       # (NUM_CONTROLLED_ACTORS,)
+                    [reward[f"agent_{i}"] for i in ego_indices], axis=0
+                )  # (NUM_CONTROLLED_ACTORS,)
 
                 # Store full NUM_UNCONTROLLED_ACTORS / NUM_CONTROLLED_ACTORS data
-                conf_done_stacked = augment_done(done, teammate_indices, config["NUM_ENVS"])  # (NUM_UNCONTROLLED_ACTORS,)
+                conf_done_stacked = augment_done(
+                    done, teammate_indices, config["NUM_ENVS"]
+                )  # (NUM_UNCONTROLLED_ACTORS,)
                 transition_conf = ConfTransition(
                     done=conf_done_stacked,
-                    action=act_conf,            # (NUM_UNCONTROLLED_ACTORS,)
-                    value=val_br,               # (NUM_UNCONTROLLED_ACTORS,)
-                    other_value=val_ego,        # (NUM_UNCONTROLLED_ACTORS,)
+                    action=act_conf,  # (NUM_UNCONTROLLED_ACTORS,)
+                    value=val_br,  # (NUM_UNCONTROLLED_ACTORS,)
+                    other_value=val_ego,  # (NUM_UNCONTROLLED_ACTORS,)
                     reward=conf_reward_stacked,
                     log_prob=logp_conf,
                     obs=obs_conf,
                     info=info_conf,
                     avail_actions=avail_actions_conf,
-                    prev_done=dones_conf  # (NUM_UNCONTROLLED_ACTORS,) pre-step done
+                    prev_done=dones_conf,  # (NUM_UNCONTROLLED_ACTORS,) pre-step done
                 )
-                br_done_stacked = augment_done(done, ego_indices, config["NUM_ENVS"])  # (NUM_CONTROLLED_ACTORS,)
+                br_done_stacked = augment_done(
+                    done, ego_indices, config["NUM_ENVS"]
+                )  # (NUM_CONTROLLED_ACTORS,)
                 transition_br = Transition(
                     done=br_done_stacked,
-                    action=act_br,              # (NUM_CONTROLLED_ACTORS,)
-                    value=val_br_val,           # (NUM_CONTROLLED_ACTORS,)
+                    action=act_br,  # (NUM_CONTROLLED_ACTORS,)
+                    value=val_br_val,  # (NUM_CONTROLLED_ACTORS,)
                     reward=br_reward_stacked,
                     log_prob=logp_br,
                     obs=obs_br,
                     info=info_br,
                     avail_actions=avail_actions_br,
-                    prev_done=dones_br  # (NUM_CONTROLLED_ACTORS,) pre-step done
+                    prev_done=dones_br,  # (NUM_CONTROLLED_ACTORS,) pre-step done
                 )
                 reset_transition = ResetTransition(
                     env_state=env_state,
@@ -489,18 +753,48 @@ def train_regret_maximizing_partners(config, env,
                     conf_done=dones_conf,
                     partner_done=dones_br,
                     conf_hstate=last_conf_h,
-                    partner_hstate=last_br_h
+                    partner_hstate=last_br_h,
                 )
                 obs_next["__conf__"] = jnp.concatenate(
-                    [augment_obs_with_id(obs_next[f'agent_{i}'], i, num_agents, augment_obs) for i in teammate_indices], axis=0)
+                    [
+                        augment_obs_with_id(
+                            obs_next[f"agent_{i}"], i, num_agents, augment_obs
+                        )
+                        for i in teammate_indices
+                    ],
+                    axis=0,
+                )
                 obs_next["__ego__"] = jnp.concatenate(
-                    [augment_obs_with_id(obs_next[f'agent_{i}'], i, num_agents, augment_obs) for i in ego_indices], axis=0)
-                done["__conf__"] = augment_done(done, teammate_indices, config["NUM_ENVS"])
+                    [
+                        augment_obs_with_id(
+                            obs_next[f"agent_{i}"], i, num_agents, augment_obs
+                        )
+                        for i in ego_indices
+                    ],
+                    axis=0,
+                )
+                done["__conf__"] = augment_done(
+                    done, teammate_indices, config["NUM_ENVS"]
+                )
                 done["__ego__"] = augment_done(done, ego_indices, config["NUM_ENVS"])
 
-                new_runner_state = (train_state_conf, train_state_br, env_state_next, obs_next, done, new_conf_h, new_br_h, reset_traj_batch, rng)
-                return new_runner_state, (transition_conf, transition_br, reset_transition)
-            
+                new_runner_state = (
+                    train_state_conf,
+                    train_state_br,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_conf_h,
+                    new_br_h,
+                    reset_traj_batch,
+                    rng,
+                )
+                return new_runner_state, (
+                    transition_conf,
+                    transition_br,
+                    reset_transition,
+                )
+
             # --------------------------
             # 3d) GAE & update step
             # --------------------------
@@ -538,95 +832,128 @@ def train_regret_maximizing_partners(config, env,
                 def _step(carry, done_prev):
                     next_w = jnp.where(done_prev, jnp.ones_like(carry), carry + 1.0)
                     return next_w, next_w
+
                 init_w = jnp.ones(done.shape[1], dtype=jnp.float32)
                 _, weights_rest = jax.lax.scan(_step, init_w, done[:-1])
-                return jnp.concatenate([init_w[None], weights_rest], axis=0) # type: ignore[arg-type]
+                return jnp.concatenate([init_w[None], weights_rest], axis=0)  # type: ignore[arg-type]
 
             def _update_epoch(update_state, unused):
                 def _compute_ppo_value_loss(pred_value, traj_batch, target_v):
-                    '''Value loss function for PPO'''
+                    """Value loss function for PPO"""
                     value_pred_clipped = traj_batch.value + (
                         pred_value - traj_batch.value
-                        ).clip(
-                        -config["CLIP_EPS"], config["CLIP_EPS"])
+                    ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                     value_losses = jnp.square(pred_value - target_v)
                     value_losses_clipped = jnp.square(value_pred_clipped - target_v)
-                    value_loss = (
-                        jnp.maximum(value_losses, value_losses_clipped).mean()
-                    )
+                    value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
                     return value_loss
-            
+
                 def _compute_ppo_pg_loss(objective, log_prob, traj_batch):
-                    '''Policy gradient loss function for PPO'''
+                    """Policy gradient loss function for PPO"""
                     ratio = jnp.exp(log_prob - traj_batch.log_prob)
                     obj_norm = (objective - objective.mean()) / (objective.std() + 1e-8)
                     pg_loss_1 = ratio * obj_norm
-                    pg_loss_2 = jnp.clip(
-                        ratio, 
-                        1.0 - config["CLIP_EPS"], 
-                        1.0 + config["CLIP_EPS"]) * obj_norm
+                    pg_loss_2 = (
+                        jnp.clip(
+                            ratio, 1.0 - config["CLIP_EPS"], 1.0 + config["CLIP_EPS"]
+                        )
+                        * obj_norm
+                    )
                     pg_loss = -jnp.mean(jnp.minimum(pg_loss_1, pg_loss_2))
                     return pg_loss
 
                 def _update_minbatch_conf(train_state_conf, batch_infos):
-                    '''
+                    """
                     Teammate update function. Note that this implementation gathers both XSP (XP data from SP start states)
-                    and SXP (SP data from XP start states) data. 
-                    '''
+                    and SXP (SP data from XP start states) data.
+                    """
                     minbatch_xp, minbatch_sp, minbatch_xsp, minbatch_sxp = batch_infos
 
-                    def _loss_fn_conf(params, minbatch_xp, minbatch_sp, minbatch_xsp, minbatch_sxp):
+                    def _loss_fn_conf(
+                        params, minbatch_xp, minbatch_sp, minbatch_xsp, minbatch_sxp
+                    ):
                         # doesn't really matter which init_conf_hstate we use here since it's all the same
-                        init_conf_hstate, traj_batch_xp, (gae_xp, gae_xp_tsw), target_v_xp = minbatch_xp
-                        _, traj_batch_sp, (gae_sp, gae_sp_tsw), target_v_sp = minbatch_sp
+                        (
+                            init_conf_hstate,
+                            traj_batch_xp,
+                            (gae_xp, gae_xp_tsw),
+                            target_v_xp,
+                        ) = minbatch_xp
+                        _, traj_batch_sp, (gae_sp, gae_sp_tsw), target_v_sp = (
+                            minbatch_sp
+                        )
                         _, traj_batch_xsp, gae_xsp, target_v_xsp = minbatch_xsp
                         _, traj_batch_sxp, gae_sxp, target_v_sxp = minbatch_sxp
 
                         # get policy and value for all 4 interaction types
-                        _, (value_xp_on_xp_data, value_sp_on_xp_data), pi_xp, _ = confederate_policy.get_action_value_policy(
-                            params=params, 
-                            obs=traj_batch_xp.obs, 
-                            done=traj_batch_xp.prev_done,
-                            avail_actions=traj_batch_xp.avail_actions,
-                            hstate=init_conf_hstate,
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here 
+                        _, (value_xp_on_xp_data, _value_sp_on_xp_data), pi_xp, _ = (
+                            confederate_policy.get_action_value_policy(
+                                params=params,
+                                obs=traj_batch_xp.obs,
+                                done=traj_batch_xp.prev_done,
+                                avail_actions=traj_batch_xp.avail_actions,
+                                hstate=init_conf_hstate,
+                                rng=jax.random.PRNGKey(
+                                    0
+                                ),  # only used for action sampling, which is not used here
+                            )
                         )
-                        _, (value_xp_on_sp_data, value_sp_on_sp_data), pi_sp, _ = confederate_policy.get_action_value_policy(
-                            params=params, 
-                            obs=traj_batch_sp.obs, 
-                            done=traj_batch_sp.prev_done,
-                            avail_actions=traj_batch_sp.avail_actions,
-                            hstate=init_conf_hstate,
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here 
+                        _, (_value_xp_on_sp_data, value_sp_on_sp_data), pi_sp, _ = (
+                            confederate_policy.get_action_value_policy(
+                                params=params,
+                                obs=traj_batch_sp.obs,
+                                done=traj_batch_sp.prev_done,
+                                avail_actions=traj_batch_sp.avail_actions,
+                                hstate=init_conf_hstate,
+                                rng=jax.random.PRNGKey(
+                                    0
+                                ),  # only used for action sampling, which is not used here
+                            )
                         )
 
-                        _, (value_xp_on_xsp_data, value_sp_on_xsp_data), pi_xsp, _ = confederate_policy.get_action_value_policy(
-                            params=params, 
-                            obs=traj_batch_xsp.obs, 
-                            done=traj_batch_xsp.prev_done,
-                            avail_actions=traj_batch_xsp.avail_actions,
-                            hstate=init_conf_hstate,
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here 
+                        _, (value_xp_on_xsp_data, _value_sp_on_xsp_data), pi_xsp, _ = (
+                            confederate_policy.get_action_value_policy(
+                                params=params,
+                                obs=traj_batch_xsp.obs,
+                                done=traj_batch_xsp.prev_done,
+                                avail_actions=traj_batch_xsp.avail_actions,
+                                hstate=init_conf_hstate,
+                                rng=jax.random.PRNGKey(
+                                    0
+                                ),  # only used for action sampling, which is not used here
+                            )
                         )
 
-                        _, (value_xp_on_sxp_data, value_sp_on_sxp_data), pi_sxp, _ = confederate_policy.get_action_value_policy(
-                            params=params, 
-                            obs=traj_batch_sxp.obs, 
-                            done=traj_batch_sxp.prev_done,
-                            avail_actions=traj_batch_sxp.avail_actions,
-                            hstate=init_conf_hstate,
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here 
+                        _, (_value_xp_on_sxp_data, value_sp_on_sxp_data), pi_sxp, _ = (
+                            confederate_policy.get_action_value_policy(
+                                params=params,
+                                obs=traj_batch_sxp.obs,
+                                done=traj_batch_sxp.prev_done,
+                                avail_actions=traj_batch_sxp.avail_actions,
+                                hstate=init_conf_hstate,
+                                rng=jax.random.PRNGKey(
+                                    0
+                                ),  # only used for action sampling, which is not used here
+                            )
                         )
 
                         log_prob_xp = pi_xp.log_prob(traj_batch_xp.action)
                         log_prob_sp = pi_sp.log_prob(traj_batch_sp.action)
                         log_prob_xsp = pi_xsp.log_prob(traj_batch_xsp.action)
                         log_prob_sxp = pi_sxp.log_prob(traj_batch_sxp.action)
-                        
-                        value_loss_xp = _compute_ppo_value_loss(value_xp_on_xp_data, traj_batch_xp, target_v_xp)
-                        value_loss_sp = _compute_ppo_value_loss(value_sp_on_sp_data, traj_batch_sp, target_v_sp)
-                        value_loss_xsp = _compute_ppo_value_loss(value_xp_on_xsp_data, traj_batch_xsp, target_v_xsp)
-                        value_loss_sxp = _compute_ppo_value_loss(value_sp_on_sxp_data, traj_batch_sxp, target_v_sxp)
+
+                        value_loss_xp = _compute_ppo_value_loss(
+                            value_xp_on_xp_data, traj_batch_xp, target_v_xp
+                        )
+                        value_loss_sp = _compute_ppo_value_loss(
+                            value_sp_on_sp_data, traj_batch_sp, target_v_sp
+                        )
+                        value_loss_xsp = _compute_ppo_value_loss(
+                            value_xp_on_xsp_data, traj_batch_xsp, target_v_xsp
+                        )
+                        value_loss_sxp = _compute_ppo_value_loss(
+                            value_sp_on_sxp_data, traj_batch_sxp, target_v_sxp
+                        )
 
                         # Compute policy objectives
                         # This is the ROTATE objective!
@@ -646,142 +973,267 @@ def train_regret_maximizing_partners(config, env,
                             total_xsp_objective = jnp.array(0.0)
                             total_sxp_objective = jnp.array(0.0)
 
-                        pg_loss_xp = _compute_ppo_pg_loss(total_xp_objective, log_prob_xp, traj_batch_xp)
-                        pg_loss_sp = _compute_ppo_pg_loss(total_sp_objective, log_prob_sp, traj_batch_sp)
-                        pg_loss_xsp = _compute_ppo_pg_loss(total_xsp_objective, log_prob_xsp, traj_batch_xsp)
-                        pg_loss_sxp = _compute_ppo_pg_loss(total_sxp_objective, log_prob_sxp, traj_batch_sxp)
+                        pg_loss_xp = _compute_ppo_pg_loss(
+                            total_xp_objective, log_prob_xp, traj_batch_xp
+                        )
+                        pg_loss_sp = _compute_ppo_pg_loss(
+                            total_sp_objective, log_prob_sp, traj_batch_sp
+                        )
+                        pg_loss_xsp = _compute_ppo_pg_loss(
+                            total_xsp_objective, log_prob_xsp, traj_batch_xsp
+                        )
+                        pg_loss_sxp = _compute_ppo_pg_loss(
+                            total_sxp_objective, log_prob_sxp, traj_batch_sxp
+                        )
 
                         entropy_xp = jnp.mean(pi_xp.entropy())
                         entropy_sp = jnp.mean(pi_sp.entropy())
                         entropy_xsp = jnp.mean(pi_xsp.entropy())
                         entropy_sxp = jnp.mean(pi_sxp.entropy())
 
-                        total_pg_loss = pg_loss_xp + (1 + config["LAMBDA_2"]) * pg_loss_sp + pg_loss_xsp + (1 + config["LAMBDA_1"]) * pg_loss_sxp
-                        total_value_loss = value_loss_xp + value_loss_sp + value_loss_xsp + value_loss_sxp
-                        total_entropy_loss = entropy_xp + entropy_sp + entropy_xsp + entropy_sxp
+                        total_pg_loss = (
+                            pg_loss_xp
+                            + (1 + config["LAMBDA_2"]) * pg_loss_sp
+                            + pg_loss_xsp
+                            + (1 + config["LAMBDA_1"]) * pg_loss_sxp
+                        )
+                        total_value_loss = (
+                            value_loss_xp
+                            + value_loss_sp
+                            + value_loss_xsp
+                            + value_loss_sxp
+                        )
+                        total_entropy_loss = (
+                            entropy_xp + entropy_sp + entropy_xsp + entropy_sxp
+                        )
 
-                        total_loss = total_pg_loss + config["VF_COEF"] * total_value_loss - config["ENT_COEF"] * total_entropy_loss
+                        total_loss = (
+                            total_pg_loss
+                            + config["VF_COEF"] * total_value_loss
+                            - config["ENT_COEF"] * total_entropy_loss
+                        )
 
-                        return total_loss, ((value_loss_xp, pg_loss_xp, entropy_xp),
-                                             (value_loss_sp, pg_loss_sp, entropy_sp),
-                                             (value_loss_xsp, pg_loss_xsp, entropy_xsp),
-                                             (value_loss_sxp, pg_loss_sxp, entropy_sxp))
-
+                        return total_loss, (
+                            (value_loss_xp, pg_loss_xp, entropy_xp),
+                            (value_loss_sp, pg_loss_sp, entropy_sp),
+                            (value_loss_xsp, pg_loss_xsp, entropy_xsp),
+                            (value_loss_sxp, pg_loss_sxp, entropy_sxp),
+                        )
 
                     grad_fn = jax.value_and_grad(_loss_fn_conf, has_aux=True)
                     (loss_val, aux_vals), grads = grad_fn(
-                        train_state_conf.params, 
-                        minbatch_xp, minbatch_sp, minbatch_xsp, minbatch_sxp)
+                        train_state_conf.params,
+                        minbatch_xp,
+                        minbatch_sp,
+                        minbatch_xsp,
+                        minbatch_sxp,
+                    )
                     train_state_conf = train_state_conf.apply_gradients(grads=grads)
                     return train_state_conf, (loss_val, aux_vals)
-                
+
                 def _update_minbatch_br(train_state_br, batch_infos):
                     minbatch_sp, minbatch_sxp = batch_infos
-                    init_br_hstate, traj_batch_sp, advantages_sp, returns_sp = minbatch_sp
-                    init_br_hstate, traj_batch_sxp, advantages_sxp, returns_sxp = minbatch_sxp
+                    init_br_hstate, traj_batch_sp, advantages_sp, returns_sp = (
+                        minbatch_sp
+                    )
+                    init_br_hstate, traj_batch_sxp, advantages_sxp, returns_sxp = (
+                        minbatch_sxp
+                    )
 
                     # merge the two sources of data since the BR is always return-maximizing
                     # axis 0 is the time dimension, axis 1 is the minibatch dimension
-                    traj_batch_sp_merged = jax.tree.map(lambda x, y: jnp.concatenate([x, y], axis=1), traj_batch_sp, traj_batch_sxp)
-                    init_br_hstate_merged = jax.tree.map(lambda x, y: jnp.concatenate([x, y], axis=1), init_br_hstate, init_br_hstate)                    
-                    advantages_sp_merged = jax.tree.map(lambda x, y: jnp.concatenate([x, y], axis=1), advantages_sp, advantages_sxp)
-                    returns_sp_merged = jax.tree.map(lambda x, y: jnp.concatenate([x, y], axis=1), returns_sp, returns_sxp)
+                    traj_batch_sp_merged = jax.tree.map(
+                        lambda x, y: jnp.concatenate([x, y], axis=1),
+                        traj_batch_sp,
+                        traj_batch_sxp,
+                    )
+                    init_br_hstate_merged = jax.tree.map(
+                        lambda x, y: jnp.concatenate([x, y], axis=1),
+                        init_br_hstate,
+                        init_br_hstate,
+                    )
+                    advantages_sp_merged = jax.tree.map(
+                        lambda x, y: jnp.concatenate([x, y], axis=1),
+                        advantages_sp,
+                        advantages_sxp,
+                    )
+                    returns_sp_merged = jax.tree.map(
+                        lambda x, y: jnp.concatenate([x, y], axis=1),
+                        returns_sp,
+                        returns_sxp,
+                    )
 
                     def _loss_fn_br(params, traj_batch, gae, target_v):
                         _, value, pi, _ = br_policy.get_action_value_policy(
-                            params=params, 
-                            obs=traj_batch.obs, 
+                            params=params,
+                            obs=traj_batch.obs,
                             done=traj_batch.prev_done,
                             avail_actions=traj_batch.avail_actions,
                             hstate=init_br_hstate_merged,
-                            rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here 
+                            rng=jax.random.PRNGKey(
+                                0
+                            ),  # only used for action sampling, which is not used here
                         )
 
                         log_prob = pi.log_prob(traj_batch.action)
 
-                        value_loss = _compute_ppo_value_loss(value, traj_batch, target_v)
+                        value_loss = _compute_ppo_value_loss(
+                            value, traj_batch, target_v
+                        )
                         pg_loss = _compute_ppo_pg_loss(gae, log_prob, traj_batch)
                         entropy = jnp.mean(pi.entropy())
 
-                        sp_loss = pg_loss + config["VF_COEF"] * value_loss - config["ENT_COEF"] * entropy
+                        sp_loss = (
+                            pg_loss
+                            + config["VF_COEF"] * value_loss
+                            - config["ENT_COEF"] * entropy
+                        )
 
                         total_loss = sp_loss
                         return total_loss, (value_loss, pg_loss, entropy)
 
                     grad_fn = jax.value_and_grad(_loss_fn_br, has_aux=True)
                     (loss_val, aux_vals), grads = grad_fn(
-                        train_state_br.params, 
-                        traj_batch_sp_merged, advantages_sp_merged, returns_sp_merged)
+                        train_state_br.params,
+                        traj_batch_sp_merged,
+                        advantages_sp_merged,
+                        returns_sp_merged,
+                    )
                     train_state_br = train_state_br.apply_gradients(grads=grads)
                     return train_state_br, (loss_val, aux_vals)
 
                 (
-                    train_state_conf, train_state_br, 
-                    conf_update_data, br_update_data,
-                    rng
+                    train_state_conf,
+                    train_state_br,
+                    conf_update_data,
+                    br_update_data,
+                    rng,
                 ) = update_state
 
                 (
-                    traj_batch_xp, traj_batch_sp_conf, traj_batch_xsp, traj_batch_sxp_conf,
-                    advantages_xp_conf, advantages_sp_conf, advantages_xsp_conf, advantages_sxp_conf,
-                    advantages_xp_conf_tsw, advantages_sp_conf_tsw,
-                    targets_xp_conf, targets_sp_conf, targets_xsp_conf, targets_sxp_conf,
+                    traj_batch_xp,
+                    traj_batch_sp_conf,
+                    traj_batch_xsp,
+                    traj_batch_sxp_conf,
+                    advantages_xp_conf,
+                    advantages_sp_conf,
+                    advantages_xsp_conf,
+                    advantages_sxp_conf,
+                    advantages_xp_conf_tsw,
+                    advantages_sp_conf_tsw,
+                    targets_xp_conf,
+                    targets_sp_conf,
+                    targets_xsp_conf,
+                    targets_sxp_conf,
                 ) = conf_update_data
 
                 (
-                    traj_batch_sp_br, traj_batch_sxp_br,
-                    advantages_sp_br, advantages_sxp_br,
-                    targets_sp_br, targets_sxp_br,
+                    traj_batch_sp_br,
+                    traj_batch_sxp_br,
+                    advantages_sp_br,
+                    advantages_sxp_br,
+                    targets_sp_br,
+                    targets_sxp_br,
                 ) = br_update_data
 
-                rng, perm_rng_xp, perm_rng_sp_conf, perm_rng_sp_br, \
-                    perm_rng_xsp, perm_rng_sxp_conf, perm_rng_sxp_br = jax.random.split(rng, 7)
+                (
+                    rng,
+                    perm_rng_xp,
+                    perm_rng_sp_conf,
+                    perm_rng_sp_br,
+                    perm_rng_xsp,
+                    perm_rng_sxp_conf,
+                    perm_rng_sxp_br,
+                ) = jax.random.split(rng, 7)
 
                 # Create minibatches for each agent and interaction type
                 # 1) Conf-ego interaction (XP)
                 # The advantages slot carries (unweighted, timestep-weighted) as a tuple; both
                 # leaves ride the same actor permutation inside _create_minibatches.
                 minibatches_xp = _create_minibatches(
-                    traj_batch_xp, (advantages_xp_conf, advantages_xp_conf_tsw), targets_xp_conf, init_conf_hstate,
-                    config["NUM_UNCONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_xp
+                    traj_batch_xp,
+                    (advantages_xp_conf, advantages_xp_conf_tsw),
+                    targets_xp_conf,
+                    init_conf_hstate,
+                    config["NUM_UNCONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_xp,
                 )
                 # 2) Conf-br interaction (SP)
                 minibatches_sp_conf = _create_minibatches(
-                    traj_batch_sp_conf, (advantages_sp_conf, advantages_sp_conf_tsw), targets_sp_conf, init_conf_hstate,
-                    config["NUM_UNCONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_sp_conf
+                    traj_batch_sp_conf,
+                    (advantages_sp_conf, advantages_sp_conf_tsw),
+                    targets_sp_conf,
+                    init_conf_hstate,
+                    config["NUM_UNCONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_sp_conf,
                 )
                 minibatches_sp_br = _create_minibatches(
-                    traj_batch_sp_br, advantages_sp_br, targets_sp_br, init_br_hstate, 
-                    config["NUM_CONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_sp_br
+                    traj_batch_sp_br,
+                    advantages_sp_br,
+                    targets_sp_br,
+                    init_br_hstate,
+                    config["NUM_CONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_sp_br,
                 )
                 # 3) Conf-ego interaction from conf-br states (XSP)
                 minibatches_xsp = _create_minibatches(
-                    traj_batch_xsp, advantages_xsp_conf, targets_xsp_conf, init_conf_hstate, 
-                    config["NUM_UNCONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_xsp
+                    traj_batch_xsp,
+                    advantages_xsp_conf,
+                    targets_xsp_conf,
+                    init_conf_hstate,
+                    config["NUM_UNCONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_xsp,
                 )
                 # 4) Conf-br interaction from conf-ego states (SXP)
                 minibatches_sxp_conf = _create_minibatches(
-                    traj_batch_sxp_conf, advantages_sxp_conf, targets_sxp_conf, init_conf_hstate, 
-                    config["NUM_UNCONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_sxp_conf
+                    traj_batch_sxp_conf,
+                    advantages_sxp_conf,
+                    targets_sxp_conf,
+                    init_conf_hstate,
+                    config["NUM_UNCONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_sxp_conf,
                 )
                 minibatches_sxp_br = _create_minibatches(
-                    traj_batch_sxp_br, advantages_sxp_br, targets_sxp_br, init_br_hstate, 
-                    config["NUM_CONTROLLED_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_sxp_br
+                    traj_batch_sxp_br,
+                    advantages_sxp_br,
+                    targets_sxp_br,
+                    init_br_hstate,
+                    config["NUM_CONTROLLED_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_sxp_br,
                 )
 
                 # Update confederate
                 train_state_conf, total_loss_conf = jax.lax.scan(
-                    _update_minbatch_conf, train_state_conf, (minibatches_xp, minibatches_sp_conf, 
-                                                              minibatches_xsp, minibatches_sxp_conf)
+                    _update_minbatch_conf,
+                    train_state_conf,
+                    (
+                        minibatches_xp,
+                        minibatches_sp_conf,
+                        minibatches_xsp,
+                        minibatches_sxp_conf,
+                    ),
                 )
 
                 # Update best response
                 train_state_br, total_loss_br = jax.lax.scan(
-                    _update_minbatch_br, train_state_br, (minibatches_sp_br, minibatches_sxp_br)
+                    _update_minbatch_br,
+                    train_state_br,
+                    (minibatches_sp_br, minibatches_sxp_br),
                 )
 
-                update_state = (train_state_conf, train_state_br, 
-                    conf_update_data, br_update_data, rng)
+                update_state = (
+                    train_state_conf,
+                    train_state_br,
+                    conf_update_data,
+                    br_update_data,
+                    rng,
+                )
                 return update_state, (total_loss_conf, total_loss_br)
 
             def _update_step(update_runner_state, unused):
@@ -789,81 +1241,200 @@ def train_regret_maximizing_partners(config, env,
                 1. Collect confederate-ego rollout (XP).
                 2. Collect confederate-br rollout (SP).
                 3. Collect confederate-ego rollout from confederate-br states (XSP).
-                4. Collect confederate-br rollout from confederate-ego states (SXP). 
+                4. Collect confederate-br rollout from confederate-ego states (SXP).
                 5. Compute advantages for XP, XSP, SP, and SXP interactions.
                 6. PPO updates for best response and confederate policies.
                 """
                 (
-                    train_state_conf, train_state_br, 
-                    env_state_xp, env_state_sp, env_state_xsp, env_state_sxp, 
-                    last_obs_xp, last_obs_sp, last_obs_xsp, last_obs_sxp, 
-                    last_dones_xp, last_dones_sp, last_dones_xsp, last_dones_sxp, 
-                    conf_hstate_xp, ego_hstate_xp, 
-                    conf_hstate_sp, br_hstate_sp, 
-                    conf_hstate_xsp, ego_hstate_xsp, 
-                    conf_hstate_sxp, br_hstate_sxp, 
-                    rng_update, update_steps
+                    train_state_conf,
+                    train_state_br,
+                    env_state_xp,
+                    env_state_sp,
+                    env_state_xsp,
+                    env_state_sxp,
+                    last_obs_xp,
+                    last_obs_sp,
+                    last_obs_xsp,
+                    last_obs_sxp,
+                    last_dones_xp,
+                    last_dones_sp,
+                    last_dones_xsp,
+                    last_dones_sxp,
+                    conf_hstate_xp,
+                    ego_hstate_xp,
+                    conf_hstate_sp,
+                    br_hstate_sp,
+                    conf_hstate_xsp,
+                    ego_hstate_xsp,
+                    conf_hstate_sxp,
+                    br_hstate_sxp,
+                    rng_update,
+                    update_steps,
                 ) = update_runner_state
 
-                rng_update, rng_xp, rng_sp, rng_xsp, rng_sxp = jax.random.split(rng_update, 5)
+                rng_update, rng_xp, rng_sp, rng_xsp, rng_sxp = jax.random.split(
+                    rng_update, 5
+                )
 
                 # 1) rollout for conf-ego interaction (XP)
-                runner_state_xp = (train_state_conf, env_state_xp, last_obs_xp, last_dones_xp,
-                                    conf_hstate_xp, ego_hstate_xp, None, rng_xp)
+                runner_state_xp = (
+                    train_state_conf,
+                    env_state_xp,
+                    last_obs_xp,
+                    last_dones_xp,
+                    conf_hstate_xp,
+                    ego_hstate_xp,
+                    None,
+                    rng_xp,
+                )
                 runner_state_xp, (traj_batch_xp, reset_traj_batch_xp) = jax.lax.scan(
-                    _env_step_conf_ego, runner_state_xp, None, config["ROLLOUT_LENGTH"])
-                (train_state_conf, env_state_xp, last_obs_xp, last_dones_xp, 
-                 conf_hstate_xp, ego_hstate_xp, _, rng_xp) = runner_state_xp
-            
+                    _env_step_conf_ego, runner_state_xp, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    train_state_conf,
+                    env_state_xp,
+                    last_obs_xp,
+                    last_dones_xp,
+                    conf_hstate_xp,
+                    ego_hstate_xp,
+                    _,
+                    rng_xp,
+                ) = runner_state_xp
+
                 # 2) rollout for conf-br interaction (SP)
-                runner_state_sp = (train_state_conf, train_state_br, env_state_sp, last_obs_sp, 
-                                   last_dones_sp, conf_hstate_sp, br_hstate_sp, None, rng_sp)
-                runner_state_sp, (traj_batch_sp_conf, traj_batch_sp_br, reset_traj_batch_sp) = jax.lax.scan(
-                    _env_step_conf_br, runner_state_sp, None, config["ROLLOUT_LENGTH"])
-                (train_state_conf, train_state_br, env_state_sp, last_obs_sp, last_dones_sp,
-                conf_hstate_sp, br_hstate_sp, _, rng_sp) = runner_state_sp
-                
+                runner_state_sp = (
+                    train_state_conf,
+                    train_state_br,
+                    env_state_sp,
+                    last_obs_sp,
+                    last_dones_sp,
+                    conf_hstate_sp,
+                    br_hstate_sp,
+                    None,
+                    rng_sp,
+                )
+                (
+                    runner_state_sp,
+                    (traj_batch_sp_conf, traj_batch_sp_br, reset_traj_batch_sp),
+                ) = jax.lax.scan(
+                    _env_step_conf_br, runner_state_sp, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    train_state_conf,
+                    train_state_br,
+                    env_state_sp,
+                    last_obs_sp,
+                    last_dones_sp,
+                    conf_hstate_sp,
+                    br_hstate_sp,
+                    _,
+                    rng_sp,
+                ) = runner_state_sp
+
                 # 3) rollout for conf-ego interaction from conf-br states (XSP)
-                runner_state_xsp = (train_state_conf, env_state_xsp, last_obs_xsp, last_dones_xsp,
-                                    conf_hstate_xsp, ego_hstate_xsp, 
-                                    reset_traj_batch_sp, rng_xsp)
+                runner_state_xsp = (
+                    train_state_conf,
+                    env_state_xsp,
+                    last_obs_xsp,
+                    last_dones_xsp,
+                    conf_hstate_xsp,
+                    ego_hstate_xsp,
+                    reset_traj_batch_sp,
+                    rng_xsp,
+                )
                 runner_state_xsp, (traj_batch_xsp, _) = jax.lax.scan(
-                    _env_step_conf_ego, runner_state_xsp, None, config["ROLLOUT_LENGTH"])
-                (train_state_conf, env_state_xsp, last_obs_xsp, last_dones_xsp, 
-                 conf_hstate_xsp, ego_hstate_xsp, _, rng_xsp) = runner_state_xsp
+                    _env_step_conf_ego, runner_state_xsp, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    train_state_conf,
+                    env_state_xsp,
+                    last_obs_xsp,
+                    last_dones_xsp,
+                    conf_hstate_xsp,
+                    ego_hstate_xsp,
+                    _,
+                    rng_xsp,
+                ) = runner_state_xsp
 
                 # 4) rollout for conf-br interaction from conf-ego states (SXP)
-                runner_state_sxp = (train_state_conf, train_state_br, env_state_sxp, last_obs_sxp, 
-                                    last_dones_sxp, conf_hstate_sxp, br_hstate_sxp, 
-                                    reset_traj_batch_xp, rng_sxp)
-                runner_state_sxp, (traj_batch_sxp_conf, traj_batch_sxp_br, _) = jax.lax.scan(
-                    _env_step_conf_br, runner_state_sxp, None, config["ROLLOUT_LENGTH"])
-                (train_state_conf, train_state_br, env_state_sxp, last_obs_sxp, last_dones_sxp,
-                 conf_hstate_sxp, br_hstate_sxp, _, rng_sxp) = runner_state_sxp
+                runner_state_sxp = (
+                    train_state_conf,
+                    train_state_br,
+                    env_state_sxp,
+                    last_obs_sxp,
+                    last_dones_sxp,
+                    conf_hstate_sxp,
+                    br_hstate_sxp,
+                    reset_traj_batch_xp,
+                    rng_sxp,
+                )
+                runner_state_sxp, (traj_batch_sxp_conf, traj_batch_sxp_br, _) = (
+                    jax.lax.scan(
+                        _env_step_conf_br,
+                        runner_state_sxp,
+                        None,
+                        config["ROLLOUT_LENGTH"],
+                    )
+                )
+                (
+                    train_state_conf,
+                    train_state_br,
+                    env_state_sxp,
+                    last_obs_sxp,
+                    last_dones_sxp,
+                    conf_hstate_sxp,
+                    br_hstate_sxp,
+                    _,
+                    rng_sxp,
+                ) = runner_state_sxp
 
-                def _compute_advantages_and_targets(batch_size, env_state, policy, policy_params, policy_hstate,
-                                                   last_obs, last_dones, traj_batch, agent_name, value_idx=None):
-                    '''Value_idx argument is to support the ActorWithDoubleCritic (confederate) policy, which
+                def _compute_advantages_and_targets(
+                    batch_size,
+                    env_state,
+                    policy,
+                    policy_params,
+                    policy_hstate,
+                    last_obs,
+                    last_dones,
+                    traj_batch,
+                    agent_name,
+                    value_idx=None,
+                ):
+                    """Value_idx argument is to support the ActorWithDoubleCritic (confederate) policy, which
                     has two value heads. Value head 0 models the ego agent while value head 1 models the best response.
 
                     agent_name should be either "__conf__" (stacked teammate obs) or "__ego__" (stacked ego obs);
                     avail_actions are obtained from the first physical agent in the corresponding role group.
-                    '''
+                    """
                     if agent_name == "__conf__":
                         avail_actions = jnp.concatenate(
-                            [jax.vmap(env.get_avail_actions)(env_state.env_state)[f'agent_{i}'].astype(jnp.float32)
-                             for i in teammate_indices], axis=0)
+                            [
+                                jax.vmap(env.get_avail_actions)(env_state.env_state)[
+                                    f"agent_{i}"
+                                ].astype(jnp.float32)
+                                for i in teammate_indices
+                            ],
+                            axis=0,
+                        )
                     else:  # __ego__
                         avail_actions = jnp.concatenate(
-                            [jax.vmap(env.get_avail_actions)(env_state.env_state)[f'agent_{i}'].astype(jnp.float32)
-                             for i in ego_indices], axis=0)
+                            [
+                                jax.vmap(env.get_avail_actions)(env_state.env_state)[
+                                    f"agent_{i}"
+                                ].astype(jnp.float32)
+                                for i in ego_indices
+                            ],
+                            axis=0,
+                        )
                     _, vals, _, _ = policy.get_action_value_policy(
                         params=policy_params,
                         obs=last_obs[agent_name].reshape(1, batch_size, -1),
                         done=last_dones[agent_name].reshape(1, batch_size),
                         avail_actions=jax.lax.stop_gradient(avail_actions),
                         hstate=policy_hstate,
-                        rng=jax.random.PRNGKey(0)  # dummy key as we don't sample actions
+                        rng=jax.random.PRNGKey(
+                            0
+                        ),  # dummy key as we don't sample actions
                     )
                     if value_idx is None:
                         last_val = vals.squeeze()
@@ -871,81 +1442,151 @@ def train_regret_maximizing_partners(config, env,
                         last_val = vals[value_idx].squeeze()
                     advantages, targets = _calculate_gae(traj_batch, last_val)
                     return advantages, targets
-                
+
                 # 5a) Compute conf advantages for XP (conf-ego) interaction
                 advantages_xp_conf, targets_xp_conf = _compute_advantages_and_targets(
                     config["NUM_UNCONTROLLED_ACTORS"],
-                    env_state_xp, conf_policy, train_state_conf.params, conf_hstate_xp,
-                    last_obs_xp, last_dones_xp, traj_batch_xp, "__conf__", value_idx=0)
+                    env_state_xp,
+                    conf_policy,
+                    train_state_conf.params,
+                    conf_hstate_xp,
+                    last_obs_xp,
+                    last_dones_xp,
+                    traj_batch_xp,
+                    "__conf__",
+                    value_idx=0,
+                )
 
                 # 5b) Compute conf and br advantages for SP (conf-br) interaction
                 advantages_sp_conf, targets_sp_conf = _compute_advantages_and_targets(
                     config["NUM_UNCONTROLLED_ACTORS"],
-                    env_state_sp, conf_policy, train_state_conf.params, conf_hstate_sp,
-                    last_obs_sp, last_dones_sp, traj_batch_sp_conf, "__conf__", value_idx=1)
+                    env_state_sp,
+                    conf_policy,
+                    train_state_conf.params,
+                    conf_hstate_sp,
+                    last_obs_sp,
+                    last_dones_sp,
+                    traj_batch_sp_conf,
+                    "__conf__",
+                    value_idx=1,
+                )
 
                 advantages_sp_br, targets_sp_br = _compute_advantages_and_targets(
                     config["NUM_CONTROLLED_ACTORS"],
-                    env_state_sp, br_policy, train_state_br.params, br_hstate_sp,
-                    last_obs_sp, last_dones_sp, traj_batch_sp_br, "__ego__", value_idx=None)
+                    env_state_sp,
+                    br_policy,
+                    train_state_br.params,
+                    br_hstate_sp,
+                    last_obs_sp,
+                    last_dones_sp,
+                    traj_batch_sp_br,
+                    "__ego__",
+                    value_idx=None,
+                )
 
                 # Timestep-weighted XP/SP advantages for the gae_ps_regret_ts_weighted objective.
                 # Computed once per update (the weights depend only on `done`) and threaded
                 # through minibatching alongside the unweighted advantages, which remain available.
-                advantages_xp_conf_tsw = _ts_weights_from_done(traj_batch_xp.done) * advantages_xp_conf
-                advantages_sp_conf_tsw = _ts_weights_from_done(traj_batch_sp_conf.done) * advantages_sp_conf
+                advantages_xp_conf_tsw = (
+                    _ts_weights_from_done(traj_batch_xp.done) * advantages_xp_conf
+                )
+                advantages_sp_conf_tsw = (
+                    _ts_weights_from_done(traj_batch_sp_conf.done) * advantages_sp_conf
+                )
 
                 # 5c) Compute conf advantages for XSP (conf-ego from conf-br states) interaction
                 advantages_xsp_conf, targets_xsp_conf = _compute_advantages_and_targets(
                     config["NUM_UNCONTROLLED_ACTORS"],
-                    env_state_xsp, conf_policy, train_state_conf.params, conf_hstate_xsp,
-                    last_obs_xsp, last_dones_xsp, traj_batch_xsp, "__conf__", value_idx=0)
+                    env_state_xsp,
+                    conf_policy,
+                    train_state_conf.params,
+                    conf_hstate_xsp,
+                    last_obs_xsp,
+                    last_dones_xsp,
+                    traj_batch_xsp,
+                    "__conf__",
+                    value_idx=0,
+                )
 
                 # 5d) Compute conf and br advantages for SXP (conf-br from conf-ego states) interaction
                 advantages_sxp_conf, targets_sxp_conf = _compute_advantages_and_targets(
                     config["NUM_UNCONTROLLED_ACTORS"],
-                    env_state_sxp, conf_policy, train_state_conf.params, conf_hstate_sxp,
-                    last_obs_sxp, last_dones_sxp, traj_batch_sxp_conf, "__conf__", value_idx=1)
+                    env_state_sxp,
+                    conf_policy,
+                    train_state_conf.params,
+                    conf_hstate_sxp,
+                    last_obs_sxp,
+                    last_dones_sxp,
+                    traj_batch_sxp_conf,
+                    "__conf__",
+                    value_idx=1,
+                )
 
                 advantages_sxp_br, targets_sxp_br = _compute_advantages_and_targets(
                     config["NUM_CONTROLLED_ACTORS"],
-                    env_state_sxp, br_policy, train_state_br.params, br_hstate_sxp,
-                    last_obs_sxp, last_dones_sxp, traj_batch_sxp_br, "__ego__", value_idx=None)
-                
+                    env_state_sxp,
+                    br_policy,
+                    train_state_br.params,
+                    br_hstate_sxp,
+                    last_obs_sxp,
+                    last_dones_sxp,
+                    traj_batch_sxp_br,
+                    "__ego__",
+                    value_idx=None,
+                )
+
                 # 6) PPO update
                 conf_update_data = (
-                    traj_batch_xp, traj_batch_sp_conf, traj_batch_xsp, traj_batch_sxp_conf,
-                    advantages_xp_conf, advantages_sp_conf, advantages_xsp_conf, advantages_sxp_conf,
-                    advantages_xp_conf_tsw, advantages_sp_conf_tsw,
-                    targets_xp_conf, targets_sp_conf, targets_xsp_conf, targets_sxp_conf,
+                    traj_batch_xp,
+                    traj_batch_sp_conf,
+                    traj_batch_xsp,
+                    traj_batch_sxp_conf,
+                    advantages_xp_conf,
+                    advantages_sp_conf,
+                    advantages_xsp_conf,
+                    advantages_sxp_conf,
+                    advantages_xp_conf_tsw,
+                    advantages_sp_conf_tsw,
+                    targets_xp_conf,
+                    targets_sp_conf,
+                    targets_xsp_conf,
+                    targets_sxp_conf,
                 )
                 br_update_data = (
-                    traj_batch_sp_br, traj_batch_sxp_br,
-                    advantages_sp_br, advantages_sxp_br,
-                    targets_sp_br, targets_sxp_br,
+                    traj_batch_sp_br,
+                    traj_batch_sxp_br,
+                    advantages_sp_br,
+                    advantages_sxp_br,
+                    targets_sp_br,
+                    targets_sxp_br,
                 )
                 rng_update, sub_rng = jax.random.split(rng_update, 2)
 
                 update_state = (
-                    train_state_conf, train_state_br, 
-                    conf_update_data, br_update_data,
-                    sub_rng
+                    train_state_conf,
+                    train_state_br,
+                    conf_update_data,
+                    br_update_data,
+                    sub_rng,
                 )
                 update_state, all_losses = jax.lax.scan(
-                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                )
                 train_state_conf = update_state[0]
                 train_state_br = update_state[1]
 
                 conf_losses, br_losses = all_losses
 
-                (conf_loss_xp, conf_loss_sp, conf_loss_xsp, conf_loss_sxp) = conf_losses[1]
-                conf_value_loss_xp = (conf_loss_xp[0] + conf_loss_xsp[0])/2.0
-                conf_pg_loss_xp = (conf_loss_xp[1] + conf_loss_xsp[1])/2.0
-                conf_entropy_xp = (conf_loss_xp[2] + conf_loss_xsp[2])/2.0
+                (conf_loss_xp, conf_loss_sp, conf_loss_xsp, conf_loss_sxp) = (
+                    conf_losses[1]
+                )
+                conf_value_loss_xp = (conf_loss_xp[0] + conf_loss_xsp[0]) / 2.0
+                conf_pg_loss_xp = (conf_loss_xp[1] + conf_loss_xsp[1]) / 2.0
+                conf_entropy_xp = (conf_loss_xp[2] + conf_loss_xsp[2]) / 2.0
 
-                conf_value_loss_sp = (conf_loss_sp[0] + conf_loss_sxp[0])/2.0
-                conf_pg_loss_sp = (conf_loss_sp[1] + conf_loss_sxp[1])/2.0
-                conf_entropy_sp = (conf_loss_sp[2] + conf_loss_sxp[2])/2.0
+                conf_value_loss_sp = (conf_loss_sp[0] + conf_loss_sxp[0]) / 2.0
+                conf_pg_loss_sp = (conf_loss_sp[1] + conf_loss_sxp[1]) / 2.0
+                conf_entropy_sp = (conf_loss_sp[2] + conf_loss_sxp[2]) / 2.0
 
                 # Mean episodic return over completed episodes, pooled across rollout
                 # variants; the live analogue of Eval/Conf{Ego,BR}Return.
@@ -954,21 +1595,34 @@ def train_regret_maximizing_partners(config, env,
                     count = 0.0
                     for tb in traj_batches:
                         done_mask = tb.info["returned_episode"]
-                        total = total + jnp.where(done_mask, tb.info["returned_episode_returns"], 0.0).sum()
+                        total = (
+                            total
+                            + jnp.where(
+                                done_mask, tb.info["returned_episode_returns"], 0.0
+                            ).sum()
+                        )
                         count = count + done_mask.sum()
                     return total / jnp.maximum(1.0, count)
 
-                conf_avg_return_ego = _avg_episode_return([traj_batch_xp, traj_batch_xsp])
-                conf_avg_return_br = _avg_episode_return([traj_batch_sp_br, traj_batch_sxp_br])
+                conf_avg_return_ego = _avg_episode_return(
+                    [traj_batch_xp, traj_batch_xsp]
+                )
+                conf_avg_return_br = _avg_episode_return(
+                    [traj_batch_sp_br, traj_batch_sxp_br]
+                )
 
                 (br_value_loss, br_pg_loss, br_entropy) = br_losses[1]
-                
+
                 # Metrics — scalarize to minimize memory carried between compiled iterations
                 def mask_and_mean(x, mask):
                     return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
 
-                mask = traj_batch_xp.info.get("returned_episode", jnp.ones_like(traj_batch_xp.reward))
-                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_xp.info)
+                mask = traj_batch_xp.info.get(
+                    "returned_episode", jnp.ones_like(traj_batch_xp.reward)
+                )
+                metric = jax.tree.map(
+                    lambda x: mask_and_mean(x, mask), traj_batch_xp.info
+                )
                 metric["update_steps"] = update_steps
                 metric["value_loss_conf_against_ego"] = conf_value_loss_xp.mean()
                 metric["value_loss_conf_against_br"] = conf_value_loss_sp.mean()
@@ -988,15 +1642,30 @@ def train_regret_maximizing_partners(config, env,
                 metric["entropy_loss_br"] = br_entropy.mean()
 
                 new_update_runner_state = (
-                    train_state_conf, train_state_br, 
-                    env_state_xp, env_state_sp, env_state_xsp, env_state_sxp, 
-                    last_obs_xp, last_obs_sp, last_obs_xsp, last_obs_sxp, 
-                    last_dones_xp, last_dones_sp, last_dones_xsp, last_dones_sxp, 
-                    conf_hstate_xp, ego_hstate_xp, 
-                    conf_hstate_sp, br_hstate_sp, 
-                    conf_hstate_xsp, ego_hstate_xsp, 
-                    conf_hstate_sxp, br_hstate_sxp, 
-                    rng_update, update_steps + 1
+                    train_state_conf,
+                    train_state_br,
+                    env_state_xp,
+                    env_state_sp,
+                    env_state_xsp,
+                    env_state_sxp,
+                    last_obs_xp,
+                    last_obs_sp,
+                    last_obs_xsp,
+                    last_obs_sxp,
+                    last_dones_xp,
+                    last_dones_sp,
+                    last_dones_xsp,
+                    last_dones_sxp,
+                    conf_hstate_xp,
+                    ego_hstate_xp,
+                    conf_hstate_sp,
+                    br_hstate_sp,
+                    conf_hstate_xsp,
+                    ego_hstate_xsp,
+                    conf_hstate_sxp,
+                    br_hstate_sxp,
+                    rng_update,
+                    update_steps + 1,
                 )
 
                 # Live logging + progress bar are handled by a single stateful callback
@@ -1010,26 +1679,36 @@ def train_regret_maximizing_partners(config, env,
             # --------------------------
             # PPO Update and Checkpoint saving
             # --------------------------
-            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1) # -1 because we store a ckpt at the last update
+            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                1, config["NUM_CHECKPOINTS"] - 1
+            )  # -1 because we store a ckpt at the last update
             num_ckpts = config["NUM_CHECKPOINTS"]
 
             # Build a PyTree that holds parameters for all conf agent checkpoints
             def init_ckpt_array(params_pytree):
                 return jax.tree.map(
-                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), 
-                    params_pytree)
-        
+                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
+                )
+
             def _update_step_with_ckpt(state_with_ckpt, unused):
-                (update_runner_state, checkpoint_array_conf, checkpoint_array_br, ckpt_idx, 
-                    eval_info_br, eval_info_ego) = state_with_ckpt
+                (
+                    update_runner_state,
+                    checkpoint_array_conf,
+                    checkpoint_array_br,
+                    ckpt_idx,
+                    eval_info_br,
+                    eval_info_ego,
+                ) = state_with_ckpt
 
                 # Single PPO update
                 (new_update_runner_state, metric) = _update_step(
-                    update_runner_state,
-                    None
+                    update_runner_state, None
                 )
 
-                rng, update_steps = new_update_runner_state[-2], new_update_runner_state[-1]
+                rng, update_steps = (
+                    new_update_runner_state[-2],
+                    new_update_runner_state[-1],
+                )
                 # Post-update states from the carry. The enclosing train_state_conf/br
                 # names are closure constants pinned to the initial params under scan, so
                 # checkpointing/eval must read the trained states from the carry instead.
@@ -1038,66 +1717,118 @@ def train_regret_maximizing_partners(config, env,
 
                 # Decide if we store a checkpoint
                 # update steps is 1-indexed because it was incremented at the end of the update step
-                to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                          jnp.equal(update_steps, config["NUM_UPDATES"]))
-                      
+                to_store = jnp.logical_or(
+                    jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
+                )
+
                 def store_and_eval_ckpt(args):
                     ckpt_arr_and_ep_infos, rng, cidx = args
-                    ckpt_arr_conf, ckpt_arr_br, prev_ep_infos_br, prev_ep_infos_ego = ckpt_arr_and_ep_infos
+                    (
+                        ckpt_arr_conf,
+                        ckpt_arr_br,
+                        _prev_ep_infos_br,
+                        _prev_ep_infos_ego,
+                    ) = ckpt_arr_and_ep_infos
                     new_ckpt_arr_conf = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_conf, upd_train_state_conf.params
+                        ckpt_arr_conf,
+                        upd_train_state_conf.params,
                     )
                     new_ckpt_arr_br = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_br, upd_train_state_br.params
+                        ckpt_arr_br,
+                        upd_train_state_br.params,
                     )
 
                     # run eval episodes
-                    rng, eval_rng, = jax.random.split(rng)
+                    (
+                        rng,
+                        eval_rng,
+                    ) = jax.random.split(rng)
                     # conf vs ego
                     last_ep_info_with_ego = run_n_agent_episodes(
-                        eval_rng, env,
-                        ego_policy=ego_policy, ego_param=ego_params,
-                        teammate_policy=confederate_policy, teammate_param=upd_train_state_conf.params,
-                        ego_indices=ego_indices, teammate_indices=teammate_indices,
-                        max_episode_steps=config["ROLLOUT_LENGTH"], num_eps=config["NUM_EVAL_EPISODES"]
+                        eval_rng,
+                        env,
+                        ego_policy=ego_policy,
+                        ego_param=ego_params,
+                        teammate_policy=confederate_policy,
+                        teammate_param=upd_train_state_conf.params,
+                        ego_indices=ego_indices,
+                        teammate_indices=teammate_indices,
+                        max_episode_steps=config["ROLLOUT_LENGTH"],
+                        num_eps=config["NUM_EVAL_EPISODES"],
                     )
                     # conf vs br: BR occupies the controlled (ego_indices) slot and the
                     # confederate the uncontrolled (teammate_indices) slot, matching the SP
                     # training rollout. This measures genuine conf+BR coordination.
                     last_ep_info_with_br = run_n_agent_episodes(
-                        eval_rng, env,
-                        ego_policy=br_policy, ego_param=upd_train_state_br.params,
-                        teammate_policy=confederate_policy, teammate_param=upd_train_state_conf.params,
-                        ego_indices=ego_indices, teammate_indices=teammate_indices,
-                        max_episode_steps=config["ROLLOUT_LENGTH"], num_eps=config["NUM_EVAL_EPISODES"]
+                        eval_rng,
+                        env,
+                        ego_policy=br_policy,
+                        ego_param=upd_train_state_br.params,
+                        teammate_policy=confederate_policy,
+                        teammate_param=upd_train_state_conf.params,
+                        ego_indices=ego_indices,
+                        teammate_indices=teammate_indices,
+                        max_episode_steps=config["ROLLOUT_LENGTH"],
+                        num_eps=config["NUM_EVAL_EPISODES"],
                     )
 
-                    return ((new_ckpt_arr_conf, new_ckpt_arr_br, last_ep_info_with_br, last_ep_info_with_ego), rng, cidx + 1)
+                    return (
+                        (
+                            new_ckpt_arr_conf,
+                            new_ckpt_arr_br,
+                            last_ep_info_with_br,
+                            last_ep_info_with_ego,
+                        ),
+                        rng,
+                        cidx + 1,
+                    )
 
                 def skip_ckpt(args):
                     return args
+
                 rng, store_and_eval_rng = jax.random.split(rng, 2)
-                (checkpoint_array_and_infos, store_and_eval_rng, ckpt_idx) = jax.lax.cond(
-                    to_store, 
-                    store_and_eval_ckpt, 
-                    skip_ckpt, 
-                    ((checkpoint_array_conf, checkpoint_array_br, eval_info_br, eval_info_ego), store_and_eval_rng, ckpt_idx)
+                (checkpoint_array_and_infos, store_and_eval_rng, ckpt_idx) = (
+                    jax.lax.cond(
+                        to_store,
+                        store_and_eval_ckpt,
+                        skip_ckpt,
+                        (
+                            (
+                                checkpoint_array_conf,
+                                checkpoint_array_br,
+                                eval_info_br,
+                                eval_info_ego,
+                            ),
+                            store_and_eval_rng,
+                            ckpt_idx,
+                        ),
+                    )
                 )
-                checkpoint_array_conf, checkpoint_array_br, ep_info_br, ep_info_ego = checkpoint_array_and_infos
-                
+                checkpoint_array_conf, checkpoint_array_br, ep_info_br, ep_info_ego = (
+                    checkpoint_array_and_infos
+                )
+
                 metric["eval_ep_last_info_br"] = ep_info_br
                 metric["eval_ep_last_info_ego"] = ep_info_ego
 
-                return (new_update_runner_state,
-                        checkpoint_array_conf, checkpoint_array_br, ckpt_idx, 
-                        ep_info_br, ep_info_ego), metric
+                return (
+                    new_update_runner_state,
+                    checkpoint_array_conf,
+                    checkpoint_array_br,
+                    ckpt_idx,
+                    ep_info_br,
+                    ep_info_ego,
+                ), metric
 
             # --------------------------
             # Init all variables for train loop
             # --------------------------
-            rng, reset_rng_xp, reset_rng_sp, reset_rng_xsp, reset_rng_sxp = jax.random.split(rng, 5)
+            rng, reset_rng_xp, reset_rng_sp, reset_rng_xsp, reset_rng_sxp = (
+                jax.random.split(rng, 5)
+            )
             reset_rngs_xp = jax.random.split(reset_rng_xp, config["NUM_ENVS"])
             reset_rngs_sp = jax.random.split(reset_rng_sp, config["NUM_ENVS"])
             reset_rngs_xsp = jax.random.split(reset_rng_xsp, config["NUM_ENVS"])
@@ -1110,8 +1841,16 @@ def train_regret_maximizing_partners(config, env,
 
             # Add stacked augmented obs for __conf__ / __ego__ role groups to each initial obs dict
             def _add_role_obs(obsv):
-                obs_ego, obs_conf = augment_all_obs(obsv, ego_indices, teammate_indices, num_agents, config["NUM_ENVS"], augment_obs=augment_obs)
+                obs_ego, obs_conf = augment_all_obs(
+                    obsv,
+                    ego_indices,
+                    teammate_indices,
+                    num_agents,
+                    config["NUM_ENVS"],
+                    augment_obs=augment_obs,
+                )
                 return {**obsv, "__conf__": obs_conf, "__ego__": obs_ego}
+
             obsv_xp = _add_role_obs(obsv_xp)
             obsv_sp = _add_role_obs(obsv_sp)
             obsv_xsp = _add_role_obs(obsv_xsp)
@@ -1119,7 +1858,9 @@ def train_regret_maximizing_partners(config, env,
 
             # Initialize hidden states (ego/BR control NUM_CONTROLLED_ACTORS; conf controls NUM_UNCONTROLLED_ACTORS)
             init_ego_hstate = ego_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
-            init_conf_hstate = confederate_policy.init_hstate(config["NUM_UNCONTROLLED_ACTORS"])
+            init_conf_hstate = confederate_policy.init_hstate(
+                config["NUM_UNCONTROLLED_ACTORS"]
+            )
             init_br_hstate = br_policy.init_hstate(config["NUM_CONTROLLED_ACTORS"])
 
             # init checkpoint array
@@ -1130,24 +1871,38 @@ def train_regret_maximizing_partners(config, env,
             # initial ep_infos for scan over _update_step_with_ckpt
             rng, rng_eval_ego, rng_eval_br = jax.random.split(rng, 3)
             ep_infos_ego = run_n_agent_episodes(
-                rng_eval_ego, env,
-                ego_policy=ego_policy, ego_param=ego_params,
-                teammate_policy=confederate_policy, teammate_param=train_state_conf.params,
-                ego_indices=ego_indices, teammate_indices=teammate_indices,
-                max_episode_steps=config["ROLLOUT_LENGTH"], num_eps=config["NUM_EVAL_EPISODES"]
+                rng_eval_ego,
+                env,
+                ego_policy=ego_policy,
+                ego_param=ego_params,
+                teammate_policy=confederate_policy,
+                teammate_param=train_state_conf.params,
+                ego_indices=ego_indices,
+                teammate_indices=teammate_indices,
+                max_episode_steps=config["ROLLOUT_LENGTH"],
+                num_eps=config["NUM_EVAL_EPISODES"],
             )
             ep_infos_br = run_n_agent_episodes(
-                rng_eval_br, env,
-                ego_policy=br_policy, ego_param=train_state_br.params,
-                teammate_policy=confederate_policy, teammate_param=train_state_conf.params,
-                ego_indices=ego_indices, teammate_indices=teammate_indices,
-                max_episode_steps=config["ROLLOUT_LENGTH"], num_eps=config["NUM_EVAL_EPISODES"]
+                rng_eval_br,
+                env,
+                ego_policy=br_policy,
+                ego_param=train_state_br.params,
+                teammate_policy=confederate_policy,
+                teammate_param=train_state_conf.params,
+                ego_indices=ego_indices,
+                teammate_indices=teammate_indices,
+                max_episode_steps=config["ROLLOUT_LENGTH"],
+                num_eps=config["NUM_EVAL_EPISODES"],
             )
 
             # Initialize done flags (add synthetic keys for stacked role-group obs)
             _init_zeros = lambda: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
-            _init_zeros_conf = lambda: jnp.zeros((config["NUM_UNCONTROLLED_ACTORS"]), dtype=bool)
-            _init_zeros_ego = lambda: jnp.zeros((config["NUM_CONTROLLED_ACTORS"]), dtype=bool)
+            _init_zeros_conf = lambda: jnp.zeros(
+                (config["NUM_UNCONTROLLED_ACTORS"]), dtype=bool
+            )
+            _init_zeros_ego = lambda: jnp.zeros(
+                (config["NUM_CONTROLLED_ACTORS"]), dtype=bool
+            )
             init_dones_xp = {k: _init_zeros() for k in env.agents + ["__all__"]}
             init_dones_sp = {k: _init_zeros() for k in env.agents + ["__all__"]}
             init_dones_xsp = {k: _init_zeros() for k in env.agents + ["__all__"]}
@@ -1155,37 +1910,60 @@ def train_regret_maximizing_partners(config, env,
             for d in [init_dones_xp, init_dones_sp, init_dones_xsp, init_dones_sxp]:
                 d["__conf__"] = _init_zeros_conf()
                 d["__ego__"] = _init_zeros_ego()
-            
+
             # Initialize update runner state
             rng, rng_update = jax.random.split(rng, 2)
             update_steps = 0
 
             update_runner_state = (
-                train_state_conf, train_state_br, 
-                env_state_xp, env_state_sp, env_state_xsp, env_state_sxp,
-                obsv_xp, obsv_sp, obsv_xsp, obsv_sxp, 
-                init_dones_xp, init_dones_sp, init_dones_xsp, init_dones_sxp,
-                init_conf_hstate, init_ego_hstate, # hstates for conf-ego XP interaction
-                init_conf_hstate, init_br_hstate, # hstates for conf-br SP interaction
-                init_conf_hstate, init_ego_hstate, # hstates for conf-ego xsp interaction
-                init_conf_hstate, init_br_hstate, # hstates for conf-br sxp interaction
-                rng_update, update_steps
+                train_state_conf,
+                train_state_br,
+                env_state_xp,
+                env_state_sp,
+                env_state_xsp,
+                env_state_sxp,
+                obsv_xp,
+                obsv_sp,
+                obsv_xsp,
+                obsv_sxp,
+                init_dones_xp,
+                init_dones_sp,
+                init_dones_xsp,
+                init_dones_sxp,
+                init_conf_hstate,
+                init_ego_hstate,  # hstates for conf-ego XP interaction
+                init_conf_hstate,
+                init_br_hstate,  # hstates for conf-br SP interaction
+                init_conf_hstate,
+                init_ego_hstate,  # hstates for conf-ego xsp interaction
+                init_conf_hstate,
+                init_br_hstate,  # hstates for conf-br sxp interaction
+                rng_update,
+                update_steps,
             )
 
             state_with_ckpt = (
-                update_runner_state, checkpoint_array_conf, checkpoint_array_br, 
-                ckpt_idx, ep_infos_br, ep_infos_ego
+                update_runner_state,
+                checkpoint_array_conf,
+                checkpoint_array_br,
+                ckpt_idx,
+                ep_infos_br,
+                ep_infos_ego,
             )
             # run training
             state_with_ckpt, metrics = jax.lax.scan(
                 _update_step_with_ckpt,
                 state_with_ckpt,
                 xs=None,
-                length=config["NUM_UPDATES"]
+                length=config["NUM_UPDATES"],
             )
             (
-                final_runner_state, checkpoint_array_conf, checkpoint_array_br, 
-                final_ckpt_idx, last_ep_infos_br, last_ep_infos_ego
+                final_runner_state,
+                checkpoint_array_conf,
+                checkpoint_array_br,
+                _final_ckpt_idx,
+                _last_ep_infos_br,
+                _last_ep_infos_ego,
             ) = state_with_ckpt
 
             out = {
@@ -1198,6 +1976,7 @@ def train_regret_maximizing_partners(config, env,
             return out
 
         return train
+
     # ------------------------------
     # Actually run the adversarial teammate training
     # ------------------------------
@@ -1205,6 +1984,7 @@ def train_regret_maximizing_partners(config, env,
     train_fn = jax.jit(jax.vmap(make_regret_maximizing_partner_train(config)))
     out = train_fn(rngs, conf_params, br_params)
     return out
+
 
 def log_metrics(config, logger, outs, metric_names: tuple, live_logged: bool = False):
     """Process training metrics and log them using the provided logger.
@@ -1223,7 +2003,9 @@ def log_metrics(config, logger, outs, metric_names: tuple, live_logged: bool = F
     teammate_metrics = teammate_outs["metrics"]
     ego_metrics = ego_outs["metrics"]
 
-    num_seeds, num_open_ended_iters, _, num_ego_updates = ego_metrics["returned_episode_returns"].shape[:4]
+    _num_seeds, num_open_ended_iters, _, num_ego_updates = ego_metrics[
+        "returned_episode_returns"
+    ].shape[:4]
     num_partner_updates = teammate_metrics["returned_episode_returns"].shape[3]
 
     ### Process/extract ROTATE-specific losses
@@ -1232,25 +2014,53 @@ def log_metrics(config, logger, outs, metric_names: tuple, live_logged: bool = F
     eval_mean_dims = (0, 2, 4, 5)
     # training metrics: shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_partner_updates) — scalarized per step
     loss_mean_dims = (0, 2)
-    avg_teammate_sp_returns = np.asarray(teammate_metrics["eval_ep_last_info_br"]["returned_episode_returns"]).mean(axis=eval_mean_dims)
-    avg_teammate_xp_returns = np.asarray(teammate_metrics["eval_ep_last_info_ego"]["returned_episode_returns"]).mean(axis=eval_mean_dims)
+    avg_teammate_sp_returns = np.asarray(
+        teammate_metrics["eval_ep_last_info_br"]["returned_episode_returns"]
+    ).mean(axis=eval_mean_dims)
+    avg_teammate_xp_returns = np.asarray(
+        teammate_metrics["eval_ep_last_info_ego"]["returned_episode_returns"]
+    ).mean(axis=eval_mean_dims)
 
-    avg_value_losses_teammate_against_ego = np.asarray(teammate_metrics["value_loss_conf_against_ego"]).mean(axis=loss_mean_dims)
-    avg_value_losses_teammate_against_br = np.asarray(teammate_metrics["value_loss_conf_against_br"]).mean(axis=loss_mean_dims)
-    avg_value_losses_br = np.asarray(teammate_metrics["value_loss_br"]).mean(axis=loss_mean_dims)
+    avg_value_losses_teammate_against_ego = np.asarray(
+        teammate_metrics["value_loss_conf_against_ego"]
+    ).mean(axis=loss_mean_dims)
+    avg_value_losses_teammate_against_br = np.asarray(
+        teammate_metrics["value_loss_conf_against_br"]
+    ).mean(axis=loss_mean_dims)
+    avg_value_losses_br = np.asarray(teammate_metrics["value_loss_br"]).mean(
+        axis=loss_mean_dims
+    )
 
-    avg_actor_losses_teammate_against_ego = np.asarray(teammate_metrics["pg_loss_conf_against_ego"]).mean(axis=loss_mean_dims)
-    avg_actor_losses_teammate_against_br = np.asarray(teammate_metrics["pg_loss_conf_against_br"]).mean(axis=loss_mean_dims)
-    avg_actor_losses_br = np.asarray(teammate_metrics["pg_loss_br"]).mean(axis=loss_mean_dims)
+    avg_actor_losses_teammate_against_ego = np.asarray(
+        teammate_metrics["pg_loss_conf_against_ego"]
+    ).mean(axis=loss_mean_dims)
+    avg_actor_losses_teammate_against_br = np.asarray(
+        teammate_metrics["pg_loss_conf_against_br"]
+    ).mean(axis=loss_mean_dims)
+    avg_actor_losses_br = np.asarray(teammate_metrics["pg_loss_br"]).mean(
+        axis=loss_mean_dims
+    )
 
-    avg_entropy_losses_teammate_against_ego = np.asarray(teammate_metrics["entropy_conf_against_ego"]).mean(axis=loss_mean_dims)
-    avg_entropy_losses_teammate_against_br = np.asarray(teammate_metrics["entropy_conf_against_br"]).mean(axis=loss_mean_dims)
-    avg_entropy_losses_br = np.asarray(teammate_metrics["entropy_loss_br"]).mean(axis=loss_mean_dims)
+    avg_entropy_losses_teammate_against_ego = np.asarray(
+        teammate_metrics["entropy_conf_against_ego"]
+    ).mean(axis=loss_mean_dims)
+    avg_entropy_losses_teammate_against_br = np.asarray(
+        teammate_metrics["entropy_conf_against_br"]
+    ).mean(axis=loss_mean_dims)
+    avg_entropy_losses_br = np.asarray(teammate_metrics["entropy_loss_br"]).mean(
+        axis=loss_mean_dims
+    )
 
     # shape (num_seeds, num_open_ended_iters, num_partner_seeds, num_partner_updates)
-    avg_returns_teammate_against_br = np.asarray(teammate_metrics["average_returns_br"]).mean(axis=loss_mean_dims)
-    avg_returns_teammate_against_ego = np.asarray(teammate_metrics["average_returns_ego"]).mean(axis=loss_mean_dims)
-    avg_train_regret = np.asarray(teammate_metrics["train_regret"]).mean(axis=loss_mean_dims)
+    avg_returns_teammate_against_br = np.asarray(
+        teammate_metrics["average_returns_br"]
+    ).mean(axis=loss_mean_dims)
+    avg_returns_teammate_against_ego = np.asarray(
+        teammate_metrics["average_returns_ego"]
+    ).mean(axis=loss_mean_dims)
+    avg_train_regret = np.asarray(teammate_metrics["train_regret"]).mean(
+        axis=loss_mean_dims
+    )
 
     # Process ego-specific metrics.
     # Ego metrics from train_ppo_ego_agent are not pre-reduced (unlike the partner
@@ -1273,7 +2083,9 @@ def log_metrics(config, logger, outs, metric_names: tuple, live_logged: bool = F
         return num / den  # -> (num_open_ended_iters, num_ego_updates)
 
     # shape (num_seeds, num_open_ended_iters, num_ego_seeds, num_ego_updates, num_partners, num_eval_episodes, num_agents_per_env)
-    avg_ego_returns = np.asarray(ego_metrics["eval_ep_last_info"]["returned_episode_returns"]).mean(axis=(0, 2, 4, 5, 6))
+    avg_ego_returns = np.asarray(
+        ego_metrics["eval_ep_last_info"]["returned_episode_returns"]
+    ).mean(axis=(0, 2, 4, 5, 6))
     avg_ego_value_losses = _reduce_ego_scalar(ego_metrics["value_loss"])
     avg_ego_actor_losses = _reduce_ego_scalar(ego_metrics["actor_loss"])
     avg_ego_entropy_losses = _reduce_ego_scalar(ego_metrics["entropy_loss"])
@@ -1303,59 +2115,156 @@ def log_metrics(config, logger, outs, metric_names: tuple, live_logged: bool = F
             global_step = iter_idx * num_partner_updates + step
 
             # Eval metrics (checkpoint-based; always logged)
-            logger.log_item("Eval/ConfEgoReturn", avg_teammate_xp_returns[iter_idx][step], train_step=global_step)
-            logger.log_item("Eval/ConfBRReturn", avg_teammate_sp_returns[iter_idx][step], train_step=global_step)
-            logger.log_item("Eval/EgoRegret", avg_teammate_sp_returns[iter_idx][step] - avg_teammate_xp_returns[iter_idx][step], train_step=global_step)
+            logger.log_item(
+                "Eval/ConfEgoReturn",
+                avg_teammate_xp_returns[iter_idx][step],
+                train_step=global_step,
+            )
+            logger.log_item(
+                "Eval/ConfBRReturn",
+                avg_teammate_sp_returns[iter_idx][step],
+                train_step=global_step,
+            )
+            logger.log_item(
+                "Eval/EgoRegret",
+                avg_teammate_sp_returns[iter_idx][step]
+                - avg_teammate_xp_returns[iter_idx][step],
+                train_step=global_step,
+            )
 
             if not live_logged:
                 # Standard partner stats from get_stats (rollout returns)
                 for stat_name, stat_data in teammate_stat_means.items():
-                    logger.log_item(f"{PARTNER_LIVE_RETURNS_PREFIX}/{stat_name}", stat_data[iter_idx, step], train_step=global_step)
+                    logger.log_item(
+                        f"{PARTNER_LIVE_RETURNS_PREFIX}/{stat_name}",
+                        stat_data[iter_idx, step],
+                        train_step=global_step,
+                    )
 
                 # Confederate losses
-                logger.log_item("Losses/ConfEgoValLoss", avg_value_losses_teammate_against_ego[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/ConfEgoActorLoss", avg_actor_losses_teammate_against_ego[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/ConfEgoEntropy", avg_entropy_losses_teammate_against_ego[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/ConfBRValLoss", avg_value_losses_teammate_against_br[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/ConfBRActorLoss", avg_actor_losses_teammate_against_br[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/ConfBREntropy", avg_entropy_losses_teammate_against_br[iter_idx][step], train_step=global_step)
+                logger.log_item(
+                    "Losses/ConfEgoValLoss",
+                    avg_value_losses_teammate_against_ego[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/ConfEgoActorLoss",
+                    avg_actor_losses_teammate_against_ego[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/ConfEgoEntropy",
+                    avg_entropy_losses_teammate_against_ego[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/ConfBRValLoss",
+                    avg_value_losses_teammate_against_br[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/ConfBRActorLoss",
+                    avg_actor_losses_teammate_against_br[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/ConfBREntropy",
+                    avg_entropy_losses_teammate_against_br[iter_idx][step],
+                    train_step=global_step,
+                )
 
                 # Best response losses
-                logger.log_item("Losses/BRValLoss", avg_value_losses_br[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/BRActorLoss", avg_actor_losses_br[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/BREntropyLoss", avg_entropy_losses_br[iter_idx][step], train_step=global_step)
+                logger.log_item(
+                    "Losses/BRValLoss",
+                    avg_value_losses_br[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/BRActorLoss",
+                    avg_actor_losses_br[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/BREntropyLoss",
+                    avg_entropy_losses_br[iter_idx][step],
+                    train_step=global_step,
+                )
 
                 # Train returns (on-policy episodic returns; live analogue of Eval/Conf*Return)
-                logger.log_item("Losses/AvgConfEgoReturns", avg_returns_teammate_against_ego[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/AvgConfBRReturns", avg_returns_teammate_against_br[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/TrainRegret", avg_train_regret[iter_idx][step], train_step=global_step)
+                logger.log_item(
+                    "Losses/AvgConfEgoReturns",
+                    avg_returns_teammate_against_ego[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/AvgConfBRReturns",
+                    avg_returns_teammate_against_br[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/TrainRegret",
+                    avg_train_regret[iter_idx][step],
+                    train_step=global_step,
+                )
 
         ### Ego metrics processing
         for step in range(num_ego_updates):
             global_step = iter_idx * num_ego_updates + step
 
             # Ego eval metrics (checkpoint-based; always logged)
-            logger.log_item("Eval/EgoConfReturn", avg_ego_returns[iter_idx][step], train_step=global_step)
+            logger.log_item(
+                "Eval/EgoConfReturn",
+                avg_ego_returns[iter_idx][step],
+                train_step=global_step,
+            )
 
             if not live_logged:
                 # Standard ego stats from get_stats (rollout returns)
                 for stat_name, stat_data in ego_stat_means.items():
-                    logger.log_item(f"Train/Ego/{stat_name}", stat_data[iter_idx, step], train_step=global_step)
+                    logger.log_item(
+                        f"Train/Ego/{stat_name}",
+                        stat_data[iter_idx, step],
+                        train_step=global_step,
+                    )
 
                 # Ego agent losses
-                logger.log_item("Losses/EgoValueLoss", avg_ego_value_losses[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/EgoActorLoss", avg_ego_actor_losses[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/EgoEntropyLoss", avg_ego_entropy_losses[iter_idx][step], train_step=global_step)
-                logger.log_item("Losses/EgoGradNorm", avg_ego_grad_norms[iter_idx][step], train_step=global_step)
+                logger.log_item(
+                    "Losses/EgoValueLoss",
+                    avg_ego_value_losses[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/EgoActorLoss",
+                    avg_ego_actor_losses[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/EgoEntropyLoss",
+                    avg_ego_entropy_losses[iter_idx][step],
+                    train_step=global_step,
+                )
+                logger.log_item(
+                    "Losses/EgoGradNorm",
+                    avg_ego_grad_norms[iter_idx][step],
+                    train_step=global_step,
+                )
 
     logger.commit()
 
     # Saving artifacts — exclude BR checkpoints to minimize disk usage
-    savedir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir # type: ignore
-    teammate_outs_save = {k: v for k, v in teammate_outs.items() if k not in ("checkpoints_br", "checkpoints_conf")}
-    out_savepath = save_train_run((teammate_outs_save, ego_outs), savedir, savename="saved_train_run")
+    savedir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir  # type: ignore
+    teammate_outs_save = {
+        k: v
+        for k, v in teammate_outs.items()
+        if k not in ("checkpoints_br", "checkpoints_conf")
+    }
+    out_savepath = save_train_run(
+        (teammate_outs_save, ego_outs), savedir, savename="saved_train_run"
+    )
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="saved_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="saved_train_run", path=out_savepath, type_name="train_run"
+        )
 
     # Cleanup locally logged out file
     if not config["local_logger"]["save_train_out"]:
@@ -1370,17 +2279,37 @@ def initialize_ego_agent(config, env, rng, obs_dim_override=None):
     elif actor_type == "mlp":
         return initialize_mlp_agent(config, env, rng, obs_dim_override=obs_dim_override)
     else:
-        raise ValueError(f"Unsupported ACTOR_TYPE for ROTATE ego: {actor_type!r}. "
-                         "Choose from 's5', 'mlp'.")
+        raise ValueError(
+            f"Unsupported ACTOR_TYPE for ROTATE ego: {actor_type!r}. "
+            "Choose from 's5', 'mlp'."
+        )
 
-def persistent_open_ended_training_step(carry, ego_policy, conf_policy, br_policy,
-                                        partner_population, config, ego_config, env,
-                                        logger=None, partner_progress_callback=None, ego_progress_callback=None):
-    '''
+
+def persistent_open_ended_training_step(
+    carry,
+    ego_policy,
+    conf_policy,
+    br_policy,
+    partner_population,
+    config,
+    ego_config,
+    env,
+    logger=None,
+    partner_progress_callback=None,
+    ego_progress_callback=None,
+):
+    """
     Train the ego agent against a growing population of regret-maximizing partners.
     Unlike the original implementation, the partner population persists across iterations.
-    '''
-    prev_ego_params, prev_conf_params, prev_br_params, population_buffer, rng, oel_iter_idx = carry
+    """
+    (
+        prev_ego_params,
+        prev_conf_params,
+        prev_br_params,
+        population_buffer,
+        rng,
+        oel_iter_idx,
+    ) = carry
     rng, partner_rng, ego_rng, conf_init_rng, br_init_rng = jax.random.split(rng, 5)
 
     # Initialize or reuse confederate parameters based on config
@@ -1395,37 +2324,46 @@ def persistent_open_ended_training_step(carry, ego_policy, conf_policy, br_polic
         init_rngs = jax.random.split(br_init_rng, config["PARTNER_POP_SIZE"])
         br_params = jax.vmap(br_policy.init_params)(init_rngs)
     elif config["REINIT_BR_TO_EGO"]:
-        br_params = jax.tree.map(lambda x: x[jnp.newaxis, ...].repeat(config["PARTNER_POP_SIZE"], axis=0), prev_ego_params)
+        br_params = jax.tree.map(
+            lambda x: x[jnp.newaxis, ...].repeat(config["PARTNER_POP_SIZE"], axis=0),
+            prev_ego_params,
+        )
     else:
         br_params = prev_br_params
-    
+
     # Train partner agents with ego_policy
     train_out = train_regret_maximizing_partners(
-        config, env,
-        ego_params=prev_ego_params, ego_policy=ego_policy,
-        conf_params=conf_params, conf_policy=conf_policy,
-        br_params=br_params, br_policy=br_policy,
+        config,
+        env,
+        ego_params=prev_ego_params,
+        ego_policy=ego_policy,
+        conf_params=conf_params,
+        conf_policy=conf_policy,
+        br_params=br_params,
+        br_policy=br_policy,
         partner_rng=partner_rng,
         logger=logger,
-        progress_callback=partner_progress_callback)
-        
+        progress_callback=partner_progress_callback,
+    )
+
     if config["EGO_TEAMMATE"] == "final":
         all_conf_params = train_out["final_params_conf"]
-        
+
     elif config["EGO_TEAMMATE"] == "all":
         n_ckpts = config["PARTNER_POP_SIZE"] * config["NUM_CHECKPOINTS"]
-        conf_ckpt_params= jax.tree.map(
-            lambda x: x.reshape((n_ckpts,) + x.shape[2:]), 
-            train_out["checkpoints_conf"]
+        conf_ckpt_params = jax.tree.map(
+            lambda x: x.reshape((n_ckpts,) + x.shape[2:]), train_out["checkpoints_conf"]
         )
         all_conf_params = jax.tree.map(
             lambda x, y: jnp.concatenate([x, y], axis=0),
             conf_ckpt_params,
-            train_out["final_params_conf"]
+            train_out["final_params_conf"],
         )
-    
+
     # Add all checkpoints and final parameters of all partners to the buffer
-    updated_buffer = add_partners_to_buffer(partner_population, population_buffer, all_conf_params)
+    updated_buffer = add_partners_to_buffer(
+        partner_population, population_buffer, all_conf_params
+    )
 
     # Train ego agent using the population buffer
     ego_out = train_ppo_ego_agent_with_buffer(
@@ -1438,7 +2376,7 @@ def persistent_open_ended_training_step(carry, ego_policy, conf_policy, br_polic
         partner_population=partner_population,
         population_buffer=updated_buffer,
         logger=logger,
-        progress_callback=ego_progress_callback
+        progress_callback=ego_progress_callback,
     )
 
     updated_ego_parameters = ego_out["final_params"]
@@ -1446,31 +2384,51 @@ def persistent_open_ended_training_step(carry, ego_policy, conf_policy, br_polic
     updated_br_parameters = train_out["final_params_br"]
 
     # Remove initial dimension of 1, to ensure that input and output carry have the same dimension
-    updated_ego_parameters = jax.tree_map(lambda x: x.squeeze(axis=0), updated_ego_parameters)
+    updated_ego_parameters = jax.tree_map(
+        lambda x: x.squeeze(axis=0), updated_ego_parameters
+    )
 
-    carry = (updated_ego_parameters, updated_conf_parameters, updated_br_parameters, 
-             updated_buffer, rng, oel_iter_idx + 1)
+    carry = (
+        updated_ego_parameters,
+        updated_conf_parameters,
+        updated_br_parameters,
+        updated_buffer,
+        rng,
+        oel_iter_idx + 1,
+    )
     return carry, (train_out, ego_out)
 
 
-def train_persistent(rng, env, algorithm_config, ego_config,
-                     logger=None, partner_progress_callback=None, ego_progress_callback=None):
-    rng, init_ego_rng, init_conf_rng1, init_conf_rng2, init_br_rng, train_rng = jax.random.split(rng, 6)
+def train_persistent(
+    rng,
+    env,
+    algorithm_config,
+    ego_config,
+    logger=None,
+    partner_progress_callback=None,
+    ego_progress_callback=None,
+):
+    rng, init_ego_rng, init_conf_rng1, init_conf_rng2, init_br_rng, train_rng = (
+        jax.random.split(rng, 6)
+    )
 
     # Compute augmented obs_dim for parameter sharing (raw obs + one-hot agent ID)
     raw_obs_dim = env.observation_space(env.agents[0]).shape[0]
-    ego_indices, teammate_indices = get_ego_teammate_indices(algorithm_config, env)
+    _ego_indices, _teammate_indices = get_ego_teammate_indices(algorithm_config, env)
     augment_obs = algorithm_config.get("EGO_INDICES") is not None
     aug_obs_dim = raw_obs_dim + env.num_agents if augment_obs else raw_obs_dim
 
     # Architecture of the confederate/BR/population policies.
     partner_actor_type = algorithm_config.get("PARTNER_ACTOR_TYPE", "mlp")
-    assert partner_actor_type in ("mlp", "s5"), \
+    assert partner_actor_type in ("mlp", "s5"), (
         f"PARTNER_ACTOR_TYPE must be one of ('mlp', 's5'), got '{partner_actor_type}'"
+    )
     recurrent = partner_actor_type == "s5"
 
     # Initialize ego agent
-    ego_policy, init_ego_params = initialize_ego_agent(ego_config, env, init_ego_rng, obs_dim_override=aug_obs_dim)
+    ego_policy, init_ego_params = initialize_ego_agent(
+        ego_config, env, init_ego_rng, obs_dim_override=aug_obs_dim
+    )
 
     # Initialize confederate agent
     if recurrent:
@@ -1494,10 +2452,14 @@ def train_persistent(rng, env, algorithm_config, ego_config,
             obs_dim=aug_obs_dim,
             fc_hidden_dim=algorithm_config.get("FC_HIDDEN_DIM", 64),
         )
-    init_conf_rngs = jax.random.split(init_conf_rng1, algorithm_config["PARTNER_POP_SIZE"])
+    init_conf_rngs = jax.random.split(
+        init_conf_rng1, algorithm_config["PARTNER_POP_SIZE"]
+    )
     init_conf_params = jax.vmap(conf_policy.init_params)(init_conf_rngs)
-    
-    assert not (algorithm_config["REINIT_BR_TO_EGO"] and algorithm_config["REINIT_BR_TO_BR"]), "Cannot reinitialize br to both ego and br"
+
+    assert not (
+        algorithm_config["REINIT_BR_TO_EGO"] and algorithm_config["REINIT_BR_TO_BR"]
+    ), "Cannot reinitialize br to both ego and br"
     if algorithm_config["REINIT_BR_TO_EGO"] or recurrent:
         br_policy = S5ActorCriticPolicy(
             action_dim=env.action_space(env.agents[0]).n,
@@ -1521,26 +2483,35 @@ def train_persistent(rng, env, algorithm_config, ego_config,
         )
     init_br_rngs = jax.random.split(init_br_rng, algorithm_config["PARTNER_POP_SIZE"])
     init_br_params = jax.vmap(br_policy.init_params)(init_br_rngs)
-    
+
     # Create persistent partner population with BufferedPopulation
     # The max_pop_size must be large enough to hold all agents across all iterations
 
     if algorithm_config["EGO_TEAMMATE"] == "final":
-        max_pop_size = algorithm_config["PARTNER_POP_SIZE"] * algorithm_config["NUM_OPEN_ENDED_ITERS"]
+        max_pop_size = (
+            algorithm_config["PARTNER_POP_SIZE"]
+            * algorithm_config["NUM_OPEN_ENDED_ITERS"]
+        )
     elif algorithm_config["EGO_TEAMMATE"] == "all":
-        max_pop_size = (algorithm_config["PARTNER_POP_SIZE"] * algorithm_config["NUM_CHECKPOINTS"] + 1) * \
-                       algorithm_config["NUM_OPEN_ENDED_ITERS"]
+        max_pop_size = (
+            algorithm_config["PARTNER_POP_SIZE"] * algorithm_config["NUM_CHECKPOINTS"]
+            + 1
+        ) * algorithm_config["NUM_OPEN_ENDED_ITERS"]
     else:
-        raise ValueError(f"Invalid EGO_TEAMMATE value: {algorithm_config['EGO_TEAMMATE']}")
+        raise ValueError(
+            f"Invalid EGO_TEAMMATE value: {algorithm_config['EGO_TEAMMATE']}"
+        )
 
     # hack to initialize the partner population's conf policy class with the right initializer shape.
     # Must match the confederate policy class or ego training fails on param-structure mismatch.
     if recurrent:
         conf_policy2, init_conf_params2 = initialize_s5_actor_with_double_critic(
-            algorithm_config, env, init_conf_rng2, obs_dim_override=aug_obs_dim)
+            algorithm_config, env, init_conf_rng2, obs_dim_override=aug_obs_dim
+        )
     else:
         conf_policy2, init_conf_params2 = initialize_actor_with_double_critic(
-            algorithm_config, env, init_conf_rng2, obs_dim_override=aug_obs_dim)
+            algorithm_config, env, init_conf_rng2, obs_dim_override=aug_obs_dim
+        )
     partner_population = BufferedPopulation(
         max_pop_size=max_pop_size,
         policy_cls=conf_policy2,
@@ -1552,21 +2523,37 @@ def train_persistent(rng, env, algorithm_config, ego_config,
 
     @jax.jit
     def open_ended_step_fn(carry, unused):
-        return persistent_open_ended_training_step(carry, ego_policy, conf_policy, br_policy, 
-                                                 partner_population, algorithm_config, ego_config, env,
-                                                 logger=logger,
-                                                 partner_progress_callback=partner_progress_callback,
-                                                 ego_progress_callback=ego_progress_callback)
-    
-    init_carry = (init_ego_params, init_conf_params, init_br_params, population_buffer, train_rng, 0)
-    final_carry, outs = jax.lax.scan(
-        open_ended_step_fn, 
-        init_carry, 
+        return persistent_open_ended_training_step(
+            carry,
+            ego_policy,
+            conf_policy,
+            br_policy,
+            partner_population,
+            algorithm_config,
+            ego_config,
+            env,
+            logger=logger,
+            partner_progress_callback=partner_progress_callback,
+            ego_progress_callback=ego_progress_callback,
+        )
+
+    init_carry = (
+        init_ego_params,
+        init_conf_params,
+        init_br_params,
+        population_buffer,
+        train_rng,
+        0,
+    )
+    _final_carry, outs = jax.lax.scan(
+        open_ended_step_fn,
+        init_carry,
         xs=None,
-        length=algorithm_config["NUM_OPEN_ENDED_ITERS"]
+        length=algorithm_config["NUM_OPEN_ENDED_ITERS"],
     )
 
     return outs
+
 
 def run_rotate(config, wandb_logger):
     algorithm_config = dict(config["algorithm"])
@@ -1574,7 +2561,7 @@ def run_rotate(config, wandb_logger):
     # Create only one environment instance
     env = make_env(algorithm_config["ENV_NAME"], algorithm_config["ENV_KWARGS"])
     env = LogWrapper(env)
-    
+
     rng = jax.random.PRNGKey(algorithm_config["TRAIN_SEED"])
     rng, init_ego_rng = jax.random.split(rng)
     rngs = jax.random.split(rng, algorithm_config["NUM_SEEDS"])
@@ -1592,30 +2579,45 @@ def run_rotate(config, wandb_logger):
 
     num_partner_updates = compute_partner_num_updates(algorithm_config)
     num_ego_updates = compute_ego_num_updates(ego_config)
-    total_partner_updates = num_partner_updates * algorithm_config["NUM_OPEN_ENDED_ITERS"]
+    total_partner_updates = (
+        num_partner_updates * algorithm_config["NUM_OPEN_ENDED_ITERS"]
+    )
     total_ego_updates = num_ego_updates * algorithm_config["NUM_OPEN_ENDED_ITERS"]
 
-    pbar_partner = tqdm(total=total_partner_updates, desc="ROTATE Partner Training", unit="update")
+    pbar_partner = tqdm(
+        total=total_partner_updates, desc="ROTATE Partner Training", unit="update"
+    )
     pbar_ego = tqdm(total=total_ego_updates, desc="ROTATE Ego Training", unit="update")
     # vmap fires num_seeds * PARTNER_POP_SIZE times per partner update step; num_seeds per ego step.
     # These stateful callbacks advance the progress bar AND live-log per-update metrics (aggregated
     # over the seed/population axes) under the end-of-run naming scheme; see make_live_log_callback.
     partner_progress_callback = make_live_log_callback(
-        pbar_partner, num_parallel=num_seeds * algorithm_config["PARTNER_POP_SIZE"],
-        logger=wandb_logger, loss_key_map=PARTNER_LIVE_LOSS_KEYS,
-        returns_prefix=PARTNER_LIVE_RETURNS_PREFIX)
+        pbar_partner,
+        num_parallel=num_seeds * algorithm_config["PARTNER_POP_SIZE"],
+        logger=wandb_logger,
+        loss_key_map=PARTNER_LIVE_LOSS_KEYS,
+        returns_prefix=PARTNER_LIVE_RETURNS_PREFIX,
+    )
     ego_progress_callback = make_live_log_callback(
-        pbar_ego, num_parallel=num_seeds,
-        logger=wandb_logger, loss_key_map=EGO_LIVE_LOSS_KEYS,
-        returns_prefix=EGO_LIVE_RETURNS_PREFIX)
+        pbar_ego,
+        num_parallel=num_seeds,
+        logger=wandb_logger,
+        loss_key_map=EGO_LIVE_LOSS_KEYS,
+        returns_prefix=EGO_LIVE_RETURNS_PREFIX,
+    )
 
     DEBUG = False
     with jax.disable_jit(DEBUG):
-        train_fn = jax.jit(jax.vmap(partial(train_persistent, 
-                env=env, algorithm_config=algorithm_config, ego_config=ego_config,
-                logger=wandb_logger,
-                partner_progress_callback=partner_progress_callback,
-                ego_progress_callback=ego_progress_callback
+        train_fn = jax.jit(
+            jax.vmap(
+                partial(
+                    train_persistent,
+                    env=env,
+                    algorithm_config=algorithm_config,
+                    ego_config=ego_config,
+                    logger=wandb_logger,
+                    partner_progress_callback=partner_progress_callback,
+                    ego_progress_callback=ego_progress_callback,
                 )
             )
         )
@@ -1623,20 +2625,24 @@ def run_rotate(config, wandb_logger):
 
     pbar_partner.close()
     pbar_ego.close()
-    
+
     end_time = time.time()
     log.info(f"ROTATE training completed in {end_time - start_time} seconds.")
 
     metric_names = get_metric_names(algorithm_config["ENV_NAME"])
-    
+
     ### Prepare return values for heldout evaluation
     teammate_outs, ego_outs = outs
-    ego_params = jax.tree_map(lambda x: x[:, :, 0], ego_outs["final_params"]) # shape (num_seeds, num_open_ended_iters, 1, num_ckpts, leaf_dim)
+    ego_params = jax.tree_map(
+        lambda x: x[:, :, 0], ego_outs["final_params"]
+    )  # shape (num_seeds, num_open_ended_iters, 1, num_ckpts, leaf_dim)
     raw_obs_dim = env.observation_space(env.agents[0]).shape[0]
     augment_obs = algorithm_config.get("EGO_INDICES") is not None
     aug_obs_dim = raw_obs_dim + env.num_agents if augment_obs else raw_obs_dim
     # Use ego_config so the eval-time policy matches the trained ego architecture
-    ego_policy, init_ego_params = initialize_ego_agent(ego_config, env, init_ego_rng, obs_dim_override=aug_obs_dim)
+    ego_policy, init_ego_params = initialize_ego_agent(
+        ego_config, env, init_ego_rng, obs_dim_override=aug_obs_dim
+    )
 
     ### Prep reduced version of outs for saving
     # Save only the buffer from the last iteration of OEL, rather than all iterations
@@ -1649,7 +2655,8 @@ def run_rotate(config, wandb_logger):
     # live_logged=True: per-update loss/reward/return stats were already logged live during
     # training (via the make_live_log_callback callbacks above), so log_metrics skips them and
     # logs only the checkpoint-based Eval/* metrics that cannot be computed live.
-    log_metrics(config, wandb_logger, (teammate_outs, ego_outs), metric_names,
-                live_logged=True)
+    log_metrics(
+        config, wandb_logger, (teammate_outs, ego_outs), metric_names, live_logged=True
+    )
 
     return ego_policy, ego_params, init_ego_params

--- a/open_ended_training/rotate.py
+++ b/open_ended_training/rotate.py
@@ -92,6 +92,7 @@ class ConfTransition(NamedTuple):
     obs: jnp.ndarray
     info: jnp.ndarray
     avail_actions: jnp.ndarray
+    prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
 def compute_partner_num_updates(cfg):
     return int(
@@ -360,7 +361,8 @@ def train_regret_maximizing_partners(config, env,
                     log_prob=logp_conf,         # (NUM_UNCONTROLLED_ACTORS,)
                     obs=obs_conf,               # (NUM_UNCONTROLLED_ACTORS, aug_obs_dim)
                     info=info_conf,
-                    avail_actions=avail_actions_conf  # (NUM_UNCONTROLLED_ACTORS, n_actions)
+                    avail_actions=avail_actions_conf,  # (NUM_UNCONTROLLED_ACTORS, n_actions)
+                    prev_done=dones_conf               # (NUM_UNCONTROLLED_ACTORS,) pre-step done
                 )
                 reset_transition = ResetTransition(
                     env_state=env_state,
@@ -465,7 +467,8 @@ def train_regret_maximizing_partners(config, env,
                     log_prob=logp_conf,
                     obs=obs_conf,
                     info=info_conf,
-                    avail_actions=avail_actions_conf
+                    avail_actions=avail_actions_conf,
+                    prev_done=dones_conf  # (NUM_UNCONTROLLED_ACTORS,) pre-step done
                 )
                 br_done_stacked = augment_done(done, ego_indices, config["NUM_ENVS"])  # (NUM_CONTROLLED_ACTORS,)
                 transition_br = Transition(
@@ -476,7 +479,8 @@ def train_regret_maximizing_partners(config, env,
                     log_prob=logp_br,
                     obs=obs_br,
                     info=info_br,
-                    avail_actions=avail_actions_br
+                    avail_actions=avail_actions_br,
+                    prev_done=dones_br  # (NUM_CONTROLLED_ACTORS,) pre-step done
                 )
                 reset_transition = ResetTransition(
                     env_state=env_state,
@@ -582,7 +586,7 @@ def train_regret_maximizing_partners(config, env,
                         _, (value_xp_on_xp_data, value_sp_on_xp_data), pi_xp, _ = confederate_policy.get_action_value_policy(
                             params=params, 
                             obs=traj_batch_xp.obs, 
-                            done=traj_batch_xp.done,
+                            done=traj_batch_xp.prev_done,
                             avail_actions=traj_batch_xp.avail_actions,
                             hstate=init_conf_hstate,
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here 
@@ -590,7 +594,7 @@ def train_regret_maximizing_partners(config, env,
                         _, (value_xp_on_sp_data, value_sp_on_sp_data), pi_sp, _ = confederate_policy.get_action_value_policy(
                             params=params, 
                             obs=traj_batch_sp.obs, 
-                            done=traj_batch_sp.done,
+                            done=traj_batch_sp.prev_done,
                             avail_actions=traj_batch_sp.avail_actions,
                             hstate=init_conf_hstate,
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here 
@@ -599,7 +603,7 @@ def train_regret_maximizing_partners(config, env,
                         _, (value_xp_on_xsp_data, value_sp_on_xsp_data), pi_xsp, _ = confederate_policy.get_action_value_policy(
                             params=params, 
                             obs=traj_batch_xsp.obs, 
-                            done=traj_batch_xsp.done,
+                            done=traj_batch_xsp.prev_done,
                             avail_actions=traj_batch_xsp.avail_actions,
                             hstate=init_conf_hstate,
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here 
@@ -608,7 +612,7 @@ def train_regret_maximizing_partners(config, env,
                         _, (value_xp_on_sxp_data, value_sp_on_sxp_data), pi_sxp, _ = confederate_policy.get_action_value_policy(
                             params=params, 
                             obs=traj_batch_sxp.obs, 
-                            done=traj_batch_sxp.done,
+                            done=traj_batch_sxp.prev_done,
                             avail_actions=traj_batch_sxp.avail_actions,
                             hstate=init_conf_hstate,
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here 
@@ -687,7 +691,7 @@ def train_regret_maximizing_partners(config, env,
                         _, value, pi, _ = br_policy.get_action_value_policy(
                             params=params, 
                             obs=traj_batch.obs, 
-                            done=traj_batch.done,
+                            done=traj_batch.prev_done,
                             avail_actions=traj_batch.avail_actions,
                             hstate=init_br_hstate_merged,
                             rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here 

--- a/open_ended_training/trajedi.py
+++ b/open_ended_training/trajedi.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 class Transition(NamedTuple):
-    done: jnp.ndarray
+    done: jnp.ndarray  # done at t+1 (post-step); used for GAE
     action: jnp.ndarray
     value: jnp.ndarray
     agent_onehot_id: jnp.ndarray
@@ -36,9 +36,10 @@ class Transition(NamedTuple):
     avail_actions: jnp.ndarray
     episode_id: jnp.ndarray
     time_id: jnp.ndarray
+    prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
 class TransitionEgo(NamedTuple):
-    done: jnp.ndarray
+    done: jnp.ndarray  # done at t+1 (post-step); used for GAE
     action: jnp.ndarray
     value: jnp.ndarray
     reward: jnp.ndarray
@@ -46,6 +47,7 @@ class TransitionEgo(NamedTuple):
     obs: jnp.ndarray
     info: jnp.ndarray
     avail_actions: jnp.ndarray
+    prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
 def gather_params(partner_params_pytree, idx_vec):
     """
@@ -269,7 +271,8 @@ def train_trajedi_partners(config, env, partner_rng):
                     info=info_0,
                     avail_actions=avail_actions_0,
                     episode_id=last_eps_counter,
-                    time_id=last_timestep_counter
+                    time_id=last_timestep_counter,
+                    prev_done=last_done["agent_0"]
                 )
 
                 transition_1 = Transition(
@@ -283,7 +286,8 @@ def train_trajedi_partners(config, env, partner_rng):
                     info=info_1,
                     avail_actions=avail_actions_1,
                     episode_id=last_eps_counter,
-                    time_id=last_timestep_counter
+                    time_id=last_timestep_counter,
+                    prev_done=last_done["agent_1"]
                 )
 
                 last_eps_counter = last_eps_counter + done["agent_0"].astype(int)
@@ -401,8 +405,8 @@ def train_trajedi_partners(config, env, partner_rng):
                     info=info_0,
                     avail_actions=avail_actions_0,
                     episode_id=jnp.zeros_like(done["agent_0"].astype(int)),
-                    time_id=jnp.zeros_like(done["agent_0"].astype(int))
-
+                    time_id=jnp.zeros_like(done["agent_0"].astype(int)),
+                    prev_done=last_done["agent_0"]
                 )
 
                 transition_1 = Transition(
@@ -416,7 +420,8 @@ def train_trajedi_partners(config, env, partner_rng):
                     info=info_1,
                     avail_actions=avail_actions_1,
                     episode_id=jnp.zeros_like(done["agent_1"].astype(int)),
-                    time_id=jnp.zeros_like(done["agent_1"].astype(int))
+                    time_id=jnp.zeros_like(done["agent_1"].astype(int)),
+                    prev_done=last_done["agent_1"]
                 )
 
                 new_runner_state = (all_train_state_conf, train_state_ego,
@@ -501,7 +506,8 @@ def train_trajedi_partners(config, env, partner_rng):
                     log_prob=logp_0,
                     obs=last_obs_br_sp["agent_0"],
                     info=info_0,
-                    avail_actions=avail_actions_0
+                    avail_actions=avail_actions_0,
+                    prev_done=last_done_br_sp["agent_0"]
                 )
 
                 transition_1 = TransitionEgo(
@@ -512,7 +518,8 @@ def train_trajedi_partners(config, env, partner_rng):
                     log_prob=logp_1,
                     obs=last_obs_br_sp["agent_1"],
                     info=info_1,
-                    avail_actions=avail_actions_1
+                    avail_actions=avail_actions_1,
+                    prev_done=last_done_br_sp["agent_1"]
                 )
 
                 (
@@ -586,7 +593,7 @@ def train_trajedi_partners(config, env, partner_rng):
                             _, (vals_sp1, _), pi_conf_sp1, _ = confederate_policy.get_action_value_policy(
                                 params=jax.tree.map(lambda x: jnp.squeeze(x, axis=0), param),
                                 obs=traj_batch_conf_sp1.obs,
-                                done=traj_batch_conf_sp1.done,
+                                done=traj_batch_conf_sp1.prev_done,
                                 avail_actions=traj_batch_conf_sp1.avail_actions,
                                 hstate=init_hstate_conf_sp1,
                                 rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
@@ -594,7 +601,7 @@ def train_trajedi_partners(config, env, partner_rng):
                             _, (vals_sp2, _), pi_conf_sp2, _ = confederate_policy.get_action_value_policy(
                                 params=jax.tree.map(lambda x: jnp.squeeze(x, axis=0), param),
                                 obs=traj_batch_conf_sp2.obs,
-                                done=traj_batch_conf_sp2.done,
+                                done=traj_batch_conf_sp2.prev_done,
                                 avail_actions=traj_batch_conf_sp2.avail_actions,
                                 hstate=init_hstate_conf_sp2,
                                 rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
@@ -613,7 +620,7 @@ def train_trajedi_partners(config, env, partner_rng):
                             _, (_, value_conf_xp), pi_conf_xp, _ = confederate_policy.get_action_value_policy(
                                 params=jax.tree.map(lambda x: jnp.squeeze(x, axis=0), param),
                                 obs=traj_batch_conf_xp.obs,
-                                done=traj_batch_conf_xp.done,
+                                done=traj_batch_conf_xp.prev_done,
                                 avail_actions=traj_batch_conf_xp.avail_actions,
                                 hstate=init_hstate_conf_xp,
                                 rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
@@ -922,7 +929,7 @@ def train_trajedi_partners(config, env, partner_rng):
                             _, value, pi, _ = ego_policy.get_action_value_policy(
                                 params=params, # (64,)
                                 obs=traj_batch_ego.obs, # (512, 15)
-                                done=traj_batch_ego.done, # (512,)
+                                done=traj_batch_ego.prev_done, # (512,)
                                 avail_actions=traj_batch_ego.avail_actions, # (512, 6)
                                 hstate=init_hstate_ego, # (1, 16, 8)
                                 rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here

--- a/open_ended_training/trajedi.py
+++ b/open_ended_training/trajedi.py
@@ -1,7 +1,9 @@
-'''TrajeDi: trains a population of confederates via self-play and cross-play against an ego agent.'''
+"""TrajeDi: trains a population of confederates via self-play and cross-play against an ego agent."""
+
+import logging
 import shutil
 import time
-import logging
+from typing import NamedTuple
 
 import hydra
 import jax
@@ -9,20 +11,22 @@ import jax.nn
 import jax.numpy as jnp
 import numpy as np
 import optax
-from typing import NamedTuple
 from flax.training.train_state import TrainState
 
-from agents.mlp_actor_critic_agent import ActorWithDoubleCriticPolicy, MLPActorCriticPolicy, ActorWithConditionalCriticPolicy
 from agents.initialize_agents import initialize_s5_agent
-from common.plot_utils import get_stats, get_metric_names
-from common.save_load_utils import save_train_run
+from agents.mlp_actor_critic_agent import (
+    ActorWithDoubleCriticPolicy,
+)
+from common.plot_utils import get_metric_names, get_stats
 from common.run_episodes import run_episodes
-from marl.ppo_utils import Transition, unbatchify, _create_minibatches
+from common.save_load_utils import save_train_run
 from envs import make_env
 from envs.log_wrapper import LogWrapper
+from marl.ppo_utils import _create_minibatches, unbatchify
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
+
 
 class Transition(NamedTuple):
     done: jnp.ndarray  # done at t+1 (post-step); used for GAE
@@ -38,6 +42,7 @@ class Transition(NamedTuple):
     time_id: jnp.ndarray
     prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
+
 class TransitionEgo(NamedTuple):
     done: jnp.ndarray  # done at t+1 (post-step); used for GAE
     action: jnp.ndarray
@@ -49,6 +54,7 @@ class TransitionEgo(NamedTuple):
     avail_actions: jnp.ndarray
     prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
+
 def gather_params(partner_params_pytree, idx_vec):
     """
     partner_params_pytree: pytree with all partner params. Each leaf has shape (n_seeds, m_ckpts, ...).
@@ -57,51 +63,79 @@ def gather_params(partner_params_pytree, idx_vec):
     Return a new pytree where each leaf has shape (num_envs, ...). Each leaf has a sampled
     partner's parameters for each environment.
     """
+
     # We'll define a function that gathers from each leaf
     # where leaf has shape (n_seeds, m_ckpts, ...), we want [idx_vec[i]] for each i.
     # We'll vmap a slicing function.
     def gather_leaf(leaf):
         def slice_one(idx):
             return leaf[idx]  # shape (...)
+
         return jax.vmap(slice_one)(idx_vec)
 
     return jax.tree.map(gather_leaf, partner_params_pytree)
 
+
 def train_trajedi_partners(config, env, partner_rng):
-    '''Train a population of confederates and an ego agent; return model checkpoints and metrics.'''
+    """Train a population of confederates and an ego agent; return model checkpoints and metrics."""
+
     def make_train(config):
         num_agents = env.num_agents
-        assert num_agents == 2, "This code assumes the environment has exactly 2 agents."
+        assert num_agents == 2, (
+            "This code assumes the environment has exactly 2 agents."
+        )
 
         config["NUM_CONF_ACTORS"] = config["NUM_ENVS_CONFS"]
         config["NUM_EGO_ACTORS"] = config["NUM_ENVS_BR"]
 
         # TOTAL_TIMESTEPS is the total env steps budget across all rollouts; each confederate member
         # sees ~TOTAL_TIMESTEPS / PARTNER_POP_SIZE steps on average.
-        config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // (config["ROLLOUT_LENGTH"] * (2*config["NUM_ENVS_CONFS"]+config["NUM_ENVS_BR"]))
-        assert config["NUM_CONF_ACTORS"] % config["NUM_MINIBATCHES"] == 0, "NUM_CONF_ACTORS must be divisible by NUM_MINIBATCHES"
-        assert config["NUM_EGO_ACTORS"] % config["NUM_MINIBATCHES"] == 0, "NUM_EGO_ACTORS must be divisible by NUM_MINIBATCHES"
-        assert config["NUM_CONF_ACTORS"] >= config["NUM_MINIBATCHES"], "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
-        assert config["NUM_EGO_ACTORS"] >= config["NUM_MINIBATCHES"], "NUM_EGO_ACTORS must be >= NUM_MINIBATCHES"
+        config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // (
+            config["ROLLOUT_LENGTH"]
+            * (2 * config["NUM_ENVS_CONFS"] + config["NUM_ENVS_BR"])
+        )
+        assert config["NUM_CONF_ACTORS"] % config["NUM_MINIBATCHES"] == 0, (
+            "NUM_CONF_ACTORS must be divisible by NUM_MINIBATCHES"
+        )
+        assert config["NUM_EGO_ACTORS"] % config["NUM_MINIBATCHES"] == 0, (
+            "NUM_EGO_ACTORS must be divisible by NUM_MINIBATCHES"
+        )
+        assert config["NUM_CONF_ACTORS"] >= config["NUM_MINIBATCHES"], (
+            "NUM_CONTROLLED_ACTORS must be >= NUM_MINIBATCHES"
+        )
+        assert config["NUM_EGO_ACTORS"] >= config["NUM_MINIBATCHES"], (
+            "NUM_EGO_ACTORS must be >= NUM_MINIBATCHES"
+        )
 
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng):
             # Initialize ego and confederate policies
             rng, init_ego_rng, init_conf_rng = jax.random.split(rng, 3)
-            all_conf_init_rngs = jax.random.split(init_conf_rng, config["PARTNER_POP_SIZE"])
+            all_conf_init_rngs = jax.random.split(
+                init_conf_rng, config["PARTNER_POP_SIZE"]
+            )
 
             # Initialize ego agent policy
             ego_policy, init_ego_params = initialize_s5_agent(config, env, init_ego_rng)
             init_ego_hstate_xp = ego_policy.init_hstate(config["NUM_CONF_ACTORS"])
-            init_ego_hstate_sp = ego_policy.init_hstate(config["NUM_EGO_ACTORS"])
+            ego_policy.init_hstate(config["NUM_EGO_ACTORS"])
 
             # Define optimizers for ego policy
             tx_ego = optax.chain(
                 optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"], eps=1e-5),
+                optax.adam(
+                    learning_rate=linear_schedule
+                    if config["ANNEAL_LR"]
+                    else config["LR"],
+                    eps=1e-5,
+                ),
             )
 
             train_state_ego = TrainState.create(
@@ -118,21 +152,27 @@ def train_trajedi_partners(config, env, partner_rng):
             init_conf_hstate = confederate_policy.init_hstate(config["NUM_CONF_ACTORS"])
 
             # Initialize parameters using the policy interfaces
-            init_params_conf = confederate_policy.init_params(init_conf_rng)
+            confederate_policy.init_params(init_conf_rng)
 
             def init_train_states(rng_agents):
                 def init_single_pop_member_optimizers(rng_agent):
                     init_params_conf = confederate_policy.init_params(rng_agent)
                     return init_params_conf
 
-                init_all_networks_and_optimizers = jax.vmap(init_single_pop_member_optimizers)
+                init_all_networks_and_optimizers = jax.vmap(
+                    init_single_pop_member_optimizers
+                )
                 all_conf_params = init_all_networks_and_optimizers(rng_agents)
 
                 # Define optimizer for confederate policy
                 tx = optax.chain(
                     optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                    optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"],
-                    eps=1e-5),
+                    optax.adam(
+                        learning_rate=linear_schedule
+                        if config["ANNEAL_LR"]
+                        else config["LR"],
+                        eps=1e-5,
+                    ),
                 )
 
                 train_state_conf = TrainState.create(
@@ -142,7 +182,7 @@ def train_trajedi_partners(config, env, partner_rng):
                 )
 
                 return train_state_conf
-            
+
             train_state_conf = init_train_states(all_conf_init_rngs)
 
             def forward_pass_conf(params, obs, done, avail_actions, hstate, rng):
@@ -152,7 +192,7 @@ def train_trajedi_partners(config, env, partner_rng):
                     done=done[jnp.newaxis, ...],
                     avail_actions=avail_actions,
                     hstate=hstate,
-                    rng=rng
+                    rng=rng,
                 )
                 return act, val, pi, new_hstate
 
@@ -174,46 +214,55 @@ def train_trajedi_partners(config, env, partner_rng):
                 Returns updated runner_state, and Transitions for agent_0 and agent_1.
                 """
                 (
-                    all_train_state_conf, last_conf_ids,
-                    env_state, 
-                    last_obs, last_done, last_conf_h_p1, last_conf_h_p2,
-                    last_eps_counter, 
+                    all_train_state_conf,
+                    last_conf_ids,
+                    env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h_p1,
+                    last_conf_h_p2,
+                    last_eps_counter,
                     last_timestep_counter,
-                    rng
+                    rng,
                 ) = runner_state
-                rng, act0_rng_sp, act1_rng_sp, step_rng_sp, conf_sampling_rng = jax.random.split(rng, 5)
+                rng, act0_rng_sp, act1_rng_sp, step_rng_sp, conf_sampling_rng = (
+                    jax.random.split(rng, 5)
+                )
 
                 # For done envs, resample both conf and brs
                 needs_resample = last_done["__all__"]
-                resampled_conf_ids = jax.random.randint(conf_sampling_rng, (config["NUM_CONF_ACTORS"],), 0, config["PARTNER_POP_SIZE"])
+                resampled_conf_ids = jax.random.randint(
+                    conf_sampling_rng,
+                    (config["NUM_CONF_ACTORS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
                 identity_matrix = jnp.eye(config["PARTNER_POP_SIZE"])
-                
+
                 # Determine final indices based on whether resampling was needed for each env
                 updated_conf_ids = jnp.where(
                     needs_resample,
-                    resampled_conf_ids,     # Use newly sampled index if True
-                    last_conf_ids           # Else, keep index from previous step
+                    resampled_conf_ids,  # Use newly sampled index if True
+                    last_conf_ids,  # Else, keep index from previous step
                 )
 
                 # Reset the hidden states for resampled conf and br if they are not None
                 # WARNING: recurrent actors are not fully tested; hstate reset logic below may not work correctly
                 if (last_conf_h_p1 is not None) and (last_conf_h_p2 is not None):
                     updated_conf_h_p1 = jnp.where(
-                        needs_resample,
-                        init_conf_hstate,
-                        last_conf_h_p1
+                        needs_resample, init_conf_hstate, last_conf_h_p1
                     )
                     updated_conf_h_p2 = jnp.where(
-                        needs_resample,
-                        init_conf_hstate,
-                        last_conf_h_p2
+                        needs_resample, init_conf_hstate, last_conf_h_p2
                     )
                 else:
                     updated_conf_h_p1 = last_conf_h_p1
                     updated_conf_h_p2 = last_conf_h_p2
 
                 # Get the corresponding conf and br params
-                updated_conf_params = gather_params(all_train_state_conf.params, updated_conf_ids)
+                updated_conf_params = gather_params(
+                    all_train_state_conf.params, updated_conf_ids
+                )
                 updated_conf_onehot_ids = identity_matrix[updated_conf_ids]
 
                 # Get available actions for agent 0 from environment state
@@ -224,34 +273,54 @@ def train_trajedi_partners(config, env, partner_rng):
 
                 # Agent_0 action
                 act0_rng_sp = jax.random.split(act0_rng_sp, config["NUM_CONF_ACTORS"])
-                act_0, (val_0, val_0_unused), pi_0, new_conf_h_p1 = jax.vmap(forward_pass_conf)(
-                    updated_conf_params, last_obs["agent_0"], 
-                    last_done["agent_0"], avail_actions_0, 
-                    updated_conf_h_p1, act0_rng_sp
+                act_0, (val_0, _val_0_unused), pi_0, new_conf_h_p1 = jax.vmap(
+                    forward_pass_conf
+                )(
+                    updated_conf_params,
+                    last_obs["agent_0"],
+                    last_done["agent_0"],
+                    avail_actions_0,
+                    updated_conf_h_p1,
+                    act0_rng_sp,
                 )
                 logp_0 = pi_0.log_prob(act_0)
-                act_0, val_0, logp_0 = act_0.squeeze(), val_0.squeeze(), logp_0.squeeze()
+                act_0, val_0, logp_0 = (
+                    act_0.squeeze(),
+                    val_0.squeeze(),
+                    logp_0.squeeze(),
+                )
 
                 # Agent_1 action
                 act1_rng_sp = jax.random.split(act1_rng_sp, config["NUM_CONF_ACTORS"])
-                act_1, (val_1, val_1_unused), pi_1, new_conf_h_p2 = jax.vmap(forward_pass_conf)(
-                    updated_conf_params, last_obs["agent_1"], 
-                    last_done["agent_1"], avail_actions_1, 
-                    updated_conf_h_p2, act1_rng_sp
+                act_1, (val_1, _val_1_unused), pi_1, new_conf_h_p2 = jax.vmap(
+                    forward_pass_conf
+                )(
+                    updated_conf_params,
+                    last_obs["agent_1"],
+                    last_done["agent_1"],
+                    avail_actions_1,
+                    updated_conf_h_p2,
+                    act1_rng_sp,
                 )
                 logp_1 = pi_1.log_prob(act_1)
-                act_1, val_1, logp_1 = act_1.squeeze(), val_1.squeeze(), logp_1.squeeze()
+                act_1, val_1, logp_1 = (
+                    act_1.squeeze(),
+                    val_1.squeeze(),
+                    logp_1.squeeze(),
+                )
 
                 # Combine actions into the env format
                 combined_actions = jnp.concatenate([act_0, act_1], axis=0)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_CONF_ACTORS"], num_agents)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_CONF_ACTORS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
 
                 # Step env
                 step_rngs = jax.random.split(step_rng_sp, config["NUM_CONF_ACTORS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state, env_act
-                )
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
 
                 # note that num_actors = num_envs * num_agents
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
@@ -272,7 +341,7 @@ def train_trajedi_partners(config, env, partner_rng):
                     avail_actions=avail_actions_0,
                     episode_id=last_eps_counter,
                     time_id=last_timestep_counter,
-                    prev_done=last_done["agent_0"]
+                    prev_done=last_done["agent_0"],
                 )
 
                 transition_1 = Transition(
@@ -287,16 +356,26 @@ def train_trajedi_partners(config, env, partner_rng):
                     avail_actions=avail_actions_1,
                     episode_id=last_eps_counter,
                     time_id=last_timestep_counter,
-                    prev_done=last_done["agent_1"]
+                    prev_done=last_done["agent_1"],
                 )
 
                 last_eps_counter = last_eps_counter + done["agent_0"].astype(int)
-                last_timestep_counter = (1-done["agent_0"].astype(int)) * (last_timestep_counter+1)
+                last_timestep_counter = (1 - done["agent_0"].astype(int)) * (
+                    last_timestep_counter + 1
+                )
 
-                new_runner_state = (all_train_state_conf, updated_conf_ids, 
-                                    env_state_next, obs_next, done, new_conf_h_p1, 
-                                    new_conf_h_p2, last_eps_counter, last_timestep_counter, 
-                                    rng)
+                new_runner_state = (
+                    all_train_state_conf,
+                    updated_conf_ids,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_conf_h_p1,
+                    new_conf_h_p2,
+                    last_eps_counter,
+                    last_timestep_counter,
+                    rng,
+                )
                 return new_runner_state, (transition_0, transition_1)
 
             def _env_step_confs_xp(runner_state, unused):
@@ -305,44 +384,54 @@ def train_trajedi_partners(config, env, partner_rng):
                 Returns updated runner_state, and Transitions for agent_0 and agent_1.
                 """
                 (
-                    all_train_state_conf, train_state_ego, last_conf_ids,
-                    env_state, last_obs, last_done, last_conf_h, last_ego_h,
-                    rng
+                    all_train_state_conf,
+                    train_state_ego,
+                    last_conf_ids,
+                    env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_ego_h,
+                    rng,
                 ) = runner_state
-                rng, act0_rng_xp, act1_rng_xp, step_rng_xp, conf_sampling_rng = jax.random.split(rng, 5)
+                rng, act0_rng_xp, act1_rng_xp, step_rng_xp, conf_sampling_rng = (
+                    jax.random.split(rng, 5)
+                )
 
                 # For done envs, resample both conf and brs
                 needs_resample = last_done["__all__"]
-                resampled_conf_ids = jax.random.randint(conf_sampling_rng, (config["NUM_CONF_ACTORS"],), 0, config["PARTNER_POP_SIZE"])
+                resampled_conf_ids = jax.random.randint(
+                    conf_sampling_rng,
+                    (config["NUM_CONF_ACTORS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
                 identity_matrix = jnp.eye(config["PARTNER_POP_SIZE"])
-                
+
                 # Determine final indices based on whether resampling was needed for each env
                 updated_conf_ids = jnp.where(
                     needs_resample,
-                    resampled_conf_ids,     # Use newly sampled index if True
-                    last_conf_ids           # Else, keep index from previous step
+                    resampled_conf_ids,  # Use newly sampled index if True
+                    last_conf_ids,  # Else, keep index from previous step
                 )
 
                 # Reset the hidden states for resampled conf and br if they are not None
                 # WARNING: recurrent actors are not fully tested; hstate reset logic below may not work correctly
-                if (last_conf_h is not None):
+                if last_conf_h is not None:
                     updated_conf_h = jnp.where(
-                        needs_resample,
-                        init_conf_hstate,
-                        last_conf_h
+                        needs_resample, init_conf_hstate, last_conf_h
                     )
                     updated_ego_h = jnp.where(
-                        needs_resample,
-                        init_ego_hstate_xp,
-                        last_ego_h
+                        needs_resample, init_ego_hstate_xp, last_ego_h
                     )
                 else:
                     updated_conf_h = last_conf_h
                     updated_ego_h = last_ego_h
 
-                
                 # Get the corresponding conf and br params
-                updated_conf_params = gather_params(all_train_state_conf.params, updated_conf_ids)
+                updated_conf_params = gather_params(
+                    all_train_state_conf.params, updated_conf_ids
+                )
                 updated_conf_onehot_ids = identity_matrix[updated_conf_ids]
 
                 # Get available actions for agent 0 from environment state
@@ -353,13 +442,22 @@ def train_trajedi_partners(config, env, partner_rng):
 
                 # Agent_0 action
                 act0_rng_xp = jax.random.split(act0_rng_xp, config["NUM_CONF_ACTORS"])
-                act_0, (val_0_unused, val_0), pi_0, new_conf_h = jax.vmap(forward_pass_conf)(
-                    updated_conf_params, last_obs["agent_0"],  
-                    last_done["agent_0"], avail_actions_0,
-                    updated_conf_h, act0_rng_xp
+                act_0, (_val_0_unused, val_0), pi_0, new_conf_h = jax.vmap(
+                    forward_pass_conf
+                )(
+                    updated_conf_params,
+                    last_obs["agent_0"],
+                    last_done["agent_0"],
+                    avail_actions_0,
+                    updated_conf_h,
+                    act0_rng_xp,
                 )
                 logp_0 = pi_0.log_prob(act_0)
-                act_0, val_0, logp_0 = act_0.squeeze(), val_0.squeeze(), logp_0.squeeze()
+                act_0, val_0, logp_0 = (
+                    act_0.squeeze(),
+                    val_0.squeeze(),
+                    logp_0.squeeze(),
+                )
 
                 # Agent_1 action
 
@@ -370,22 +468,28 @@ def train_trajedi_partners(config, env, partner_rng):
                     done=last_done["agent_1"].reshape(1, config["NUM_CONF_ACTORS"]),
                     avail_actions=jax.lax.stop_gradient(avail_actions_1),
                     hstate=updated_ego_h,
-                    rng=act1_rng_xp
+                    rng=act1_rng_xp,
                 )
 
                 logp_1 = pi_1.log_prob(act_1)
-                act_1, val_1, logp_1 = act_1.squeeze(), val_1.squeeze(), logp_1.squeeze()
+                act_1, val_1, logp_1 = (
+                    act_1.squeeze(),
+                    val_1.squeeze(),
+                    logp_1.squeeze(),
+                )
 
                 # Combine actions into the env format
                 combined_actions = jnp.concatenate([act_0, act_1], axis=0)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_CONF_ACTORS"], num_agents)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_CONF_ACTORS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
 
                 # Step env
                 step_rngs = jax.random.split(step_rng_xp, config["NUM_CONF_ACTORS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state, env_act
-                )
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
 
                 # note that num_actors = num_envs * num_agents
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
@@ -406,7 +510,7 @@ def train_trajedi_partners(config, env, partner_rng):
                     avail_actions=avail_actions_0,
                     episode_id=jnp.zeros_like(done["agent_0"].astype(int)),
                     time_id=jnp.zeros_like(done["agent_0"].astype(int)),
-                    prev_done=last_done["agent_0"]
+                    prev_done=last_done["agent_0"],
                 )
 
                 transition_1 = Transition(
@@ -421,13 +525,20 @@ def train_trajedi_partners(config, env, partner_rng):
                     avail_actions=avail_actions_1,
                     episode_id=jnp.zeros_like(done["agent_1"].astype(int)),
                     time_id=jnp.zeros_like(done["agent_1"].astype(int)),
-                    prev_done=last_done["agent_1"]
+                    prev_done=last_done["agent_1"],
                 )
 
-                new_runner_state = (all_train_state_conf, train_state_ego,
-                                    updated_conf_ids, env_state_next, 
-                                    obs_next, done, new_conf_h, 
-                                    new_ego_h, rng)
+                new_runner_state = (
+                    all_train_state_conf,
+                    train_state_ego,
+                    updated_conf_ids,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_conf_h,
+                    new_ego_h,
+                    rng,
+                )
                 return new_runner_state, (transition_0, transition_1)
 
             def _env_step_br_sp(runner_state, unused):
@@ -436,20 +547,29 @@ def train_trajedi_partners(config, env, partner_rng):
                 Returns updated runner_state, and Transitions for agent_0 and agent_1.
                 """
                 (
-                    train_state_ego, env_state_br_sp, last_obs_br_sp, 
-                    last_done_br_sp, last_br_h_p1, last_br_h_p2, rng
+                    train_state_ego,
+                    env_state_br_sp,
+                    last_obs_br_sp,
+                    last_done_br_sp,
+                    last_br_h_p1,
+                    last_br_h_p2,
+                    rng,
                 ) = runner_state
-                rng, act0_rng_br_sp, act1_rng_br_sp, step_rng_sp = jax.random.split(rng, 4)
+                rng, act0_rng_br_sp, act1_rng_br_sp, step_rng_sp = jax.random.split(
+                    rng, 4
+                )
 
                 # For done envs, resample both conf and brs
-                needs_resample = last_done_br_sp["__all__"]
-                
+                last_done_br_sp["__all__"]
+
                 # Reset the hidden states for resampled conf and br if they are not None
                 updated_br_h_p1 = last_br_h_p1
                 updated_br_h_p2 = last_br_h_p2
 
                 # Get available actions for agent 0 from environment state
-                avail_actions = jax.vmap(env.get_avail_actions)(env_state_br_sp.env_state)
+                avail_actions = jax.vmap(env.get_avail_actions)(
+                    env_state_br_sp.env_state
+                )
                 avail_actions = jax.lax.stop_gradient(avail_actions)
                 avail_actions_0 = avail_actions["agent_0"].astype(jnp.float32)
                 avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
@@ -458,38 +578,56 @@ def train_trajedi_partners(config, env, partner_rng):
                 act0_rng_br_sp, _ = jax.random.split(act0_rng_br_sp, 2)
                 act_0, val_0, pi_0, new_br_h_p1 = ego_policy.get_action_value_policy(
                     params=train_state_ego.params,
-                    obs=last_obs_br_sp["agent_0"].reshape(1, config["NUM_EGO_ACTORS"], -1),
-                    done=last_done_br_sp["agent_0"].reshape(1, config["NUM_EGO_ACTORS"]),
+                    obs=last_obs_br_sp["agent_0"].reshape(
+                        1, config["NUM_EGO_ACTORS"], -1
+                    ),
+                    done=last_done_br_sp["agent_0"].reshape(
+                        1, config["NUM_EGO_ACTORS"]
+                    ),
                     avail_actions=jax.lax.stop_gradient(avail_actions_0),
                     hstate=updated_br_h_p1,
-                    rng=act0_rng_br_sp
+                    rng=act0_rng_br_sp,
                 )
                 logp_0 = pi_0.log_prob(act_0)
-                act_0, val_0, logp_0 = act_0.squeeze(), val_0.squeeze(), logp_0.squeeze()
+                act_0, val_0, logp_0 = (
+                    act_0.squeeze(),
+                    val_0.squeeze(),
+                    logp_0.squeeze(),
+                )
 
                 # Agent_1 action
                 act1_rng_br_sp, _ = jax.random.split(act1_rng_br_sp, 2)
                 act_1, val_1, pi_1, new_br_h_p2 = ego_policy.get_action_value_policy(
                     params=train_state_ego.params,
-                    obs=last_obs_br_sp["agent_1"].reshape(1, config["NUM_EGO_ACTORS"], -1),
-                    done=last_done_br_sp["agent_1"].reshape(1, config["NUM_EGO_ACTORS"]),
+                    obs=last_obs_br_sp["agent_1"].reshape(
+                        1, config["NUM_EGO_ACTORS"], -1
+                    ),
+                    done=last_done_br_sp["agent_1"].reshape(
+                        1, config["NUM_EGO_ACTORS"]
+                    ),
                     avail_actions=jax.lax.stop_gradient(avail_actions_1),
                     hstate=updated_br_h_p2,
-                    rng=act1_rng_br_sp
+                    rng=act1_rng_br_sp,
                 )
                 logp_1 = pi_1.log_prob(act_1)
-                act_1, val_1, logp_1 = act_1.squeeze(), val_1.squeeze(), logp_1.squeeze()
+                act_1, val_1, logp_1 = (
+                    act_1.squeeze(),
+                    val_1.squeeze(),
+                    logp_1.squeeze(),
+                )
 
                 # Combine actions into the env format
                 combined_actions = jnp.concatenate([act_0, act_1], axis=0)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_EGO_ACTORS"], num_agents)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_EGO_ACTORS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
 
                 # Step env
                 step_rngs = jax.random.split(step_rng_sp, config["NUM_EGO_ACTORS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state_br_sp, env_act
-                )
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state_br_sp, env_act)
 
                 # note that num_actors = num_envs * num_agents
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
@@ -507,7 +645,7 @@ def train_trajedi_partners(config, env, partner_rng):
                     obs=last_obs_br_sp["agent_0"],
                     info=info_0,
                     avail_actions=avail_actions_0,
-                    prev_done=last_done_br_sp["agent_0"]
+                    prev_done=last_done_br_sp["agent_0"],
                 )
 
                 transition_1 = TransitionEgo(
@@ -519,18 +657,29 @@ def train_trajedi_partners(config, env, partner_rng):
                     obs=last_obs_br_sp["agent_1"],
                     info=info_1,
                     avail_actions=avail_actions_1,
-                    prev_done=last_done_br_sp["agent_1"]
+                    prev_done=last_done_br_sp["agent_1"],
                 )
 
                 (
-                    train_state_ego, env_state_br_sp, last_obs_br_sp, 
-                    last_done_br_sp, last_br_h_p1, last_br_h_p2, rng
+                    train_state_ego,
+                    env_state_br_sp,
+                    last_obs_br_sp,
+                    last_done_br_sp,
+                    last_br_h_p1,
+                    last_br_h_p2,
+                    rng,
                 ) = runner_state
-                new_runner_state = (train_state_ego, env_state_next, 
-                                    obs_next, done, 
-                                    new_br_h_p1, new_br_h_p2, rng)
+                new_runner_state = (
+                    train_state_ego,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_br_h_p1,
+                    new_br_h_p2,
+                    rng,
+                )
                 return new_runner_state, (transition_0, transition_1)
-            
+
             # --------------------------
             # 3d) GAE & update step
             # --------------------------
@@ -542,7 +691,7 @@ def train_trajedi_partners(config, env, partner_rng):
                         transition.value,
                         transition.reward,
                     )
-                    
+
                     delta = reward + config["GAMMA"] * next_value * (1 - done) - value
                     gae = (
                         delta
@@ -562,17 +711,39 @@ def train_trajedi_partners(config, env, partner_rng):
             def _update_epoch(update_state, unused):
                 def _update_minbatch_conf(train_state_conf, batch_infos):
                     minbatch_conf_xp, minbatch_conf_sp1, minbatch_conf_sp2 = batch_infos
-                    init_hstate_conf_xp, traj_batch_conf_xp, gae_conf_xp, target_v_conf_xp = minbatch_conf_xp   
-                    init_hstate_conf_sp1, traj_batch_conf_sp1, gae_conf_sp1, target_v_conf_sp1 = minbatch_conf_sp1
-                    init_hstate_conf_sp2, traj_batch_conf_sp2, gae_conf_sp2, target_v_conf_sp2 = minbatch_conf_sp2
+                    (
+                        init_hstate_conf_xp,
+                        traj_batch_conf_xp,
+                        gae_conf_xp,
+                        target_v_conf_xp,
+                    ) = minbatch_conf_xp
+                    (
+                        init_hstate_conf_sp1,
+                        traj_batch_conf_sp1,
+                        gae_conf_sp1,
+                        target_v_conf_sp1,
+                    ) = minbatch_conf_sp1
+                    (
+                        init_hstate_conf_sp2,
+                        traj_batch_conf_sp2,
+                        gae_conf_sp2,
+                        target_v_conf_sp2,
+                    ) = minbatch_conf_sp2
 
                     def _loss_fn_policy(
-                        params, init_hstate_conf_sp1, traj_batch_conf_sp1,
-                        gae_conf_sp1, target_v_conf_sp1,
-                        init_hstate_conf_sp2, traj_batch_conf_sp2,
-                        gae_conf_sp2, target_v_conf_sp2,
+                        params,
+                        init_hstate_conf_sp1,
+                        traj_batch_conf_sp1,
+                        gae_conf_sp1,
+                        target_v_conf_sp1,
+                        init_hstate_conf_sp2,
+                        traj_batch_conf_sp2,
+                        gae_conf_sp2,
+                        target_v_conf_sp2,
                         init_hstate_conf_xp,
-                        traj_batch_conf_xp, gae_conf_xp, target_v_conf_xp
+                        traj_batch_conf_xp,
+                        gae_conf_xp,
+                        target_v_conf_xp,
                     ):
                         # get policy and value of confederate for xp (vs ego) and sp (vs confederate) interactions.
                         # All forward passes and per-sample loss tensors below are shared across population
@@ -583,76 +754,134 @@ def train_trajedi_partners(config, env, partner_rng):
                                 weights.sum() == 0,
                                 lambda x: jnp.zeros_like(x).astype(jnp.float32),
                                 lambda x: x,
-                                (
-                                    weights*loss_tensor
-                                ).sum()/(weights.sum() + 1e-8)
+                                (weights * loss_tensor).sum() / (weights.sum() + 1e-8),
                             )
 
-                        def _compute_indiv_pol_sp_log_probs_and_vals_and_entropy(agent_id):                    
+                        def _compute_indiv_pol_sp_log_probs_and_vals_and_entropy(
+                            agent_id,
+                        ):
                             param = gather_params(params, agent_id)
-                            _, (vals_sp1, _), pi_conf_sp1, _ = confederate_policy.get_action_value_policy(
-                                params=jax.tree.map(lambda x: jnp.squeeze(x, axis=0), param),
-                                obs=traj_batch_conf_sp1.obs,
-                                done=traj_batch_conf_sp1.prev_done,
-                                avail_actions=traj_batch_conf_sp1.avail_actions,
-                                hstate=init_hstate_conf_sp1,
-                                rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
+                            _, (vals_sp1, _), pi_conf_sp1, _ = (
+                                confederate_policy.get_action_value_policy(
+                                    params=jax.tree.map(
+                                        lambda x: jnp.squeeze(x, axis=0), param
+                                    ),
+                                    obs=traj_batch_conf_sp1.obs,
+                                    done=traj_batch_conf_sp1.prev_done,
+                                    avail_actions=traj_batch_conf_sp1.avail_actions,
+                                    hstate=init_hstate_conf_sp1,
+                                    rng=jax.random.PRNGKey(
+                                        0
+                                    ),  # only used for action sampling, which is not used here
+                                )
                             )
-                            _, (vals_sp2, _), pi_conf_sp2, _ = confederate_policy.get_action_value_policy(
-                                params=jax.tree.map(lambda x: jnp.squeeze(x, axis=0), param),
-                                obs=traj_batch_conf_sp2.obs,
-                                done=traj_batch_conf_sp2.prev_done,
-                                avail_actions=traj_batch_conf_sp2.avail_actions,
-                                hstate=init_hstate_conf_sp2,
-                                rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
+                            _, (vals_sp2, _), pi_conf_sp2, _ = (
+                                confederate_policy.get_action_value_policy(
+                                    params=jax.tree.map(
+                                        lambda x: jnp.squeeze(x, axis=0), param
+                                    ),
+                                    obs=traj_batch_conf_sp2.obs,
+                                    done=traj_batch_conf_sp2.prev_done,
+                                    avail_actions=traj_batch_conf_sp2.avail_actions,
+                                    hstate=init_hstate_conf_sp2,
+                                    rng=jax.random.PRNGKey(
+                                        0
+                                    ),  # only used for action sampling, which is not used here
+                                )
                             )
 
-                            log_prob_conf_sp1 = pi_conf_sp1.log_prob(traj_batch_conf_sp1.action)
-                            log_prob_conf_sp2 = pi_conf_sp2.log_prob(traj_batch_conf_sp2.action)
+                            log_prob_conf_sp1 = pi_conf_sp1.log_prob(
+                                traj_batch_conf_sp1.action
+                            )
+                            log_prob_conf_sp2 = pi_conf_sp2.log_prob(
+                                traj_batch_conf_sp2.action
+                            )
 
                             sp1_entropy = pi_conf_sp1.entropy()
                             sp2_entropy = pi_conf_sp2.entropy()
 
-                            return log_prob_conf_sp1, log_prob_conf_sp2, vals_sp1, vals_sp2, sp1_entropy, sp2_entropy
-                        
-                        def _compute_indiv_pol_xp_log_probs_and_vals_and_entropy(agent_id):                    
-                            param = gather_params(params, agent_id)
-                            _, (_, value_conf_xp), pi_conf_xp, _ = confederate_policy.get_action_value_policy(
-                                params=jax.tree.map(lambda x: jnp.squeeze(x, axis=0), param),
-                                obs=traj_batch_conf_xp.obs,
-                                done=traj_batch_conf_xp.prev_done,
-                                avail_actions=traj_batch_conf_xp.avail_actions,
-                                hstate=init_hstate_conf_xp,
-                                rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
+                            return (
+                                log_prob_conf_sp1,
+                                log_prob_conf_sp2,
+                                vals_sp1,
+                                vals_sp2,
+                                sp1_entropy,
+                                sp2_entropy,
                             )
-                            log_prob_conf_xp = pi_conf_xp.log_prob(traj_batch_conf_xp.action)
+
+                        def _compute_indiv_pol_xp_log_probs_and_vals_and_entropy(
+                            agent_id,
+                        ):
+                            param = gather_params(params, agent_id)
+                            _, (_, value_conf_xp), pi_conf_xp, _ = (
+                                confederate_policy.get_action_value_policy(
+                                    params=jax.tree.map(
+                                        lambda x: jnp.squeeze(x, axis=0), param
+                                    ),
+                                    obs=traj_batch_conf_xp.obs,
+                                    done=traj_batch_conf_xp.prev_done,
+                                    avail_actions=traj_batch_conf_xp.avail_actions,
+                                    hstate=init_hstate_conf_xp,
+                                    rng=jax.random.PRNGKey(
+                                        0
+                                    ),  # only used for action sampling, which is not used here
+                                )
+                            )
+                            log_prob_conf_xp = pi_conf_xp.log_prob(
+                                traj_batch_conf_xp.action
+                            )
                             all_xp_entropy = pi_conf_xp.entropy()
 
                             return log_prob_conf_xp, value_conf_xp, all_xp_entropy
-                        
-                        possible_agent_ids = jnp.expand_dims(jnp.arange(config["PARTNER_POP_SIZE"]), 1)
-                        all_sp_log_probs_sp1, all_sp_log_probs_sp2, all_vals_sp1, all_vals_sp2, all_sp1_entropy, all_sp2_entropy = jax.vmap(_compute_indiv_pol_sp_log_probs_and_vals_and_entropy)(possible_agent_ids)
-                        all_xp_log_probs, all_vals_xp, all_xp_entropy = jax.vmap(_compute_indiv_pol_xp_log_probs_and_vals_and_entropy)(possible_agent_ids)
+
+                        possible_agent_ids = jnp.expand_dims(
+                            jnp.arange(config["PARTNER_POP_SIZE"]), 1
+                        )
+                        (
+                            all_sp_log_probs_sp1,
+                            all_sp_log_probs_sp2,
+                            all_vals_sp1,
+                            all_vals_sp2,
+                            all_sp1_entropy,
+                            all_sp2_entropy,
+                        ) = jax.vmap(
+                            _compute_indiv_pol_sp_log_probs_and_vals_and_entropy
+                        )(possible_agent_ids)
+                        all_xp_log_probs, all_vals_xp, all_xp_entropy = jax.vmap(
+                            _compute_indiv_pol_xp_log_probs_and_vals_and_entropy
+                        )(possible_agent_ids)
 
                         # pop x time x batch
                         selected_indices_sp1 = jnp.expand_dims(
-                            jnp.argmax(traj_batch_conf_sp1.agent_onehot_id, axis=-1), axis=0
+                            jnp.argmax(traj_batch_conf_sp1.agent_onehot_id, axis=-1),
+                            axis=0,
                         )
                         selected_indices_sp2 = jnp.expand_dims(
-                            jnp.argmax(traj_batch_conf_sp2.agent_onehot_id, axis=-1), axis=0
+                            jnp.argmax(traj_batch_conf_sp2.agent_onehot_id, axis=-1),
+                            axis=0,
                         )
                         selected_indices_xp = jnp.expand_dims(
-                            jnp.argmax(traj_batch_conf_xp.agent_onehot_id, axis=-1), axis=0
+                            jnp.argmax(traj_batch_conf_xp.agent_onehot_id, axis=-1),
+                            axis=0,
                         )
 
                         selected_log_probs_sp1 = jnp.squeeze(
-                            jnp.take_along_axis(all_sp_log_probs_sp1, selected_indices_sp1, axis=0), axis=0
+                            jnp.take_along_axis(
+                                all_sp_log_probs_sp1, selected_indices_sp1, axis=0
+                            ),
+                            axis=0,
                         )
                         selected_log_probs_sp2 = jnp.squeeze(
-                            jnp.take_along_axis(all_sp_log_probs_sp2, selected_indices_sp2, axis=0), axis=0
+                            jnp.take_along_axis(
+                                all_sp_log_probs_sp2, selected_indices_sp2, axis=0
+                            ),
+                            axis=0,
                         )
                         selected_log_probs_xp = jnp.squeeze(
-                            jnp.take_along_axis(all_xp_log_probs, selected_indices_xp, axis=0), axis=0
+                            jnp.take_along_axis(
+                                all_xp_log_probs, selected_indices_xp, axis=0
+                            ),
+                            axis=0,
                         )
 
                         log_prob_conf_sp1 = selected_log_probs_sp1
@@ -660,244 +889,496 @@ def train_trajedi_partners(config, env, partner_rng):
                         log_prob_conf_xp = selected_log_probs_xp
 
                         value_conf_sp1 = jnp.squeeze(
-                            jnp.take_along_axis(all_vals_sp1, selected_indices_sp1, axis=0), axis=0
+                            jnp.take_along_axis(
+                                all_vals_sp1, selected_indices_sp1, axis=0
+                            ),
+                            axis=0,
                         )
                         value_conf_sp2 = jnp.squeeze(
-                            jnp.take_along_axis(all_vals_sp2, selected_indices_sp2, axis=0), axis=0
+                            jnp.take_along_axis(
+                                all_vals_sp2, selected_indices_sp2, axis=0
+                            ),
+                            axis=0,
                         )
                         value_conf_xp = jnp.squeeze(
-                            jnp.take_along_axis(all_vals_xp, selected_indices_xp, axis=0), axis=0
+                            jnp.take_along_axis(
+                                all_vals_xp, selected_indices_xp, axis=0
+                            ),
+                            axis=0,
                         )
 
                         entropy_conf_sp1 = jnp.squeeze(
-                            jnp.take_along_axis(all_sp1_entropy, selected_indices_sp1, axis=0), axis=0
+                            jnp.take_along_axis(
+                                all_sp1_entropy, selected_indices_sp1, axis=0
+                            ),
+                            axis=0,
                         )
                         entropy_conf_sp2 = jnp.squeeze(
-                            jnp.take_along_axis(all_sp2_entropy, selected_indices_sp2, axis=0), axis=0
+                            jnp.take_along_axis(
+                                all_sp2_entropy, selected_indices_sp2, axis=0
+                            ),
+                            axis=0,
                         )
                         entropy_conf_xp = jnp.squeeze(
-                            jnp.take_along_axis(all_xp_entropy, selected_indices_xp, axis=0), axis=0
+                            jnp.take_along_axis(
+                                all_xp_entropy, selected_indices_xp, axis=0
+                            ),
+                            axis=0,
                         )
 
-                        copied_episode_counters_sp1 = jnp.tile(traj_batch_conf_sp1.episode_id[None, ...], (jnp.shape(selected_log_probs_sp1)[0], 1, 1)) 
-                        copied_episode_counters_sp2 = jnp.tile(traj_batch_conf_sp2.episode_id[None, ...], (jnp.shape(selected_log_probs_sp2)[0], 1, 1)) 
-                        copied_timestep_counters_sp1 = jnp.tile(traj_batch_conf_sp1.time_id[None, ...], (jnp.shape(selected_log_probs_sp1)[0], 1, 1)) 
-                        copied_timestep_counters_sp2 = jnp.tile(traj_batch_conf_sp2.time_id[None, ...], (jnp.shape(selected_log_probs_sp2)[0], 1, 1)) 
-                        copied_all_sp_log_probs_sp1 = jnp.tile(all_sp_log_probs_sp1[None, ...], (jnp.shape(selected_log_probs_sp1)[0], 1, 1, 1))
-                        copied_all_sp_log_probs_sp2 = jnp.tile(all_sp_log_probs_sp2[None, ...], (jnp.shape(selected_log_probs_sp2)[0], 1, 1, 1))
-                        copied_selected_sp_log_probs_sp1 = jnp.tile(selected_log_probs_sp1[None, ...], (jnp.shape(selected_log_probs_sp1)[0], 1, 1))
-                        copied_selected_sp_log_probs_sp2 = jnp.tile(selected_log_probs_sp2[None, ...], (jnp.shape(selected_log_probs_sp2)[0], 1, 1))
-                        copied_original_sp_log_probs_sp1 = jnp.tile(traj_batch_conf_sp1.log_prob[None, ...], (jnp.shape(selected_log_probs_sp1)[0], 1, 1))
-                        copied_original_sp_log_probs_sp2 = jnp.tile(traj_batch_conf_sp2.log_prob[None, ...], (jnp.shape(selected_log_probs_sp2)[0], 1, 1))
-                        
+                        copied_episode_counters_sp1 = jnp.tile(
+                            traj_batch_conf_sp1.episode_id[None, ...],
+                            (jnp.shape(selected_log_probs_sp1)[0], 1, 1),
+                        )
+                        copied_episode_counters_sp2 = jnp.tile(
+                            traj_batch_conf_sp2.episode_id[None, ...],
+                            (jnp.shape(selected_log_probs_sp2)[0], 1, 1),
+                        )
+                        copied_timestep_counters_sp1 = jnp.tile(
+                            traj_batch_conf_sp1.time_id[None, ...],
+                            (jnp.shape(selected_log_probs_sp1)[0], 1, 1),
+                        )
+                        copied_timestep_counters_sp2 = jnp.tile(
+                            traj_batch_conf_sp2.time_id[None, ...],
+                            (jnp.shape(selected_log_probs_sp2)[0], 1, 1),
+                        )
+                        copied_all_sp_log_probs_sp1 = jnp.tile(
+                            all_sp_log_probs_sp1[None, ...],
+                            (jnp.shape(selected_log_probs_sp1)[0], 1, 1, 1),
+                        )
+                        copied_all_sp_log_probs_sp2 = jnp.tile(
+                            all_sp_log_probs_sp2[None, ...],
+                            (jnp.shape(selected_log_probs_sp2)[0], 1, 1, 1),
+                        )
+                        copied_selected_sp_log_probs_sp1 = jnp.tile(
+                            selected_log_probs_sp1[None, ...],
+                            (jnp.shape(selected_log_probs_sp1)[0], 1, 1),
+                        )
+                        copied_selected_sp_log_probs_sp2 = jnp.tile(
+                            selected_log_probs_sp2[None, ...],
+                            (jnp.shape(selected_log_probs_sp2)[0], 1, 1),
+                        )
+                        copied_original_sp_log_probs_sp1 = jnp.tile(
+                            traj_batch_conf_sp1.log_prob[None, ...],
+                            (jnp.shape(selected_log_probs_sp1)[0], 1, 1),
+                        )
+                        copied_original_sp_log_probs_sp2 = jnp.tile(
+                            traj_batch_conf_sp2.log_prob[None, ...],
+                            (jnp.shape(selected_log_probs_sp2)[0], 1, 1),
+                        )
+
                         def per_step_aggregate(
-                                all_eps_id_sp1, all_eps_id_sp2, 
-                                eps_id_sp1, eps_id_sp2,
-                                all_time_id_sp1, all_time_id_sp2, 
-                                time_id_sp1, time_id_sp2,
-                                all_sp_log_probs_sp1, all_sp_log_probs_sp2,
-                                selected_log_probs_sp1, selected_log_probs_sp2,
-                                original_log_probs_sp1, original_log_probs_sp2
+                            all_eps_id_sp1,
+                            all_eps_id_sp2,
+                            eps_id_sp1,
+                            eps_id_sp2,
+                            all_time_id_sp1,
+                            all_time_id_sp2,
+                            time_id_sp1,
+                            time_id_sp2,
+                            all_sp_log_probs_sp1,
+                            all_sp_log_probs_sp2,
+                            selected_log_probs_sp1,
+                            selected_log_probs_sp2,
+                            original_log_probs_sp1,
+                            original_log_probs_sp2,
                         ):
                             is_relevant_weight_sp1 = (
-                                all_eps_id_sp1 == jnp.tile(eps_id_sp1[None, ...], (jnp.shape(all_eps_id_sp1)[0], 1))
+                                all_eps_id_sp1
+                                == jnp.tile(
+                                    eps_id_sp1[None, ...],
+                                    (jnp.shape(all_eps_id_sp1)[0], 1),
+                                )
                             ).astype(int)
 
                             is_relevant_weight_sp2 = (
-                                all_eps_id_sp2 == jnp.tile(eps_id_sp2[None, ...], (jnp.shape(all_eps_id_sp2)[0], 1))
+                                all_eps_id_sp2
+                                == jnp.tile(
+                                    eps_id_sp2[None, ...],
+                                    (jnp.shape(all_eps_id_sp2)[0], 1),
+                                )
                             ).astype(int)
-                            
-                            time_diff_sp1 = jnp.tile(time_id_sp1[None, ...], (jnp.shape(all_time_id_sp1)[0], 1)) - all_time_id_sp1
-                            time_diff_sp2 = jnp.tile(time_id_sp2[None, ...], (jnp.shape(all_time_id_sp2)[0], 1)) - all_time_id_sp2
+
+                            time_diff_sp1 = (
+                                jnp.tile(
+                                    time_id_sp1[None, ...],
+                                    (jnp.shape(all_time_id_sp1)[0], 1),
+                                )
+                                - all_time_id_sp1
+                            )
+                            time_diff_sp2 = (
+                                jnp.tile(
+                                    time_id_sp2[None, ...],
+                                    (jnp.shape(all_time_id_sp2)[0], 1),
+                                )
+                                - all_time_id_sp2
+                            )
 
                             abs_diff_time_id_sp1 = jnp.abs(time_diff_sp1)
                             abs_diff_time_id_sp2 = jnp.abs(time_diff_sp2)
-                            log_mult1_weight = is_relevant_weight_sp1*(config["GAMMA"]**abs_diff_time_id_sp1)
-                            log_mult2_weight = is_relevant_weight_sp2*(config["GAMMA"]**abs_diff_time_id_sp2)
-                            
+                            log_mult1_weight = is_relevant_weight_sp1 * (
+                                config["GAMMA"] ** abs_diff_time_id_sp1
+                            )
+                            log_mult2_weight = is_relevant_weight_sp2 * (
+                                config["GAMMA"] ** abs_diff_time_id_sp2
+                            )
+
                             # Sum selected log prob on the timestep axis (i.e., 0)
                             summed_selected_log_probs_sp1 = jnp.sum(
-                                selected_log_probs_sp1*is_relevant_weight_sp1,
-                                axis=0
+                                selected_log_probs_sp1 * is_relevant_weight_sp1, axis=0
                             )
 
                             # Sum selected log prob on the timestep axis (i.e., 0)
                             summed_selected_log_probs_sp2 = jnp.sum(
-                                selected_log_probs_sp2*is_relevant_weight_sp2,
-                                axis=0
+                                selected_log_probs_sp2 * is_relevant_weight_sp2, axis=0
                             )
 
                             summed_original_log_probs_sp1 = jnp.sum(
-                                original_log_probs_sp1*is_relevant_weight_sp1,
-                                axis=0
+                                original_log_probs_sp1 * is_relevant_weight_sp1, axis=0
                             )
 
                             # Sum selected log prob on the timestep axis (i.e., 0)
                             summed_original_log_probs_sp2 = jnp.sum(
-                                original_log_probs_sp2*is_relevant_weight_sp2,
-                                axis=0
+                                original_log_probs_sp2 * is_relevant_weight_sp2, axis=0
                             )
 
                             log_delta_i_t_sp1 = jnp.sum(
-                                selected_log_probs_sp1*log_mult1_weight,
-                                axis=0
+                                selected_log_probs_sp1 * log_mult1_weight, axis=0
                             )
 
                             log_delta_i_t_sp2 = jnp.sum(
-                                selected_log_probs_sp2*log_mult2_weight,
-                                axis=0
+                                selected_log_probs_sp2 * log_mult2_weight, axis=0
                             )
 
                             # Compute mean policy trajectory log probs
-                            copied_weight_sp1 = jnp.tile(is_relevant_weight_sp1[None, ...], (config["PARTNER_POP_SIZE"], 1, 1))
-                            copied_weight_sp2 = jnp.tile(is_relevant_weight_sp2[None, ...], (config["PARTNER_POP_SIZE"], 1, 1))
-                            copied_mult1_weight = jnp.tile(log_mult1_weight[None, ...], (config["PARTNER_POP_SIZE"], 1, 1))
-                            copied_mult2_weight = jnp.tile(log_mult2_weight[None, ...], (config["PARTNER_POP_SIZE"], 1, 1))
+                            copied_weight_sp1 = jnp.tile(
+                                is_relevant_weight_sp1[None, ...],
+                                (config["PARTNER_POP_SIZE"], 1, 1),
+                            )
+                            copied_weight_sp2 = jnp.tile(
+                                is_relevant_weight_sp2[None, ...],
+                                (config["PARTNER_POP_SIZE"], 1, 1),
+                            )
+                            copied_mult1_weight = jnp.tile(
+                                log_mult1_weight[None, ...],
+                                (config["PARTNER_POP_SIZE"], 1, 1),
+                            )
+                            copied_mult2_weight = jnp.tile(
+                                log_mult2_weight[None, ...],
+                                (config["PARTNER_POP_SIZE"], 1, 1),
+                            )
 
                             def logmeanexp(inp_array, axis=0):
                                 # max-shifted logsumexp for numerical stability with large-magnitude log probs
-                                return jax.nn.logsumexp(inp_array, axis=axis) - jnp.log(inp_array.shape[axis])
-                            
-                            traj_log_prob_sp1 = jnp.sum(all_sp_log_probs_sp1*copied_weight_sp1, axis=1)
-                            traj_log_prob_sp2 = jnp.sum(all_sp_log_probs_sp2*copied_weight_sp2, axis=1)
-                            avg_pol_traj_log_prob_sp1 = logmeanexp(traj_log_prob_sp1, axis=0)
-                            avg_pol_traj_log_prob_sp2 = logmeanexp(traj_log_prob_sp2, axis=0)
+                                return jax.nn.logsumexp(inp_array, axis=axis) - jnp.log(
+                                    inp_array.shape[axis]
+                                )
+
+                            traj_log_prob_sp1 = jnp.sum(
+                                all_sp_log_probs_sp1 * copied_weight_sp1, axis=1
+                            )
+                            traj_log_prob_sp2 = jnp.sum(
+                                all_sp_log_probs_sp2 * copied_weight_sp2, axis=1
+                            )
+                            avg_pol_traj_log_prob_sp1 = logmeanexp(
+                                traj_log_prob_sp1, axis=0
+                            )
+                            avg_pol_traj_log_prob_sp2 = logmeanexp(
+                                traj_log_prob_sp2, axis=0
+                            )
 
                             log_delta_hat_t_sp1 = logmeanexp(
                                 jnp.sum(
-                                    all_sp_log_probs_sp1*copied_mult1_weight,
-                                    axis=1
-                                ), axis=0
+                                    all_sp_log_probs_sp1 * copied_mult1_weight, axis=1
+                                ),
+                                axis=0,
                             )
 
                             log_delta_hat_t_sp2 = logmeanexp(
                                 jnp.sum(
-                                    all_sp_log_probs_sp2*copied_mult2_weight,
-                                    axis=1
-                                ), axis=0
+                                    all_sp_log_probs_sp2 * copied_mult2_weight, axis=1
+                                ),
+                                axis=0,
                             )
 
-                            return summed_selected_log_probs_sp1, summed_selected_log_probs_sp2, summed_original_log_probs_sp1, summed_original_log_probs_sp2, avg_pol_traj_log_prob_sp1, avg_pol_traj_log_prob_sp2, log_delta_i_t_sp1, log_delta_i_t_sp2, log_delta_hat_t_sp1, log_delta_hat_t_sp2
+                            return (
+                                summed_selected_log_probs_sp1,
+                                summed_selected_log_probs_sp2,
+                                summed_original_log_probs_sp1,
+                                summed_original_log_probs_sp2,
+                                avg_pol_traj_log_prob_sp1,
+                                avg_pol_traj_log_prob_sp2,
+                                log_delta_i_t_sp1,
+                                log_delta_i_t_sp2,
+                                log_delta_hat_t_sp1,
+                                log_delta_hat_t_sp2,
+                            )
 
-                        log_traj_pi_sp1, log_traj_pi_sp2, log_traj_ori_pi_sp1, log_traj_ori_pi_sp2, log_traj_pi_hat_sp1, log_traj_pi_hat_sp2, log_delta_i_t_sp1, log_delta_i_t_sp2, log_delta_hat_t_sp1, log_delta_hat_t_sp2 = jax.vmap(per_step_aggregate)(
-                            copied_episode_counters_sp1, copied_episode_counters_sp2,
-                            traj_batch_conf_sp1.episode_id, traj_batch_conf_sp2.episode_id,
-                            copied_timestep_counters_sp1, copied_timestep_counters_sp2,
-                            traj_batch_conf_sp1.time_id, traj_batch_conf_sp2.time_id,
-                            copied_all_sp_log_probs_sp1, copied_all_sp_log_probs_sp2,
-                            copied_selected_sp_log_probs_sp1, copied_selected_sp_log_probs_sp2,
-                            copied_original_sp_log_probs_sp1, copied_original_sp_log_probs_sp2
+                        (
+                            log_traj_pi_sp1,
+                            log_traj_pi_sp2,
+                            log_traj_ori_pi_sp1,
+                            log_traj_ori_pi_sp2,
+                            log_traj_pi_hat_sp1,
+                            log_traj_pi_hat_sp2,
+                            log_delta_i_t_sp1,
+                            log_delta_i_t_sp2,
+                            log_delta_hat_t_sp1,
+                            log_delta_hat_t_sp2,
+                        ) = jax.vmap(per_step_aggregate)(
+                            copied_episode_counters_sp1,
+                            copied_episode_counters_sp2,
+                            traj_batch_conf_sp1.episode_id,
+                            traj_batch_conf_sp2.episode_id,
+                            copied_timestep_counters_sp1,
+                            copied_timestep_counters_sp2,
+                            traj_batch_conf_sp1.time_id,
+                            traj_batch_conf_sp2.time_id,
+                            copied_all_sp_log_probs_sp1,
+                            copied_all_sp_log_probs_sp2,
+                            copied_selected_sp_log_probs_sp1,
+                            copied_selected_sp_log_probs_sp2,
+                            copied_original_sp_log_probs_sp1,
+                            copied_original_sp_log_probs_sp2,
                         )
 
                         delta_hat_traj_sp1 = jnp.exp(log_delta_hat_t_sp1)
                         delta_hat_traj_sp2 = jnp.exp(log_delta_hat_t_sp2)
                         delta_i_traj_sp1 = jnp.exp(log_delta_i_t_sp1)
                         delta_i_traj_sp2 = jnp.exp(log_delta_i_t_sp2)
-                        
-                        pol_ratios_sp1 = jnp.exp(log_traj_pi_hat_sp1-log_traj_ori_pi_sp1)
-                        pol_ratios_sp2 = jnp.exp(log_traj_pi_hat_sp2-log_traj_ori_pi_sp2)
 
-                        pol_ratios2_sp1 = jnp.exp(log_traj_pi_sp1-log_traj_ori_pi_sp1)
-                        pol_ratios2_sp2 = jnp.exp(log_traj_pi_sp2-log_traj_ori_pi_sp2)
+                        pol_ratios_sp1 = jnp.exp(
+                            log_traj_pi_hat_sp1 - log_traj_ori_pi_sp1
+                        )
+                        pol_ratios_sp2 = jnp.exp(
+                            log_traj_pi_hat_sp2 - log_traj_ori_pi_sp2
+                        )
+
+                        pol_ratios2_sp1 = jnp.exp(log_traj_pi_sp1 - log_traj_ori_pi_sp1)
+                        pol_ratios2_sp2 = jnp.exp(log_traj_pi_sp2 - log_traj_ori_pi_sp2)
 
                         # Both terms of the JSD gradient multiplier must be in probability space
-                        pi_multiplier_sp1 = jax.lax.stop_gradient(pol_ratios2_sp1*(delta_hat_traj_sp1 - ((1.0/config["PARTNER_POP_SIZE"]) * delta_i_traj_sp1)))
-                        pi_multiplier_sp2 = jax.lax.stop_gradient(pol_ratios2_sp2*(delta_hat_traj_sp2 - ((1.0/config["PARTNER_POP_SIZE"]) * delta_i_traj_sp2)))
+                        pi_multiplier_sp1 = jax.lax.stop_gradient(
+                            pol_ratios2_sp1
+                            * (
+                                delta_hat_traj_sp1
+                                - (
+                                    (1.0 / config["PARTNER_POP_SIZE"])
+                                    * delta_i_traj_sp1
+                                )
+                            )
+                        )
+                        pi_multiplier_sp2 = jax.lax.stop_gradient(
+                            pol_ratios2_sp2
+                            * (
+                                delta_hat_traj_sp2
+                                - (
+                                    (1.0 / config["PARTNER_POP_SIZE"])
+                                    * delta_i_traj_sp2
+                                )
+                            )
+                        )
 
-                        delta_multiplier_sp1 = jax.lax.stop_gradient(pol_ratios_sp1 * delta_i_traj_sp1)
-                        delta_multiplier_sp2 = jax.lax.stop_gradient(pol_ratios_sp2 * delta_i_traj_sp2)
+                        delta_multiplier_sp1 = jax.lax.stop_gradient(
+                            pol_ratios_sp1 * delta_i_traj_sp1
+                        )
+                        delta_multiplier_sp2 = jax.lax.stop_gradient(
+                            pol_ratios_sp2 * delta_i_traj_sp2
+                        )
 
-                        trajedi_loss_sp1 = pi_multiplier_sp1 * log_traj_pi_sp1 + delta_multiplier_sp1 * log_delta_i_t_sp1
-                        trajedi_loss_sp2 = pi_multiplier_sp2 * log_traj_pi_sp2 + delta_multiplier_sp2 * log_delta_i_t_sp2
+                        trajedi_loss_sp1 = (
+                            pi_multiplier_sp1 * log_traj_pi_sp1
+                            + delta_multiplier_sp1 * log_delta_i_t_sp1
+                        )
+                        trajedi_loss_sp2 = (
+                            pi_multiplier_sp2 * log_traj_pi_sp2
+                            + delta_multiplier_sp2 * log_delta_i_t_sp2
+                        )
 
                         # Per-sample (unmasked) value loss tensors
                         value_pred_conf_xp_clipped = traj_batch_conf_xp.value + (
                             value_conf_xp - traj_batch_conf_xp.value
-                            ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
-                        value_losses_conf_xp = jnp.square(value_conf_xp - target_v_conf_xp)
-                        value_losses_clipped_conf_xp = jnp.square(value_pred_conf_xp_clipped - target_v_conf_xp)
-                        value_loss_tensor_xp = jnp.maximum(value_losses_conf_xp, value_losses_clipped_conf_xp)
+                        ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
+                        value_losses_conf_xp = jnp.square(
+                            value_conf_xp - target_v_conf_xp
+                        )
+                        value_losses_clipped_conf_xp = jnp.square(
+                            value_pred_conf_xp_clipped - target_v_conf_xp
+                        )
+                        value_loss_tensor_xp = jnp.maximum(
+                            value_losses_conf_xp, value_losses_clipped_conf_xp
+                        )
 
                         value_pred_conf_sp1_clipped = traj_batch_conf_sp1.value + (
                             value_conf_sp1 - traj_batch_conf_sp1.value
-                            ).clip(
-                            -config["CLIP_EPS"], config["CLIP_EPS"])
-                        value_losses_conf_sp1 = jnp.square(value_conf_sp1 - target_v_conf_sp1)
-                        value_losses_clipped_conf_sp1 = jnp.square(value_pred_conf_sp1_clipped - target_v_conf_sp1)
-                        value_loss_tensor_sp1 = jnp.maximum(value_losses_conf_sp1, value_losses_clipped_conf_sp1)
+                        ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
+                        value_losses_conf_sp1 = jnp.square(
+                            value_conf_sp1 - target_v_conf_sp1
+                        )
+                        value_losses_clipped_conf_sp1 = jnp.square(
+                            value_pred_conf_sp1_clipped - target_v_conf_sp1
+                        )
+                        value_loss_tensor_sp1 = jnp.maximum(
+                            value_losses_conf_sp1, value_losses_clipped_conf_sp1
+                        )
 
                         value_pred_conf_sp2_clipped = traj_batch_conf_sp2.value + (
                             value_conf_sp2 - traj_batch_conf_sp2.value
-                            ).clip(
-                            -config["CLIP_EPS"], config["CLIP_EPS"])
-                        value_losses_conf_sp2 = jnp.square(value_conf_sp2 - target_v_conf_sp2)
-                        value_losses_clipped_conf_sp2 = jnp.square(value_pred_conf_sp2_clipped - target_v_conf_sp2)
-                        value_loss_tensor_sp2 = jnp.maximum(value_losses_conf_sp2, value_losses_clipped_conf_sp2)
+                        ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
+                        value_losses_conf_sp2 = jnp.square(
+                            value_conf_sp2 - target_v_conf_sp2
+                        )
+                        value_losses_clipped_conf_sp2 = jnp.square(
+                            value_pred_conf_sp2_clipped - target_v_conf_sp2
+                        )
+                        value_loss_tensor_sp2 = jnp.maximum(
+                            value_losses_conf_sp2, value_losses_clipped_conf_sp2
+                        )
 
                         # Per-sample (unmasked) policy gradient loss tensors
-                        ratio_conf_xp = jnp.exp(log_prob_conf_xp - traj_batch_conf_xp.log_prob)
-                        gae_norm_conf_xp = (gae_conf_xp - gae_conf_xp.mean()) / (gae_conf_xp.std() + 1e-8)
+                        ratio_conf_xp = jnp.exp(
+                            log_prob_conf_xp - traj_batch_conf_xp.log_prob
+                        )
+                        gae_norm_conf_xp = (gae_conf_xp - gae_conf_xp.mean()) / (
+                            gae_conf_xp.std() + 1e-8
+                        )
                         pg_loss_1_conf_xp = ratio_conf_xp * gae_norm_conf_xp
-                        pg_loss_2_conf_xp = jnp.clip(
-                            ratio_conf_xp,
-                            1.0 - config["CLIP_EPS"],
-                            1.0 + config["CLIP_EPS"]) * gae_norm_conf_xp
-                        pg_loss_tensor_xp = -jnp.minimum(pg_loss_1_conf_xp, pg_loss_2_conf_xp)
+                        pg_loss_2_conf_xp = (
+                            jnp.clip(
+                                ratio_conf_xp,
+                                1.0 - config["CLIP_EPS"],
+                                1.0 + config["CLIP_EPS"],
+                            )
+                            * gae_norm_conf_xp
+                        )
+                        pg_loss_tensor_xp = -jnp.minimum(
+                            pg_loss_1_conf_xp, pg_loss_2_conf_xp
+                        )
 
-                        ratio_conf_sp1 = jnp.exp(log_prob_conf_sp1 - traj_batch_conf_sp1.log_prob)
-                        gae_norm_conf_sp1 = (gae_conf_sp1 - gae_conf_sp1.mean()) / (gae_conf_sp1.std() + 1e-8)
+                        ratio_conf_sp1 = jnp.exp(
+                            log_prob_conf_sp1 - traj_batch_conf_sp1.log_prob
+                        )
+                        gae_norm_conf_sp1 = (gae_conf_sp1 - gae_conf_sp1.mean()) / (
+                            gae_conf_sp1.std() + 1e-8
+                        )
                         pg_loss_1_conf_sp1 = ratio_conf_sp1 * gae_norm_conf_sp1
-                        pg_loss_2_conf_sp1 = jnp.clip(
-                            ratio_conf_sp1,
-                            1.0 - config["CLIP_EPS"],
-                            1.0 + config["CLIP_EPS"]) * gae_norm_conf_sp1
-                        pg_loss_tensor_sp1 = -jnp.minimum(pg_loss_1_conf_sp1, pg_loss_2_conf_sp1)
+                        pg_loss_2_conf_sp1 = (
+                            jnp.clip(
+                                ratio_conf_sp1,
+                                1.0 - config["CLIP_EPS"],
+                                1.0 + config["CLIP_EPS"],
+                            )
+                            * gae_norm_conf_sp1
+                        )
+                        pg_loss_tensor_sp1 = -jnp.minimum(
+                            pg_loss_1_conf_sp1, pg_loss_2_conf_sp1
+                        )
 
-                        ratio_conf_sp2 = jnp.exp(log_prob_conf_sp2 - traj_batch_conf_sp2.log_prob)
-                        gae_norm_conf_sp2 = (gae_conf_sp2 - gae_conf_sp2.mean()) / (gae_conf_sp2.std() + 1e-8)
+                        ratio_conf_sp2 = jnp.exp(
+                            log_prob_conf_sp2 - traj_batch_conf_sp2.log_prob
+                        )
+                        gae_norm_conf_sp2 = (gae_conf_sp2 - gae_conf_sp2.mean()) / (
+                            gae_conf_sp2.std() + 1e-8
+                        )
                         pg_loss_1_conf_sp2 = ratio_conf_sp2 * gae_norm_conf_sp2
-                        pg_loss_2_conf_sp2 = jnp.clip(
-                            ratio_conf_sp2,
-                            1.0 - config["CLIP_EPS"],
-                            1.0 + config["CLIP_EPS"]) * gae_norm_conf_sp2
-                        pg_loss_tensor_sp2 = -jnp.minimum(pg_loss_1_conf_sp2, pg_loss_2_conf_sp2)
+                        pg_loss_2_conf_sp2 = (
+                            jnp.clip(
+                                ratio_conf_sp2,
+                                1.0 - config["CLIP_EPS"],
+                                1.0 + config["CLIP_EPS"],
+                            )
+                            * gae_norm_conf_sp2
+                        )
+                        pg_loss_tensor_sp2 = -jnp.minimum(
+                            pg_loss_1_conf_sp2, pg_loss_2_conf_sp2
+                        )
 
                         def _per_agent_losses(agent_id):
                             # Masked losses for one population member. Since the shared tensors above do
                             # not depend on agent_id, grad(sum over agents) here equals the sum of the
                             # per-agent grads that the previous vmap-of-value_and_grad computed.
                             loss_weights_sp1 = jnp.equal(
-                                jnp.argmax(traj_batch_conf_sp1.agent_onehot_id, axis=-1), agent_id
+                                jnp.argmax(
+                                    traj_batch_conf_sp1.agent_onehot_id, axis=-1
+                                ),
+                                agent_id,
                             ).astype(jnp.float32)
                             loss_weights_sp2 = jnp.equal(
-                                jnp.argmax(traj_batch_conf_sp2.agent_onehot_id, axis=-1), agent_id
+                                jnp.argmax(
+                                    traj_batch_conf_sp2.agent_onehot_id, axis=-1
+                                ),
+                                agent_id,
                             ).astype(jnp.float32)
                             loss_weights_xp = jnp.equal(
-                                jnp.argmax(traj_batch_conf_xp.agent_onehot_id, axis=-1), agent_id
+                                jnp.argmax(traj_batch_conf_xp.agent_onehot_id, axis=-1),
+                                agent_id,
                             ).astype(jnp.float32)
 
-                            trajedi_loss_agent_sp1 = compute_mean_weighted_losses(trajedi_loss_sp1, loss_weights_sp1)
-                            trajedi_loss_agent_sp2 = compute_mean_weighted_losses(trajedi_loss_sp2, loss_weights_sp2)
+                            trajedi_loss_agent_sp1 = compute_mean_weighted_losses(
+                                trajedi_loss_sp1, loss_weights_sp1
+                            )
+                            trajedi_loss_agent_sp2 = compute_mean_weighted_losses(
+                                trajedi_loss_sp2, loss_weights_sp2
+                            )
 
-                            value_loss_conf_xp = compute_mean_weighted_losses(value_loss_tensor_xp, loss_weights_xp)
-                            value_loss_conf_sp1 = compute_mean_weighted_losses(value_loss_tensor_sp1, loss_weights_sp1)
-                            value_loss_conf_sp2 = compute_mean_weighted_losses(value_loss_tensor_sp2, loss_weights_sp2)
+                            value_loss_conf_xp = compute_mean_weighted_losses(
+                                value_loss_tensor_xp, loss_weights_xp
+                            )
+                            value_loss_conf_sp1 = compute_mean_weighted_losses(
+                                value_loss_tensor_sp1, loss_weights_sp1
+                            )
+                            value_loss_conf_sp2 = compute_mean_weighted_losses(
+                                value_loss_tensor_sp2, loss_weights_sp2
+                            )
 
-                            pg_loss_conf_xp = compute_mean_weighted_losses(pg_loss_tensor_xp, loss_weights_xp)
-                            pg_loss_conf_sp1 = compute_mean_weighted_losses(pg_loss_tensor_sp1, loss_weights_sp1)
-                            pg_loss_conf_sp2 = compute_mean_weighted_losses(pg_loss_tensor_sp2, loss_weights_sp2)
+                            pg_loss_conf_xp = compute_mean_weighted_losses(
+                                pg_loss_tensor_xp, loss_weights_xp
+                            )
+                            pg_loss_conf_sp1 = compute_mean_weighted_losses(
+                                pg_loss_tensor_sp1, loss_weights_sp1
+                            )
+                            pg_loss_conf_sp2 = compute_mean_weighted_losses(
+                                pg_loss_tensor_sp2, loss_weights_sp2
+                            )
 
-                            entropy_agent_xp = compute_mean_weighted_losses(entropy_conf_xp, loss_weights_xp)
-                            entropy_agent_sp1 = compute_mean_weighted_losses(entropy_conf_sp1, loss_weights_sp1)
-                            entropy_agent_sp2 = compute_mean_weighted_losses(entropy_conf_sp2, loss_weights_sp2)
+                            entropy_agent_xp = compute_mean_weighted_losses(
+                                entropy_conf_xp, loss_weights_xp
+                            )
+                            entropy_agent_sp1 = compute_mean_weighted_losses(
+                                entropy_conf_sp1, loss_weights_sp1
+                            )
+                            entropy_agent_sp2 = compute_mean_weighted_losses(
+                                entropy_conf_sp2, loss_weights_sp2
+                            )
 
                             # We negate the pg_loss_conf_ego to minimize the ego agent's objective
-                            conf_xp_loss = pg_loss_conf_xp + config["VF_COEF"] * value_loss_conf_xp - config["ENT_COEF"] * entropy_agent_xp
-                            conf_sp_loss = pg_loss_conf_sp1 + pg_loss_conf_sp2 + config["VF_COEF"] * (value_loss_conf_sp1 + value_loss_conf_sp2) - config["ENT_COEF"] * (entropy_agent_sp1 + entropy_agent_sp2) + config["TRAJEDI_COEF"] * (trajedi_loss_agent_sp1 + trajedi_loss_agent_sp2)
+                            conf_xp_loss = (
+                                pg_loss_conf_xp
+                                + config["VF_COEF"] * value_loss_conf_xp
+                                - config["ENT_COEF"] * entropy_agent_xp
+                            )
+                            conf_sp_loss = (
+                                pg_loss_conf_sp1
+                                + pg_loss_conf_sp2
+                                + config["VF_COEF"]
+                                * (value_loss_conf_sp1 + value_loss_conf_sp2)
+                                - config["ENT_COEF"]
+                                * (entropy_agent_sp1 + entropy_agent_sp2)
+                                + config["TRAJEDI_COEF"]
+                                * (trajedi_loss_agent_sp1 + trajedi_loss_agent_sp2)
+                            )
 
                             total_loss = conf_xp_loss + conf_sp_loss
 
-                            return total_loss, (value_loss_conf_xp, value_loss_conf_sp1+value_loss_conf_sp2, pg_loss_conf_xp, pg_loss_conf_sp1+pg_loss_conf_sp2, entropy_agent_xp, entropy_agent_sp1+entropy_agent_sp2, trajedi_loss_agent_sp1+trajedi_loss_agent_sp2)
+                            return total_loss, (
+                                value_loss_conf_xp,
+                                value_loss_conf_sp1 + value_loss_conf_sp2,
+                                pg_loss_conf_xp,
+                                pg_loss_conf_sp1 + pg_loss_conf_sp2,
+                                entropy_agent_xp,
+                                entropy_agent_sp1 + entropy_agent_sp2,
+                                trajedi_loss_agent_sp1 + trajedi_loss_agent_sp2,
+                            )
 
                         per_agent_total, per_agent_aux = jax.vmap(_per_agent_losses)(
                             jnp.arange(config["PARTNER_POP_SIZE"])
@@ -907,82 +1388,159 @@ def train_trajedi_partners(config, env, partner_rng):
                     grad_fn = jax.value_and_grad(_loss_fn_policy, has_aux=True)
                     (_, (loss_val_conf, aux_vals_conf)), grads_conf = grad_fn(
                         train_state_conf.params,
-                        init_hstate_conf_sp1, traj_batch_conf_sp1, gae_conf_sp1, target_v_conf_sp1,
-                        init_hstate_conf_sp2, traj_batch_conf_sp2, gae_conf_sp2, target_v_conf_sp2,
-                        init_hstate_conf_xp, traj_batch_conf_xp, gae_conf_xp, target_v_conf_xp
+                        init_hstate_conf_sp1,
+                        traj_batch_conf_sp1,
+                        gae_conf_sp1,
+                        target_v_conf_sp1,
+                        init_hstate_conf_sp2,
+                        traj_batch_conf_sp2,
+                        gae_conf_sp2,
+                        target_v_conf_sp2,
+                        init_hstate_conf_xp,
+                        traj_batch_conf_xp,
+                        gae_conf_xp,
+                        target_v_conf_xp,
                     )
-                    train_state_conf = train_state_conf.apply_gradients(grads=grads_conf)
+                    train_state_conf = train_state_conf.apply_gradients(
+                        grads=grads_conf
+                    )
                     return train_state_conf, (loss_val_conf, aux_vals_conf)
 
                 def _update_minbatch_ego(train_state_ego, batch_info):
-                    minibatches_ego_xp, minibatches_ego_sp1, minibatches_ego_sp2 = batch_info
-                    init_hstate_ego_xp, traj_batch_ego_xp, advantages_xp, returns_xp = minibatches_ego_xp
-                    init_hstate_ego_sp1, traj_batch_ego_sp1, advantages_sp1, returns_sp1 = minibatches_ego_sp1
-                    init_hstate_ego_sp2, traj_batch_ego_sp2, advantages_sp2, returns_sp2 = minibatches_ego_sp2
+                    minibatches_ego_xp, minibatches_ego_sp1, minibatches_ego_sp2 = (
+                        batch_info
+                    )
+                    init_hstate_ego_xp, traj_batch_ego_xp, advantages_xp, returns_xp = (
+                        minibatches_ego_xp
+                    )
+                    (
+                        init_hstate_ego_sp1,
+                        traj_batch_ego_sp1,
+                        advantages_sp1,
+                        returns_sp1,
+                    ) = minibatches_ego_sp1
+                    (
+                        init_hstate_ego_sp2,
+                        traj_batch_ego_sp2,
+                        advantages_sp2,
+                        returns_sp2,
+                    ) = minibatches_ego_sp2
 
                     def _loss_fn_ego(
-                        params, init_hstate_ego_xp, traj_batch_ego_xp, advantages_xp, returns_xp,
-                        init_hstate_ego_sp1, traj_batch_ego_sp1, advantages_sp1, returns_sp1,
-                        init_hstate_ego_sp2, traj_batch_ego_sp2, advantages_sp2, returns_sp2
+                        params,
+                        init_hstate_ego_xp,
+                        traj_batch_ego_xp,
+                        advantages_xp,
+                        returns_xp,
+                        init_hstate_ego_sp1,
+                        traj_batch_ego_sp1,
+                        advantages_sp1,
+                        returns_sp1,
+                        init_hstate_ego_sp2,
+                        traj_batch_ego_sp2,
+                        advantages_sp2,
+                        returns_sp2,
                     ):
-                        def compute_single_minibatch_loss(init_hstate_ego, traj_batch_ego, gae, target_v):
+                        def compute_single_minibatch_loss(
+                            init_hstate_ego, traj_batch_ego, gae, target_v
+                        ):
                             _, value, pi, _ = ego_policy.get_action_value_policy(
-                                params=params, # (64,)
-                                obs=traj_batch_ego.obs, # (512, 15)
-                                done=traj_batch_ego.prev_done, # (512,)
-                                avail_actions=traj_batch_ego.avail_actions, # (512, 6)
-                                hstate=init_hstate_ego, # (1, 16, 8)
-                                rng=jax.random.PRNGKey(0) # only used for action sampling, which is not used here
+                                params=params,  # (64,)
+                                obs=traj_batch_ego.obs,  # (512, 15)
+                                done=traj_batch_ego.prev_done,  # (512,)
+                                avail_actions=traj_batch_ego.avail_actions,  # (512, 6)
+                                hstate=init_hstate_ego,  # (1, 16, 8)
+                                rng=jax.random.PRNGKey(
+                                    0
+                                ),  # only used for action sampling, which is not used here
                             )
                             log_prob = pi.log_prob(traj_batch_ego.action)
 
                             # Value loss
                             value_pred_clipped = traj_batch_ego.value + (
                                 value - traj_batch_ego.value
-                                ).clip(
-                                -config["CLIP_EPS"], config["CLIP_EPS"])
+                            ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                             value_losses = jnp.square(value - target_v)
-                            value_losses_clipped = jnp.square(value_pred_clipped - target_v)
-                            value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
+                            value_losses_clipped = jnp.square(
+                                value_pred_clipped - target_v
+                            )
+                            value_loss = jnp.maximum(
+                                value_losses, value_losses_clipped
+                            ).mean()
 
                             # Policy gradient loss
                             ratio = jnp.exp(log_prob - traj_batch_ego.log_prob)
                             gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                             pg_loss_1 = ratio * gae_norm
-                            pg_loss_2 = jnp.clip(
-                                ratio,
-                                1.0 - config["CLIP_EPS"],
-                                1.0 + config["CLIP_EPS"]) * gae_norm
+                            pg_loss_2 = (
+                                jnp.clip(
+                                    ratio,
+                                    1.0 - config["CLIP_EPS"],
+                                    1.0 + config["CLIP_EPS"],
+                                )
+                                * gae_norm
+                            )
                             pg_loss = -jnp.mean(jnp.minimum(pg_loss_1, pg_loss_2))
 
                             # Entropy
                             entropy = jnp.mean(pi.entropy())
 
-                            total_loss = pg_loss + config["VF_COEF"] * value_loss - config["ENT_COEF"] * entropy
+                            total_loss = (
+                                pg_loss
+                                + config["VF_COEF"] * value_loss
+                                - config["ENT_COEF"] * entropy
+                            )
                             return total_loss, (value_loss, pg_loss, entropy)
-                        
-                        xp_total_loss, (xp_value_loss, xp_pg_loss, xp_entropy) = compute_single_minibatch_loss(
-                            init_hstate_ego_xp, traj_batch_ego_xp, advantages_xp, returns_xp
+
+                        xp_total_loss, (xp_value_loss, xp_pg_loss, xp_entropy) = (
+                            compute_single_minibatch_loss(
+                                init_hstate_ego_xp,
+                                traj_batch_ego_xp,
+                                advantages_xp,
+                                returns_xp,
+                            )
                         )
-                        sp1_total_loss, (sp1_value_loss, sp1_pg_loss, sp1_entropy) = compute_single_minibatch_loss(
-                            init_hstate_ego_sp1, traj_batch_ego_sp1, advantages_sp1, returns_sp1
+                        sp1_total_loss, (sp1_value_loss, sp1_pg_loss, sp1_entropy) = (
+                            compute_single_minibatch_loss(
+                                init_hstate_ego_sp1,
+                                traj_batch_ego_sp1,
+                                advantages_sp1,
+                                returns_sp1,
+                            )
                         )
-                        sp2_total_loss, (sp2_value_loss, sp2_pg_loss, sp2_entropy) = compute_single_minibatch_loss(
-                            init_hstate_ego_sp2, traj_batch_ego_sp2, advantages_sp2, returns_sp2
+                        sp2_total_loss, (sp2_value_loss, sp2_pg_loss, sp2_entropy) = (
+                            compute_single_minibatch_loss(
+                                init_hstate_ego_sp2,
+                                traj_batch_ego_sp2,
+                                advantages_sp2,
+                                returns_sp2,
+                            )
                         )
 
-                        return xp_total_loss+sp1_total_loss+sp2_total_loss, (
-                            xp_value_loss, sp1_value_loss+sp2_value_loss,
-                            xp_pg_loss, sp1_pg_loss+sp2_pg_loss,
-                            xp_entropy, sp1_entropy+sp2_entropy
+                        return xp_total_loss + sp1_total_loss + sp2_total_loss, (
+                            xp_value_loss,
+                            sp1_value_loss + sp2_value_loss,
+                            xp_pg_loss,
+                            sp1_pg_loss + sp2_pg_loss,
+                            xp_entropy,
+                            sp1_entropy + sp2_entropy,
                         )
 
                     grad_fn = jax.value_and_grad(_loss_fn_ego, has_aux=True)
                     (loss_val, aux_vals), grads = grad_fn(
-                        train_state_ego.params, 
-                        init_hstate_ego_xp, traj_batch_ego_xp, advantages_xp, returns_xp,
-                        init_hstate_ego_sp1, traj_batch_ego_sp1, advantages_sp1, returns_sp1,
-                        init_hstate_ego_sp2, traj_batch_ego_sp2, advantages_sp2, returns_sp2,
+                        train_state_ego.params,
+                        init_hstate_ego_xp,
+                        traj_batch_ego_xp,
+                        advantages_xp,
+                        returns_xp,
+                        init_hstate_ego_sp1,
+                        traj_batch_ego_sp1,
+                        advantages_sp1,
+                        returns_sp1,
+                        init_hstate_ego_sp2,
+                        traj_batch_ego_sp2,
+                        advantages_sp2,
+                        returns_sp2,
                     )
                     train_state_ego = train_state_ego.apply_gradients(grads=grads)
                     return train_state_ego, (loss_val, aux_vals)
@@ -990,72 +1548,140 @@ def train_trajedi_partners(config, env, partner_rng):
                 # TODO Update this part of code to adjust to the types of interactions
                 # used during training
                 (
-                    train_state_conf, train_state_ego,
-                    traj_batch_conf_sp1, traj_batch_conf_sp2, traj_batch_conf_xp,
-                    traj_batch_br_sp1, traj_batch_br_sp2, traj_batch_br_xp,
-                    advantages_conf_sp1, advantages_conf_sp2, advantages_conf_xp,
-                    advantages_br_sp1, advantages_br_sp2, advantages_br_xp,
-                    targets_conf_sp1, targets_conf_sp2, targets_conf_xp,
-                    targets_br_sp1, targets_br_sp2, targets_br_xp,
-                    rng_conf, rng_br
+                    train_state_conf,
+                    train_state_ego,
+                    traj_batch_conf_sp1,
+                    traj_batch_conf_sp2,
+                    traj_batch_conf_xp,
+                    traj_batch_br_sp1,
+                    traj_batch_br_sp2,
+                    traj_batch_br_xp,
+                    advantages_conf_sp1,
+                    advantages_conf_sp2,
+                    advantages_conf_xp,
+                    advantages_br_sp1,
+                    advantages_br_sp2,
+                    advantages_br_xp,
+                    targets_conf_sp1,
+                    targets_conf_sp2,
+                    targets_conf_xp,
+                    targets_br_sp1,
+                    targets_br_sp2,
+                    targets_br_xp,
+                    rng_conf,
+                    rng_br,
                 ) = update_state
 
-                init_hstate_conf = confederate_policy.init_hstate(config["NUM_CONF_ACTORS"])
+                init_hstate_conf = confederate_policy.init_hstate(
+                    config["NUM_CONF_ACTORS"]
+                )
                 init_hstate_br_xp = ego_policy.init_hstate(config["NUM_CONF_ACTORS"])
                 init_hstate_br_sp = ego_policy.init_hstate(config["NUM_EGO_ACTORS"])
 
-                rng_conf, perm_rng_conf_sp1, perm_rng_conf_sp2, perm_rng_conf_xp = jax.random.split(rng_conf, 4)
-                rng_br, perm_rng_br_sp1, perm_rng_br_sp2, perm_rng_br_xp = jax.random.split(rng_br, 4)
+                rng_conf, perm_rng_conf_sp1, perm_rng_conf_sp2, perm_rng_conf_xp = (
+                    jax.random.split(rng_conf, 4)
+                )
+                rng_br, perm_rng_br_sp1, perm_rng_br_sp2, perm_rng_br_xp = (
+                    jax.random.split(rng_br, 4)
+                )
                 # Create minibatches for each agent and interaction type
                 minibatches_conf_sp1 = _create_minibatches(
-                    traj_batch_conf_sp1, advantages_conf_sp1, targets_conf_sp1, init_hstate_conf,
-                    config["NUM_CONF_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_conf_sp1
+                    traj_batch_conf_sp1,
+                    advantages_conf_sp1,
+                    targets_conf_sp1,
+                    init_hstate_conf,
+                    config["NUM_CONF_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_conf_sp1,
                 )
 
                 minibatches_conf_sp2 = _create_minibatches(
-                    traj_batch_conf_sp2, advantages_conf_sp2, targets_conf_sp2, init_hstate_conf,
-                    config["NUM_CONF_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_conf_sp2
+                    traj_batch_conf_sp2,
+                    advantages_conf_sp2,
+                    targets_conf_sp2,
+                    init_hstate_conf,
+                    config["NUM_CONF_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_conf_sp2,
                 )
 
                 minibatches_conf_xp = _create_minibatches(
-                    traj_batch_conf_xp, advantages_conf_xp, targets_conf_xp, init_hstate_conf,
-                    config["NUM_CONF_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_conf_xp
+                    traj_batch_conf_xp,
+                    advantages_conf_xp,
+                    targets_conf_xp,
+                    init_hstate_conf,
+                    config["NUM_CONF_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_conf_xp,
                 )
 
                 minibatches_br_sp1 = _create_minibatches(
-                    traj_batch_br_sp1, advantages_br_sp1, targets_br_sp1, init_hstate_br_sp,
-                    config["NUM_EGO_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_br_sp1
+                    traj_batch_br_sp1,
+                    advantages_br_sp1,
+                    targets_br_sp1,
+                    init_hstate_br_sp,
+                    config["NUM_EGO_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_br_sp1,
                 )
 
                 minibatches_br_sp2 = _create_minibatches(
-                    traj_batch_br_sp2, advantages_br_sp2, targets_br_sp2, init_hstate_br_sp,
-                    config["NUM_EGO_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_br_sp2
+                    traj_batch_br_sp2,
+                    advantages_br_sp2,
+                    targets_br_sp2,
+                    init_hstate_br_sp,
+                    config["NUM_EGO_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_br_sp2,
                 )
 
                 minibatches_br_xp = _create_minibatches(
-                    traj_batch_br_xp, advantages_br_xp, targets_br_xp, init_hstate_br_xp,
-                    config["NUM_CONF_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_br_xp
+                    traj_batch_br_xp,
+                    advantages_br_xp,
+                    targets_br_xp,
+                    init_hstate_br_xp,
+                    config["NUM_CONF_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_br_xp,
                 )
 
                 # Update confederates
                 train_state_conf, all_losses_conf = jax.lax.scan(
-                    _update_minbatch_conf, train_state_conf, (minibatches_conf_xp, minibatches_conf_sp1, minibatches_conf_sp2)
+                    _update_minbatch_conf,
+                    train_state_conf,
+                    (minibatches_conf_xp, minibatches_conf_sp1, minibatches_conf_sp2),
                 )
 
                 # Update ego agent
                 train_state_ego, all_losses_ego = jax.lax.scan(
-                    _update_minbatch_ego, train_state_ego, (minibatches_br_xp, minibatches_br_sp1, minibatches_br_sp2)
+                    _update_minbatch_ego,
+                    train_state_ego,
+                    (minibatches_br_xp, minibatches_br_sp1, minibatches_br_sp2),
                 )
 
                 update_state = (
-                    train_state_conf, train_state_ego,
-                    traj_batch_conf_sp1, traj_batch_conf_sp2, traj_batch_conf_xp,
-                    traj_batch_br_sp1, traj_batch_br_sp2, traj_batch_br_xp,
-                    advantages_conf_sp1, advantages_conf_sp2, advantages_conf_xp,
-                    advantages_br_sp1, advantages_br_sp2, advantages_br_xp,
-                    targets_conf_sp1, targets_conf_sp2, targets_conf_xp,
-                    targets_br_sp1, targets_br_sp2, targets_br_xp,
-                    rng_conf, rng_br
+                    train_state_conf,
+                    train_state_ego,
+                    traj_batch_conf_sp1,
+                    traj_batch_conf_sp2,
+                    traj_batch_conf_xp,
+                    traj_batch_br_sp1,
+                    traj_batch_br_sp2,
+                    traj_batch_br_xp,
+                    advantages_conf_sp1,
+                    advantages_conf_sp2,
+                    advantages_conf_xp,
+                    advantages_br_sp1,
+                    advantages_br_sp2,
+                    advantages_br_xp,
+                    targets_conf_sp1,
+                    targets_conf_sp2,
+                    targets_conf_xp,
+                    targets_br_sp1,
+                    targets_br_sp2,
+                    targets_br_xp,
+                    rng_conf,
+                    rng_br,
                 )
                 return update_state, (all_losses_conf, all_losses_ego)
 
@@ -1069,82 +1695,172 @@ def train_trajedi_partners(config, env, partner_rng):
                 6. PPO updates for confederate and ego policies.
                 """
                 (
-                    all_train_state_conf, train_state_ego,
-                    last_env_state_confs_sp, last_env_state_confs_xp, last_env_state_br_sp,
-                    last_obs_confs_sp, last_obs_confs_xp, last_obs_br_sp, 
-                    last_done_confs_sp, last_done_confs_xp, last_done_br_sp,
-                    last_conf_h_sp_p1, last_conf_h_sp_p2, 
-                    last_conf_h_xp, last_br_h_xp,
-                    last_br_h_sp_p1, last_br_h_sp_p2,
-                    last_eps_counter, last_timestep_counter,
-                    rng_conf, rng_br, update_steps
+                    all_train_state_conf,
+                    train_state_ego,
+                    last_env_state_confs_sp,
+                    last_env_state_confs_xp,
+                    last_env_state_br_sp,
+                    last_obs_confs_sp,
+                    last_obs_confs_xp,
+                    last_obs_br_sp,
+                    last_done_confs_sp,
+                    last_done_confs_xp,
+                    last_done_br_sp,
+                    last_conf_h_sp_p1,
+                    last_conf_h_sp_p2,
+                    last_conf_h_xp,
+                    last_br_h_xp,
+                    last_br_h_sp_p1,
+                    last_br_h_sp_p2,
+                    last_eps_counter,
+                    last_timestep_counter,
+                    rng_conf,
+                    rng_br,
+                    update_steps,
                 ) = update_runner_state
 
-                rng_conf, conf_sampling_sp_rng, conf_sampling_xp_rng = jax.random.split(rng_conf, 3)
-                conf_ids_sp = jax.random.randint(conf_sampling_sp_rng, (config["NUM_ENVS_CONFS"],), 0, config["PARTNER_POP_SIZE"])
-                conf_ids_xp = jax.random.randint(conf_sampling_xp_rng, (config["NUM_ENVS_CONFS"],), 0, config["PARTNER_POP_SIZE"])
+                rng_conf, conf_sampling_sp_rng, conf_sampling_xp_rng = jax.random.split(
+                    rng_conf, 3
+                )
+                conf_ids_sp = jax.random.randint(
+                    conf_sampling_sp_rng,
+                    (config["NUM_ENVS_CONFS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
+                conf_ids_xp = jax.random.randint(
+                    conf_sampling_xp_rng,
+                    (config["NUM_ENVS_CONFS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
 
                 # 1) rollout for self-play interactions between confederates
                 runner_state_conf_sp = (
-                    all_train_state_conf, conf_ids_sp,
-                    last_env_state_confs_sp, last_obs_confs_sp, 
-                    last_done_confs_sp, last_conf_h_sp_p1, 
-                    last_conf_h_sp_p2, last_eps_counter, 
-                    last_timestep_counter, rng_conf
+                    all_train_state_conf,
+                    conf_ids_sp,
+                    last_env_state_confs_sp,
+                    last_obs_confs_sp,
+                    last_done_confs_sp,
+                    last_conf_h_sp_p1,
+                    last_conf_h_sp_p2,
+                    last_eps_counter,
+                    last_timestep_counter,
+                    rng_conf,
                 )
 
-                runner_state_conf_sp, (traj_batch_conf_p0, traj_batch_conf_p1) = jax.lax.scan(
-                    _env_step_confs_sp, runner_state_conf_sp, None, config["ROLLOUT_LENGTH"])
+                runner_state_conf_sp, (traj_batch_conf_p0, traj_batch_conf_p1) = (
+                    jax.lax.scan(
+                        _env_step_confs_sp,
+                        runner_state_conf_sp,
+                        None,
+                        config["ROLLOUT_LENGTH"],
+                    )
+                )
                 (
-                    all_train_state_conf, last_conf_ids, last_env_state_confs_sp, 
-                    last_obs_confs_sp, last_done_confs_sp, last_conf_h_sp_p1, 
-                    last_conf_h_sp_p2, last_eps_counter, last_timestep_counter, rng_conf
+                    all_train_state_conf,
+                    last_conf_ids,
+                    last_env_state_confs_sp,
+                    last_obs_confs_sp,
+                    last_done_confs_sp,
+                    last_conf_h_sp_p1,
+                    last_conf_h_sp_p2,
+                    last_eps_counter,
+                    last_timestep_counter,
+                    rng_conf,
                 ) = runner_state_conf_sp
 
                 # 2) rollout for cross-play interactions of confederate against ego
                 runner_state_conf_xp = (
-                    all_train_state_conf, train_state_ego, conf_ids_xp,
-                    last_env_state_confs_xp, last_obs_confs_xp, 
-                    last_done_confs_xp, last_conf_h_xp, last_br_h_xp,
-                    rng_conf
+                    all_train_state_conf,
+                    train_state_ego,
+                    conf_ids_xp,
+                    last_env_state_confs_xp,
+                    last_obs_confs_xp,
+                    last_done_confs_xp,
+                    last_conf_h_xp,
+                    last_br_h_xp,
+                    rng_conf,
                 )
-                runner_state_conf_xp, (traj_batch_conf_xp, traj_batch_br_xp) = jax.lax.scan(
-                    _env_step_confs_xp, runner_state_conf_xp, None, config["ROLLOUT_LENGTH"])
+                runner_state_conf_xp, (traj_batch_conf_xp, traj_batch_br_xp) = (
+                    jax.lax.scan(
+                        _env_step_confs_xp,
+                        runner_state_conf_xp,
+                        None,
+                        config["ROLLOUT_LENGTH"],
+                    )
+                )
                 (
-                    all_train_state_conf, train_state_ego, last_conf_ids_xp,
-                    last_env_state_confs_xp, last_obs_confs_xp, last_done_confs_xp,
-                    last_conf_h_xp, last_br_h_xp, rng_conf
+                    all_train_state_conf,
+                    train_state_ego,
+                    last_conf_ids_xp,
+                    last_env_state_confs_xp,
+                    last_obs_confs_xp,
+                    last_done_confs_xp,
+                    last_conf_h_xp,
+                    last_br_h_xp,
+                    rng_conf,
                 ) = runner_state_conf_xp
 
                 # 3) rollout self-play interactions of ego agent
                 runner_state_br_sp = (
-                    train_state_ego, last_env_state_br_sp, last_obs_br_sp, 
-                    last_done_br_sp, last_br_h_sp_p1, last_br_h_sp_p2,
-                    rng_br
+                    train_state_ego,
+                    last_env_state_br_sp,
+                    last_obs_br_sp,
+                    last_done_br_sp,
+                    last_br_h_sp_p1,
+                    last_br_h_sp_p2,
+                    rng_br,
                 )
-                runner_state_br_sp, (traj_batch_br_sp_p1, traj_batch_br_sp_p2) = jax.lax.scan(
-                    _env_step_br_sp, runner_state_br_sp, None, config["ROLLOUT_LENGTH"])
+                runner_state_br_sp, (traj_batch_br_sp_p1, traj_batch_br_sp_p2) = (
+                    jax.lax.scan(
+                        _env_step_br_sp,
+                        runner_state_br_sp,
+                        None,
+                        config["ROLLOUT_LENGTH"],
+                    )
+                )
                 (
-                    train_state_ego, last_env_state_br_sp, last_obs_br_sp, 
-                    last_done_br_sp, last_br_h_sp_p1, last_br_h_sp_p2,
-                    rng_br
+                    train_state_ego,
+                    last_env_state_br_sp,
+                    last_obs_br_sp,
+                    last_done_br_sp,
+                    last_br_h_sp_p1,
+                    last_br_h_sp_p2,
+                    rng_br,
                 ) = runner_state_br_sp
 
-                def _compute_advantages_and_targets_conf(batch_size, env_state, policy_params, policy_hstate,
-                                                   last_obs, last_dones, last_conf_ids, traj_batch,
-                                                   agent_name, value_idx=None):
-                    '''value_idx selects which of the confederate's two value heads to use:
-                    head 0 = self-play, head 1 = cross-play against ego.'''
-                    avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)[agent_name].astype(jnp.float32)
-                    rng_key = jax.random.PRNGKey(0)  # dummy key as we don't sample actions
+                def _compute_advantages_and_targets_conf(
+                    batch_size,
+                    env_state,
+                    policy_params,
+                    policy_hstate,
+                    last_obs,
+                    last_dones,
+                    last_conf_ids,
+                    traj_batch,
+                    agent_name,
+                    value_idx=None,
+                ):
+                    """value_idx selects which of the confederate's two value heads to use:
+                    head 0 = self-play, head 1 = cross-play against ego."""
+                    avail_actions = jax.vmap(env.get_avail_actions)(
+                        env_state.env_state
+                    )[agent_name].astype(jnp.float32)
+                    rng_key = jax.random.PRNGKey(
+                        0
+                    )  # dummy key as we don't sample actions
                     rng_keys = jax.random.split(rng_key, last_obs[agent_name].shape[0])
                     specific_policy_params = gather_params(policy_params, last_conf_ids)
                     _, vals, _, _ = jax.vmap(forward_pass_conf)(
-                        specific_policy_params, last_obs[agent_name], 
-                        last_dones[agent_name], jax.lax.stop_gradient(avail_actions), 
-                        policy_hstate, rng_keys  # dummy key as we don't sample actions
+                        specific_policy_params,
+                        last_obs[agent_name],
+                        last_dones[agent_name],
+                        jax.lax.stop_gradient(avail_actions),
+                        policy_hstate,
+                        rng_keys,  # dummy key as we don't sample actions
                     )
-                
+
                     if value_idx is None:
                         last_val = vals.squeeze()
                     else:
@@ -1152,90 +1868,160 @@ def train_trajedi_partners(config, env, partner_rng):
                     advantages, targets = _calculate_gae(traj_batch, last_val)
                     return advantages, targets
 
-                def _compute_advantages_and_targets_br(batch_size, env_state, policy_params, policy_hstate,
-                                                   last_obs, last_dones, traj_batch, agent_name):
-                    avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)[agent_name].astype(jnp.float32)
+                def _compute_advantages_and_targets_br(
+                    batch_size,
+                    env_state,
+                    policy_params,
+                    policy_hstate,
+                    last_obs,
+                    last_dones,
+                    traj_batch,
+                    agent_name,
+                ):
+                    avail_actions = jax.vmap(env.get_avail_actions)(
+                        env_state.env_state
+                    )[agent_name].astype(jnp.float32)
                     _, vals, _, _ = ego_policy.get_action_value_policy(
                         params=policy_params,
                         obs=last_obs[agent_name].reshape(1, batch_size, -1),
                         done=last_dones[agent_name].reshape(1, batch_size),
                         avail_actions=jax.lax.stop_gradient(avail_actions),
                         hstate=policy_hstate,
-                        rng=jax.random.PRNGKey(0)  # dummy key as we don't sample actions
+                        rng=jax.random.PRNGKey(
+                            0
+                        ),  # dummy key as we don't sample actions
                     )
                     last_val = vals.squeeze()
                     advantages, targets = _calculate_gae(traj_batch, last_val)
                     return advantages, targets
 
-
                 # 4a) compute advantage for confederate agent from interaction with itself
-                advantages_sp_conf_p1, targets_sp_conf_p1 = _compute_advantages_and_targets_conf(
-                    config["NUM_CONF_ACTORS"],
-                    last_env_state_confs_sp, all_train_state_conf.params, 
-                    last_conf_h_sp_p1, last_obs_confs_sp, last_done_confs_sp, last_conf_ids,
-                    traj_batch_conf_p0, "agent_0", value_idx=0
+                advantages_sp_conf_p1, targets_sp_conf_p1 = (
+                    _compute_advantages_and_targets_conf(
+                        config["NUM_CONF_ACTORS"],
+                        last_env_state_confs_sp,
+                        all_train_state_conf.params,
+                        last_conf_h_sp_p1,
+                        last_obs_confs_sp,
+                        last_done_confs_sp,
+                        last_conf_ids,
+                        traj_batch_conf_p0,
+                        "agent_0",
+                        value_idx=0,
+                    )
                 )
 
-                advantages_sp_conf_p2, targets_sp_conf_p2 = _compute_advantages_and_targets_conf(
-                    config["NUM_CONF_ACTORS"],
-                    last_env_state_confs_sp, all_train_state_conf.params, 
-                    last_conf_h_sp_p2, last_obs_confs_sp, last_done_confs_sp, last_conf_ids, 
-                    traj_batch_conf_p1, "agent_1", value_idx=0
+                advantages_sp_conf_p2, targets_sp_conf_p2 = (
+                    _compute_advantages_and_targets_conf(
+                        config["NUM_CONF_ACTORS"],
+                        last_env_state_confs_sp,
+                        all_train_state_conf.params,
+                        last_conf_h_sp_p2,
+                        last_obs_confs_sp,
+                        last_done_confs_sp,
+                        last_conf_ids,
+                        traj_batch_conf_p1,
+                        "agent_1",
+                        value_idx=0,
+                    )
                 )
 
                 # 4b) compute advantage for confederate agent from cross-play against ego
-                advantages_xp_conf, targets_xp_conf = _compute_advantages_and_targets_conf(
-                    config["NUM_CONF_ACTORS"],
-                    last_env_state_confs_xp, all_train_state_conf.params, 
-                    last_conf_h_xp, last_obs_confs_xp, last_done_confs_xp, last_conf_ids_xp,
-                    traj_batch_conf_xp, "agent_0", value_idx=1
+                advantages_xp_conf, targets_xp_conf = (
+                    _compute_advantages_and_targets_conf(
+                        config["NUM_CONF_ACTORS"],
+                        last_env_state_confs_xp,
+                        all_train_state_conf.params,
+                        last_conf_h_xp,
+                        last_obs_confs_xp,
+                        last_done_confs_xp,
+                        last_conf_ids_xp,
+                        traj_batch_conf_xp,
+                        "agent_0",
+                        value_idx=1,
+                    )
                 )
-            
+
                 # 5a) compute advantage for ego agent from interaction with confederates
                 advantages_xp_br, targets_xp_br = _compute_advantages_and_targets_br(
                     config["NUM_CONF_ACTORS"],
-                    last_env_state_confs_xp, train_state_ego.params, 
-                    last_br_h_xp, last_obs_confs_xp, last_done_confs_xp, 
-                    traj_batch_br_xp, "agent_1"
+                    last_env_state_confs_xp,
+                    train_state_ego.params,
+                    last_br_h_xp,
+                    last_obs_confs_xp,
+                    last_done_confs_xp,
+                    traj_batch_br_xp,
+                    "agent_1",
                 )
 
                 # 5b) compute advantage for ego agent from interaction with itself
-                advantages_sp_br_p1, targets_sp_br_p1 = _compute_advantages_and_targets_br(
-                    config["NUM_EGO_ACTORS"],
-                    last_env_state_br_sp, train_state_ego.params, 
-                    last_br_h_sp_p1, last_obs_br_sp, last_done_br_sp, 
-                    traj_batch_br_sp_p1, "agent_0"
+                advantages_sp_br_p1, targets_sp_br_p1 = (
+                    _compute_advantages_and_targets_br(
+                        config["NUM_EGO_ACTORS"],
+                        last_env_state_br_sp,
+                        train_state_ego.params,
+                        last_br_h_sp_p1,
+                        last_obs_br_sp,
+                        last_done_br_sp,
+                        traj_batch_br_sp_p1,
+                        "agent_0",
+                    )
                 )
 
-                advantages_sp_br_p2, targets_sp_br_p2 = _compute_advantages_and_targets_br(
-                    config["NUM_EGO_ACTORS"],
-                    last_env_state_br_sp, train_state_ego.params, 
-                    last_br_h_sp_p2, last_obs_br_sp, last_done_br_sp, 
-                    traj_batch_br_sp_p2, "agent_1"
+                advantages_sp_br_p2, targets_sp_br_p2 = (
+                    _compute_advantages_and_targets_br(
+                        config["NUM_EGO_ACTORS"],
+                        last_env_state_br_sp,
+                        train_state_ego.params,
+                        last_br_h_sp_p2,
+                        last_obs_br_sp,
+                        last_done_br_sp,
+                        traj_batch_br_sp_p2,
+                        "agent_1",
+                    )
                 )
-                
+
                 # 6) PPO update
                 update_state = (
-                    all_train_state_conf, train_state_ego,
-                    traj_batch_conf_p0, traj_batch_conf_p1, traj_batch_conf_xp,
-                    traj_batch_br_sp_p1, traj_batch_br_sp_p2, traj_batch_br_xp,
-                    advantages_sp_conf_p1, advantages_sp_conf_p2, advantages_xp_conf,
-                    advantages_sp_br_p1, advantages_sp_br_p2, advantages_xp_br,
-                    targets_sp_conf_p1, targets_sp_conf_p2, targets_xp_conf,
-                    targets_sp_br_p1, targets_sp_br_p2, targets_xp_br,
-                    rng_conf, rng_br
+                    all_train_state_conf,
+                    train_state_ego,
+                    traj_batch_conf_p0,
+                    traj_batch_conf_p1,
+                    traj_batch_conf_xp,
+                    traj_batch_br_sp_p1,
+                    traj_batch_br_sp_p2,
+                    traj_batch_br_xp,
+                    advantages_sp_conf_p1,
+                    advantages_sp_conf_p2,
+                    advantages_xp_conf,
+                    advantages_sp_br_p1,
+                    advantages_sp_br_p2,
+                    advantages_xp_br,
+                    targets_sp_conf_p1,
+                    targets_sp_conf_p2,
+                    targets_xp_conf,
+                    targets_sp_br_p1,
+                    targets_sp_br_p2,
+                    targets_xp_br,
+                    rng_conf,
+                    rng_br,
                 )
                 update_state, (all_losses_conf, all_losses_ego) = jax.lax.scan(
-                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                )
                 all_train_state_conf = update_state[0]
                 train_state_ego = update_state[1]
 
                 # Metrics
                 def mask_and_mean(x, mask):
                     return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
-                
-                mask = traj_batch_conf_p0.info.get("returned_episode", jnp.ones_like(traj_batch_conf_p0.reward))
-                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_conf_p0.info)
+
+                mask = traj_batch_conf_p0.info.get(
+                    "returned_episode", jnp.ones_like(traj_batch_conf_p0.reward)
+                )
+                metric = jax.tree.map(
+                    lambda x: mask_and_mean(x, mask), traj_batch_conf_p0.info
+                )
                 metric["update_steps"] = update_steps
 
                 # Conf agent losses: value_loss_ego, value_loss_br, pg_loss_ego, pg_loss_br, entropy_ego, entropy_br
@@ -1255,129 +2041,215 @@ def train_trajedi_partners(config, env, partner_rng):
                 metric["entropy_loss_ego_against_conf"] = all_losses_ego[1][4].mean()
                 metric["entropy_loss_ego_self_play"] = all_losses_ego[1][5].mean()
 
-                metric["average_rewards_conf_sp"] = (jnp.mean(traj_batch_conf_p0.reward) + jnp.mean(traj_batch_conf_p1.reward))/2.0
-                metric["average_rewards_conf_xp"] = jnp.mean(traj_batch_conf_xp.reward) 
-                metric["average_rewards_ego_sp"] = (jnp.mean(traj_batch_br_sp_p1.reward) + jnp.mean(traj_batch_br_sp_p2.reward))/2.0
+                metric["average_rewards_conf_sp"] = (
+                    jnp.mean(traj_batch_conf_p0.reward)
+                    + jnp.mean(traj_batch_conf_p1.reward)
+                ) / 2.0
+                metric["average_rewards_conf_xp"] = jnp.mean(traj_batch_conf_xp.reward)
+                metric["average_rewards_ego_sp"] = (
+                    jnp.mean(traj_batch_br_sp_p1.reward)
+                    + jnp.mean(traj_batch_br_sp_p2.reward)
+                ) / 2.0
                 metric["average_rewards_br"] = jnp.mean(traj_batch_br_xp.reward)
 
                 update_steps = update_steps + 1
 
                 new_runner_state = (
-                    all_train_state_conf, train_state_ego,
-                    last_env_state_confs_sp, last_env_state_confs_xp, last_env_state_br_sp,
-                    last_obs_confs_sp, last_obs_confs_xp, last_obs_br_sp, 
-                    last_done_confs_sp, last_done_confs_xp, last_done_br_sp,
-                    last_conf_h_sp_p1, last_conf_h_sp_p2, 
-                    last_conf_h_xp, last_br_h_xp,
-                    last_br_h_sp_p1, last_br_h_sp_p2,
-                    last_eps_counter, last_timestep_counter,
-                    rng_conf, rng_br, update_steps
+                    all_train_state_conf,
+                    train_state_ego,
+                    last_env_state_confs_sp,
+                    last_env_state_confs_xp,
+                    last_env_state_br_sp,
+                    last_obs_confs_sp,
+                    last_obs_confs_xp,
+                    last_obs_br_sp,
+                    last_done_confs_sp,
+                    last_done_confs_xp,
+                    last_done_br_sp,
+                    last_conf_h_sp_p1,
+                    last_conf_h_sp_p2,
+                    last_conf_h_xp,
+                    last_br_h_xp,
+                    last_br_h_sp_p1,
+                    last_br_h_sp_p2,
+                    last_eps_counter,
+                    last_timestep_counter,
+                    rng_conf,
+                    rng_br,
+                    update_steps,
                 )
                 return (new_runner_state, metric)
 
             # --------------------------
             # PPO Update and Checkpoint saving
             # --------------------------
-            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)  # -1 because we store a ckpt at the last update
+            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                1, config["NUM_CHECKPOINTS"] - 1
+            )  # -1 because we store a ckpt at the last update
             num_ckpts = config["NUM_CHECKPOINTS"]
 
             # Build a PyTree that holds parameters for all conf agent checkpoints
             def init_ckpt_array(params_pytree):
                 return jax.tree.map(
-                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype),
-                    params_pytree)
+                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
+                )
 
             def _update_step_with_ckpt(state_with_ckpt, unused):
                 (
                     (
-                        all_train_state_conf, train_state_ego,
-                        env_state_confs_sp, env_state_confs_xp, env_state_br_sp,
-                        obs_confs_sp, obs_confs_xp, obs_br_sp, 
-                        done_confs_sp, done_confs_xp, done_br_sp,
-                        conf_h_sp_p1, conf_h_sp_p2, 
-                        conf_h_xp, br_h_xp,
-                        br_h_sp_p1, br_h_sp_p2,
-                        eps_counter, timestep_counter,
-                        rng_conf, rng_br, update_steps
-                    ), checkpoint_array_conf, checkpoint_array_ego, ckpt_idx,
-                    eval_info_ego
+                        all_train_state_conf,
+                        train_state_ego,
+                        env_state_confs_sp,
+                        env_state_confs_xp,
+                        env_state_br_sp,
+                        obs_confs_sp,
+                        obs_confs_xp,
+                        obs_br_sp,
+                        done_confs_sp,
+                        done_confs_xp,
+                        done_br_sp,
+                        conf_h_sp_p1,
+                        conf_h_sp_p2,
+                        conf_h_xp,
+                        br_h_xp,
+                        br_h_sp_p1,
+                        br_h_sp_p2,
+                        eps_counter,
+                        timestep_counter,
+                        rng_conf,
+                        rng_br,
+                        update_steps,
+                    ),
+                    checkpoint_array_conf,
+                    checkpoint_array_ego,
+                    ckpt_idx,
+                    eval_info_ego,
                 ) = state_with_ckpt
-
 
                 # Single PPO update
                 (new_runner_state, metric) = _update_step(
                     (
-                        all_train_state_conf, train_state_ego,
-                        env_state_confs_sp, env_state_confs_xp, env_state_br_sp,
-                        obs_confs_sp, obs_confs_xp, obs_br_sp, 
-                        done_confs_sp, done_confs_xp, done_br_sp,
-                        conf_h_sp_p1, conf_h_sp_p2, 
-                        conf_h_xp, br_h_xp,
-                        br_h_sp_p1, br_h_sp_p2,
-                        eps_counter, timestep_counter,
-                        rng_conf, rng_br, update_steps
+                        all_train_state_conf,
+                        train_state_ego,
+                        env_state_confs_sp,
+                        env_state_confs_xp,
+                        env_state_br_sp,
+                        obs_confs_sp,
+                        obs_confs_xp,
+                        obs_br_sp,
+                        done_confs_sp,
+                        done_confs_xp,
+                        done_br_sp,
+                        conf_h_sp_p1,
+                        conf_h_sp_p2,
+                        conf_h_xp,
+                        br_h_xp,
+                        br_h_sp_p1,
+                        br_h_sp_p2,
+                        eps_counter,
+                        timestep_counter,
+                        rng_conf,
+                        rng_br,
+                        update_steps,
                     ),
-                    None
+                    None,
                 )
 
                 (
-                    all_train_state_conf, train_state_ego,
-                    env_state_confs_sp, env_state_confs_xp, env_state_br_sp,
-                    obs_confs_sp, obs_confs_xp, obs_br_sp, 
-                    done_confs_sp, done_confs_xp, done_br_sp,
-                    conf_h_sp_p1, conf_h_sp_p2, 
-                    conf_h_xp, br_h_xp,
-                    br_h_sp_p1, br_h_sp_p2,
-                    eps_counter, timestep_counter,
-                    rng_conf, rng_br, update_steps
+                    all_train_state_conf,
+                    train_state_ego,
+                    env_state_confs_sp,
+                    env_state_confs_xp,
+                    env_state_br_sp,
+                    obs_confs_sp,
+                    obs_confs_xp,
+                    obs_br_sp,
+                    done_confs_sp,
+                    done_confs_xp,
+                    done_br_sp,
+                    conf_h_sp_p1,
+                    conf_h_sp_p2,
+                    conf_h_xp,
+                    br_h_xp,
+                    br_h_sp_p1,
+                    br_h_sp_p2,
+                    eps_counter,
+                    timestep_counter,
+                    rng_conf,
+                    rng_br,
+                    update_steps,
                 ) = new_runner_state
 
                 # Decide if we store a checkpoint
                 # update steps is 1-indexed because it was incremented at the end of the update step
-                to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                        jnp.equal(update_steps, config["NUM_UPDATES"]))
+                to_store = jnp.logical_or(
+                    jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
+                )
 
                 def store_and_eval_ckpt(args):
                     ckpt_arr_and_ep_infos, rng, cidx = args
-                    ckpt_arr_conf, ckpt_arr_ego, prev_ep_infos_ego = ckpt_arr_and_ep_infos
+                    ckpt_arr_conf, ckpt_arr_ego, _prev_ep_infos_ego = (
+                        ckpt_arr_and_ep_infos
+                    )
                     new_ckpt_arr_conf = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_conf, all_train_state_conf.params
+                        ckpt_arr_conf,
+                        all_train_state_conf.params,
                     )
-                    
+
                     new_ckpt_arr_ego = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_ego, train_state_ego.params
+                        ckpt_arr_ego,
+                        train_state_ego.params,
                     )
 
                     # run eval episodes
-                    rng, eval_rng, = jax.random.split(rng)
+                    (
+                        rng,
+                        eval_rng,
+                    ) = jax.random.split(rng)
                     # conf vs ego
 
                     def run_all_episodes_xp(rng, train_state_conf, train_state_ego):
                         conf_ids = jnp.arange(config["PARTNER_POP_SIZE"])
-                        gathered_conf_model_params = gather_params(train_state_conf.params, conf_ids)
+                        gathered_conf_model_params = gather_params(
+                            train_state_conf.params, conf_ids
+                        )
 
                         rng, eval_rng = jax.random.split(rng)
+
                         def run_episodes_fixed_rng(conf_param):
                             return run_episodes(
-                                eval_rng, env,
-                                conf_param, confederate_policy,
-                                train_state_ego.params, ego_policy,
-                                config["ROLLOUT_LENGTH"], config["NUM_EVAL_EPISODES"],
+                                eval_rng,
+                                env,
+                                conf_param,
+                                confederate_policy,
+                                train_state_ego.params,
+                                ego_policy,
+                                config["ROLLOUT_LENGTH"],
+                                config["NUM_EVAL_EPISODES"],
                             )
-                        ep_infos = jax.vmap(run_episodes_fixed_rng)(
-                            gathered_conf_model_params # leaves where shape is (pop_size*pop_size, ...)
+
+                        ep_infos = jax.vmap(
+                            run_episodes_fixed_rng
+                        )(
+                            gathered_conf_model_params  # leaves where shape is (pop_size*pop_size, ...)
                         )
                         return ep_infos
-            
-                    last_ep_info_with_ego = jax.tree.map(lambda x: x.mean(), run_all_episodes_xp(
-                        eval_rng,
-                        all_train_state_conf,
-                        train_state_ego
-                    ))
 
-                    return ((new_ckpt_arr_conf, new_ckpt_arr_ego, last_ep_info_with_ego), rng, cidx + 1)
+                    last_ep_info_with_ego = jax.tree.map(
+                        lambda x: x.mean(),
+                        run_all_episodes_xp(
+                            eval_rng, all_train_state_conf, train_state_ego
+                        ),
+                    )
+
+                    return (
+                        (new_ckpt_arr_conf, new_ckpt_arr_ego, last_ep_info_with_ego),
+                        rng,
+                        cidx + 1,
+                    )
 
                 def skip_ckpt(args):
                     return args
@@ -1386,22 +2258,47 @@ def train_trajedi_partners(config, env, partner_rng):
                     to_store,
                     store_and_eval_ckpt,
                     skip_ckpt,
-                    ((checkpoint_array_conf, checkpoint_array_ego, eval_info_ego), rng_br, ckpt_idx)
+                    (
+                        (checkpoint_array_conf, checkpoint_array_ego, eval_info_ego),
+                        rng_br,
+                        ckpt_idx,
+                    ),
                 )
-                checkpoint_array_conf, checkpoint_array_ego, ep_info_ego = checkpoint_array_and_infos
+                checkpoint_array_conf, checkpoint_array_ego, ep_info_ego = (
+                    checkpoint_array_and_infos
+                )
                 metric["eval_ep_last_info_ego"] = ep_info_ego
 
-                return ((all_train_state_conf, train_state_ego, 
-                         env_state_confs_sp, env_state_confs_xp, env_state_br_sp,
-                         obs_confs_sp, obs_confs_xp, obs_br_sp, 
-                         done_confs_sp, done_confs_xp, done_br_sp,
-                         conf_h_sp_p1, conf_h_sp_p2, 
-                         conf_h_xp, br_h_xp,
-                         br_h_sp_p1, br_h_sp_p2,
-                         eps_counter, timestep_counter,
-                         rng_conf, rng_br, update_steps),
-                         checkpoint_array_conf, checkpoint_array_ego, ckpt_idx,
-                         ep_info_ego), metric
+                return (
+                    (
+                        all_train_state_conf,
+                        train_state_ego,
+                        env_state_confs_sp,
+                        env_state_confs_xp,
+                        env_state_br_sp,
+                        obs_confs_sp,
+                        obs_confs_xp,
+                        obs_br_sp,
+                        done_confs_sp,
+                        done_confs_xp,
+                        done_br_sp,
+                        conf_h_sp_p1,
+                        conf_h_sp_p2,
+                        conf_h_xp,
+                        br_h_xp,
+                        br_h_sp_p1,
+                        br_h_sp_p2,
+                        eps_counter,
+                        timestep_counter,
+                        rng_conf,
+                        rng_br,
+                        update_steps,
+                    ),
+                    checkpoint_array_conf,
+                    checkpoint_array_ego,
+                    ckpt_idx,
+                    ep_info_ego,
+                ), metric
 
             # init checkpoint array
             checkpoint_array_conf = init_ckpt_array(train_state_conf.params)
@@ -1410,52 +2307,86 @@ def train_trajedi_partners(config, env, partner_rng):
 
             # initial state for scan over _update_step_with_ckpt
             update_steps = 0
-            
+
             def run_all_episodes(rng, train_state_conf, train_state_ego):
                 conf_ids = jnp.arange(config["PARTNER_POP_SIZE"])
-                gathered_conf_model_params = gather_params(train_state_conf.params, conf_ids)
+                gathered_conf_model_params = gather_params(
+                    train_state_conf.params, conf_ids
+                )
 
                 rng, eval_rng = jax.random.split(rng)
+
                 def run_episodes_fixed_rng(conf_param):
                     return run_episodes(
-                        eval_rng, env,
-                        conf_param, confederate_policy,
-                        train_state_ego.params, ego_policy,
-                        config["ROLLOUT_LENGTH"], config["NUM_EVAL_EPISODES"],
+                        eval_rng,
+                        env,
+                        conf_param,
+                        confederate_policy,
+                        train_state_ego.params,
+                        ego_policy,
+                        config["ROLLOUT_LENGTH"],
+                        config["NUM_EVAL_EPISODES"],
                     )
-                ep_infos = jax.vmap(run_episodes_fixed_rng)(
-                    gathered_conf_model_params # leaves where shape is (pop_size*pop_size, ...)
+
+                ep_infos = jax.vmap(
+                    run_episodes_fixed_rng
+                )(
+                    gathered_conf_model_params  # leaves where shape is (pop_size*pop_size, ...)
                 )
                 return ep_infos
-            
-            rng, rng_eval = jax.random.split(rng, 2)
-            ep_infos = jax.tree.map(lambda x: x.mean(), run_all_episodes(
-                rng_eval,
-                train_state_conf,
-                train_state_ego
-            ))
 
-            rng, reset_rng_conf_sp, reset_rng_xp, reset_rng_br_sp= jax.random.split(rng, 4)
+            rng, rng_eval = jax.random.split(rng, 2)
+            ep_infos = jax.tree.map(
+                lambda x: x.mean(),
+                run_all_episodes(rng_eval, train_state_conf, train_state_ego),
+            )
+
+            rng, reset_rng_conf_sp, reset_rng_xp, reset_rng_br_sp = jax.random.split(
+                rng, 4
+            )
             reset_rngs_xp = jax.random.split(reset_rng_xp, config["NUM_CONF_ACTORS"])
-            reset_rngs_conf_sp = jax.random.split(reset_rng_conf_sp, config["NUM_CONF_ACTORS"])
-            reset_rngs_br_sp = jax.random.split(reset_rng_br_sp, config["NUM_EGO_ACTORS"])
+            reset_rngs_conf_sp = jax.random.split(
+                reset_rng_conf_sp, config["NUM_CONF_ACTORS"]
+            )
+            reset_rngs_br_sp = jax.random.split(
+                reset_rng_br_sp, config["NUM_EGO_ACTORS"]
+            )
 
             obs_xp, env_state_xp = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_xp)
-            obs_confs_sp, env_state_confs_sp = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_conf_sp)
-            obs_br_sp, env_state_br_sp = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_br_sp)
-            
+            obs_confs_sp, env_state_confs_sp = jax.vmap(env.reset, in_axes=(0,))(
+                reset_rngs_conf_sp
+            )
+            obs_br_sp, env_state_br_sp = jax.vmap(env.reset, in_axes=(0,))(
+                reset_rngs_br_sp
+            )
+
             # Initialize hidden states
-            init_conf_hstate_sp1 = confederate_policy.init_hstate(config["NUM_CONF_ACTORS"])
-            init_conf_hstate_sp2 = confederate_policy.init_hstate(config["NUM_CONF_ACTORS"])
-            init_conf_hstate_xp = confederate_policy.init_hstate(config["NUM_CONF_ACTORS"])
+            init_conf_hstate_sp1 = confederate_policy.init_hstate(
+                config["NUM_CONF_ACTORS"]
+            )
+            init_conf_hstate_sp2 = confederate_policy.init_hstate(
+                config["NUM_CONF_ACTORS"]
+            )
+            init_conf_hstate_xp = confederate_policy.init_hstate(
+                config["NUM_CONF_ACTORS"]
+            )
             init_ego_hstate_sp1 = ego_policy.init_hstate(config["NUM_EGO_ACTORS"])
             init_ego_hstate_sp2 = ego_policy.init_hstate(config["NUM_EGO_ACTORS"])
             init_ego_hstate_xp = ego_policy.init_hstate(config["NUM_CONF_ACTORS"])
 
             # Initialize done flags
-            init_dones_conf_sp = {k: jnp.zeros((config["NUM_CONF_ACTORS"]), dtype=bool) for k in env.agents + ["__all__"]}
-            init_dones_xp = {k: jnp.zeros((config["NUM_CONF_ACTORS"]), dtype=bool) for k in env.agents + ["__all__"]}
-            init_dones_br_sp = {k: jnp.zeros((config["NUM_EGO_ACTORS"]), dtype=bool) for k in env.agents + ["__all__"]}
+            init_dones_conf_sp = {
+                k: jnp.zeros((config["NUM_CONF_ACTORS"]), dtype=bool)
+                for k in env.agents + ["__all__"]
+            }
+            init_dones_xp = {
+                k: jnp.zeros((config["NUM_CONF_ACTORS"]), dtype=bool)
+                for k in env.agents + ["__all__"]
+            }
+            init_dones_br_sp = {
+                k: jnp.zeros((config["NUM_EGO_ACTORS"]), dtype=bool)
+                for k in env.agents + ["__all__"]
+            }
 
             init_eps_counter = jnp.zeros((config["NUM_CONF_ACTORS"]), dtype=int)
             init_timestep_counter = jnp.zeros((config["NUM_CONF_ACTORS"]), dtype=int)
@@ -1463,31 +2394,50 @@ def train_trajedi_partners(config, env, partner_rng):
             rng, rng_conf, rng_br = jax.random.split(rng, 3)
 
             update_runner_state = (
-                train_state_conf, train_state_ego,
-                env_state_confs_sp, env_state_xp, env_state_br_sp,
-                obs_confs_sp, obs_xp, obs_br_sp, 
-                init_dones_conf_sp, init_dones_xp, init_dones_br_sp,
-                init_conf_hstate_sp1, init_conf_hstate_sp2, 
-                init_conf_hstate_xp, init_ego_hstate_xp,
-                init_ego_hstate_sp1, init_ego_hstate_sp2,
-                init_eps_counter, init_timestep_counter,
-                rng_conf, rng_br, update_steps
+                train_state_conf,
+                train_state_ego,
+                env_state_confs_sp,
+                env_state_xp,
+                env_state_br_sp,
+                obs_confs_sp,
+                obs_xp,
+                obs_br_sp,
+                init_dones_conf_sp,
+                init_dones_xp,
+                init_dones_br_sp,
+                init_conf_hstate_sp1,
+                init_conf_hstate_sp2,
+                init_conf_hstate_xp,
+                init_ego_hstate_xp,
+                init_ego_hstate_sp1,
+                init_ego_hstate_sp2,
+                init_eps_counter,
+                init_timestep_counter,
+                rng_conf,
+                rng_br,
+                update_steps,
             )
 
             state_with_ckpt = (
-                update_runner_state, checkpoint_array_conf, checkpoint_array_ego,
-                ckpt_idx, ep_infos
+                update_runner_state,
+                checkpoint_array_conf,
+                checkpoint_array_ego,
+                ckpt_idx,
+                ep_infos,
             )
             # run training
             state_with_ckpt, metrics = jax.lax.scan(
                 _update_step_with_ckpt,
                 state_with_ckpt,
                 xs=None,
-                length=config["NUM_UPDATES"]
+                length=config["NUM_UPDATES"],
             )
             (
-                final_runner_state, checkpoint_array_conf, checkpoint_array_ego,
-                final_ckpt_idx, last_ep_infos_ego
+                final_runner_state,
+                checkpoint_array_conf,
+                checkpoint_array_ego,
+                _final_ckpt_idx,
+                _last_ep_infos_ego,
             ) = state_with_ckpt
 
             out = {
@@ -1500,6 +2450,7 @@ def train_trajedi_partners(config, env, partner_rng):
             return out
 
         return train
+
     # ------------------------------
     # Actually run the adversarial teammate training
     # ------------------------------
@@ -1522,28 +2473,52 @@ def log_metrics(config, logger, outs, metric_names: tuple):
 
     # Extract metrics for all agents
     # shape (num_seeds, num_updates)  [pre-scalarized: mean over partners, eval eps, and agents taken inside scan]
-    avg_returns_confs_vs_br = np.asarray(metrics["eval_ep_last_info_ego"]["returned_episode_returns"]).mean(axis=0)
-    
+    avg_returns_confs_vs_br = np.asarray(
+        metrics["eval_ep_last_info_ego"]["returned_episode_returns"]
+    ).mean(axis=0)
+
     # Value losses
     # shape (num_seeds, num_updates)
-    avg_value_losses_conf_self_play = np.asarray(metrics["value_loss_conf_self_play"]).mean(axis=0)
-    avg_value_losses_conf_vs_br = np.asarray(metrics["value_loss_conf_against_br"]).mean(axis=0)
-    avg_value_losses_br_sp = np.asarray(metrics["value_loss_ego_self_play"]).mean(axis=0)
-    avg_value_losses_br_xp = np.asarray(metrics["value_loss_ego_against_conf"]).mean(axis=0)
+    avg_value_losses_conf_self_play = np.asarray(
+        metrics["value_loss_conf_self_play"]
+    ).mean(axis=0)
+    avg_value_losses_conf_vs_br = np.asarray(
+        metrics["value_loss_conf_against_br"]
+    ).mean(axis=0)
+    avg_value_losses_br_sp = np.asarray(metrics["value_loss_ego_self_play"]).mean(
+        axis=0
+    )
+    avg_value_losses_br_xp = np.asarray(metrics["value_loss_ego_against_conf"]).mean(
+        axis=0
+    )
 
     # Actor losses
     # shape (num_seeds, num_updates)
-    avg_actor_losses_conf_self_play = np.asarray(metrics["pg_loss_conf_self_play"]).mean(axis=0)
-    avg_actor_losses_conf_vs_br = np.asarray(metrics["pg_loss_conf_against_br"]).mean(axis=0)
+    avg_actor_losses_conf_self_play = np.asarray(
+        metrics["pg_loss_conf_self_play"]
+    ).mean(axis=0)
+    avg_actor_losses_conf_vs_br = np.asarray(metrics["pg_loss_conf_against_br"]).mean(
+        axis=0
+    )
     avg_actor_losses_ego_sp = np.asarray(metrics["pg_loss_ego_self_play"]).mean(axis=0)
-    avg_actor_losses_ego_xp = np.asarray(metrics["pg_loss_ego_against_conf"]).mean(axis=0)
+    avg_actor_losses_ego_xp = np.asarray(metrics["pg_loss_ego_against_conf"]).mean(
+        axis=0
+    )
 
     # Entropy losses
     #  shape (num_seeds, num_updates)
-    avg_entropy_losses_conf_self_play = np.asarray(metrics["entropy_conf_self_play"]).mean(axis=0)
-    avg_entropy_losses_conf_vs_br = np.asarray(metrics["entropy_conf_against_br"]).mean(axis=0)
-    avg_entropy_losses_ego_sp = np.asarray(metrics["entropy_loss_ego_self_play"]).mean(axis=0)
-    avg_entropy_losses_ego_xp = np.asarray(metrics["entropy_loss_ego_against_conf"]).mean(axis=0)
+    avg_entropy_losses_conf_self_play = np.asarray(
+        metrics["entropy_conf_self_play"]
+    ).mean(axis=0)
+    avg_entropy_losses_conf_vs_br = np.asarray(metrics["entropy_conf_against_br"]).mean(
+        axis=0
+    )
+    avg_entropy_losses_ego_sp = np.asarray(metrics["entropy_loss_ego_self_play"]).mean(
+        axis=0
+    )
+    avg_entropy_losses_ego_xp = np.asarray(
+        metrics["entropy_loss_ego_against_conf"]
+    ).mean(axis=0)
 
     # Entropy losses
     #  shape (num_seeds, num_updates)
@@ -1571,34 +2546,97 @@ def log_metrics(config, logger, outs, metric_names: tuple):
                 logger.log_item(f"Train/Ego_{stat_name}", stat_mean, train_step=step)
 
         # Log returns for different agent interactions
-        logger.log_item("Eval/ConfReturn-Against-BR", avg_returns_confs_vs_br[step], train_step=step)
-        
+        logger.log_item(
+            "Eval/ConfReturn-Against-BR", avg_returns_confs_vs_br[step], train_step=step
+        )
 
         # Confederate losses
-        logger.log_item("Losses/ConfValLoss-Self-Play", avg_value_losses_conf_self_play[step], train_step=step)
-        logger.log_item("Losses/ConfActorLoss-Self-Play", avg_actor_losses_conf_self_play[step], train_step=step)
-        logger.log_item("Losses/ConfEntropy-Self-Play", avg_entropy_losses_conf_self_play[step], train_step=step)
-        logger.log_item("Losses/ConfTrajeDiLoss-Self-Play", avg_sp_trajedi_loss[step], train_step=step)
+        logger.log_item(
+            "Losses/ConfValLoss-Self-Play",
+            avg_value_losses_conf_self_play[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/ConfActorLoss-Self-Play",
+            avg_actor_losses_conf_self_play[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/ConfEntropy-Self-Play",
+            avg_entropy_losses_conf_self_play[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/ConfTrajeDiLoss-Self-Play",
+            avg_sp_trajedi_loss[step],
+            train_step=step,
+        )
 
-        logger.log_item("Losses/ConfValLoss-Against-BR", avg_value_losses_conf_vs_br[step], train_step=step)
-        logger.log_item("Losses/ConfActorLoss-Against-BR", avg_actor_losses_conf_vs_br[step], train_step=step)
-        logger.log_item("Losses/ConfEntropy-Against-BR", avg_entropy_losses_conf_vs_br[step], train_step=step)
+        logger.log_item(
+            "Losses/ConfValLoss-Against-BR",
+            avg_value_losses_conf_vs_br[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/ConfActorLoss-Against-BR",
+            avg_actor_losses_conf_vs_br[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/ConfEntropy-Against-BR",
+            avg_entropy_losses_conf_vs_br[step],
+            train_step=step,
+        )
 
         # Best response losses
-        logger.log_item("Losses/BRValLoss-Self-Play", avg_value_losses_br_sp[step], train_step=step)
-        logger.log_item("Losses/BRActorLoss-Self-Play", avg_actor_losses_ego_sp[step], train_step=step)
-        logger.log_item("Losses/BREntropyLoss-Self-Play", avg_entropy_losses_ego_sp[step], train_step=step)
+        logger.log_item(
+            "Losses/BRValLoss-Self-Play", avg_value_losses_br_sp[step], train_step=step
+        )
+        logger.log_item(
+            "Losses/BRActorLoss-Self-Play",
+            avg_actor_losses_ego_sp[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/BREntropyLoss-Self-Play",
+            avg_entropy_losses_ego_sp[step],
+            train_step=step,
+        )
 
         # Ego agent losses
-        logger.log_item("Losses/EgoValLoss-Against-Confs", avg_value_losses_br_xp[step], train_step=step)
-        logger.log_item("Losses/EgoActorLoss-Against-Confs", avg_actor_losses_ego_xp[step], train_step=step)
-        logger.log_item("Losses/EgoEntropyLoss-Against-Confs", avg_entropy_losses_ego_xp[step], train_step=step)
+        logger.log_item(
+            "Losses/EgoValLoss-Against-Confs",
+            avg_value_losses_br_xp[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/EgoActorLoss-Against-Confs",
+            avg_actor_losses_ego_xp[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/EgoEntropyLoss-Against-Confs",
+            avg_entropy_losses_ego_xp[step],
+            train_step=step,
+        )
 
         # Rewards
-        logger.log_item("Losses/AvgConfRewards-Against-BR", avg_rewards_conf_xp[step], train_step=step)
-        logger.log_item("Losses/AvgConfRewards-Self-Play", avg_rewards_conf_sp[step], train_step=step)
-        logger.log_item("Losses/AvgBRRewards-Against-Conf", avg_rewards_br_xp[step], train_step=step)
-        logger.log_item("Losses/AvgEgoRewards-Self-Play", avg_rewards_br_sp[step], train_step=step)
+        logger.log_item(
+            "Losses/AvgConfRewards-Against-BR",
+            avg_rewards_conf_xp[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/AvgConfRewards-Self-Play",
+            avg_rewards_conf_sp[step],
+            train_step=step,
+        )
+        logger.log_item(
+            "Losses/AvgBRRewards-Against-Conf", avg_rewards_br_xp[step], train_step=step
+        )
+        logger.log_item(
+            "Losses/AvgEgoRewards-Self-Play", avg_rewards_br_sp[step], train_step=step
+        )
 
     logger.commit()
 
@@ -1606,11 +2644,14 @@ def log_metrics(config, logger, outs, metric_names: tuple):
     savedir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
     out_savepath = save_train_run(outs, savedir, savename="saved_train_run")
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="saved_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="saved_train_run", path=out_savepath, type_name="train_run"
+        )
 
     # Cleanup locally logged out file
     if not config["local_logger"]["save_train_out"]:
         shutil.rmtree(out_savepath)
+
 
 def run_trajedi(config, wandb_logger):
     algorithm_config = dict(config["algorithm"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,8 @@ target-version = "py311"
 # control: CI clones into a directory named "jax-aht", and the hyphen is not
 # a valid identifier.
 "**/__init__.py" = ["N999"]
+# Legacy capitalized module names predate the lint rules; renaming them is out
+# of scope for incremental lint.
+"teammate_generation/BRDiv.py" = ["N999"]
+"teammate_generation/CoMeDi.py" = ["N999"]
+"teammate_generation/LBRDiv.py" = ["N999"]

--- a/scripts_ab_meliba.sh
+++ b/scripts_ab_meliba.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# A/B test: meliba_ego (recurrent ego, GRU) on overcooked coord_ring vs comedi hparam train teammates.
+# Usage: scripts_ab_meliba.sh <workdir> <gpu> <label> [total_timesteps]
+WORKDIR=$1; GPU=$2; LABEL=$3; TT=${4:-1e7}
+cd $WORKDIR || exit 1
+export CUDA_VISIBLE_DEVICES=$GPU PYTHONPATH=. XLA_PYTHON_CLIENT_MEM_FRACTION=0.85
+PARTNER=/scratch/cluster/clw4542/explore_marl/jax-aht/hparam_train_teammates/hparam_search/overcooked-v1/coord_ring/comedi/hparam_search_train_teammates/2026-08-23_23-18-34/saved_train_run
+exec timeout 28800 /scratch/cluster/clw4542/conda_envs/oeaht/bin/python ego_agent_training/run.py \
+  algorithm=meliba_ego/_base_ task=overcooked-v1/coord_ring \
+  logger.mode=disabled run_heldout_eval=false label=$LABEL \
+  algorithm.EGO_ACTOR_TYPE=rnn \
+  algorithm.TOTAL_TIMESTEPS=$TT \
+  algorithm.partner_agent.ippo.path=$PARTNER \
+  algorithm.partner_agent.ippo.actor_type=actor_with_conditional_critic \
+  algorithm.partner_agent.ippo.ckpt_key=final_params_conf \
+  algorithm.partner_agent.ippo.idx_list=null \
+  +algorithm.partner_agent.ippo.POP_SIZE=10

--- a/scripts_ab_ppo.sh
+++ b/scripts_ab_ppo.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# A/B test: ppo_ego (S5 recurrent ego) on overcooked coord_ring vs comedi hparam train teammates.
+# Usage: scripts_ab_ppo.sh <workdir> <gpu> <label> [total_timesteps]
+WORKDIR=$1; GPU=$2; LABEL=$3; TT=${4:-1e7}
+cd $WORKDIR || exit 1
+export CUDA_VISIBLE_DEVICES=$GPU PYTHONPATH=. XLA_PYTHON_CLIENT_MEM_FRACTION=0.85
+PARTNER=/scratch/cluster/clw4542/explore_marl/jax-aht/hparam_train_teammates/hparam_search/overcooked-v1/coord_ring/comedi/hparam_search_train_teammates/2026-08-23_23-18-34/saved_train_run
+exec timeout 28800 /scratch/cluster/clw4542/conda_envs/oeaht/bin/python ego_agent_training/run.py \
+  algorithm=ppo_ego/overcooked-v1/coord_ring task=overcooked-v1/coord_ring \
+  logger.mode=disabled run_heldout_eval=false label=$LABEL \
+  algorithm.TOTAL_TIMESTEPS=$TT \
+  algorithm.NUM_EGO_TRAIN_SEEDS=3 \
+  algorithm.partner_agent.ippo.path=$PARTNER \
+  algorithm.partner_agent.ippo.actor_type=actor_with_conditional_critic \
+  algorithm.partner_agent.ippo.ckpt_key=final_params_conf \
+  algorithm.partner_agent.ippo.idx_list=null \
+  +algorithm.partner_agent.ippo.POP_SIZE=10

--- a/teammate_generation/BRDiv.py
+++ b/teammate_generation/BRDiv.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 class XPTransition(NamedTuple):
-    done: jnp.ndarray
+    done: jnp.ndarray  # done at t+1 (post-step); used for GAE
     action: jnp.ndarray
     value: jnp.ndarray
     self_onehot_id: jnp.ndarray
@@ -43,6 +43,7 @@ class XPTransition(NamedTuple):
     obs: jnp.ndarray
     info: jnp.ndarray
     avail_actions: jnp.ndarray
+    prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
 def _get_all_ids(pop_size):
     cross_product = np.meshgrid(
@@ -274,7 +275,8 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     log_prob=logp_0,
                     obs=last_obs["agent_0"],
                     info=info_0,
-                    avail_actions=avail_actions_0
+                    avail_actions=avail_actions_0,
+                    prev_done=last_done["agent_0"]
                 )
 
                 transition_1 = XPTransition(
@@ -287,7 +289,8 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     log_prob=logp_1,
                     obs=last_obs["agent_1"],
                     info=info_1,
-                    avail_actions=avail_actions_1
+                    avail_actions=avail_actions_1,
+                    prev_done=last_done["agent_1"]
                 )
                 new_runner_state = (all_train_state_conf, all_train_state_br, updated_conf_ids, updated_br_ids,
                                     env_state_next, obs_next, done, new_conf_h, new_br_h, rng)
@@ -349,7 +352,7 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         _, value, pi, _ = agent_policy.get_action_value_policy(
                             params=squeezed_param,
                             obs=traj_batch.obs,
-                            done=traj_batch.done,
+                            done=traj_batch.prev_done,
                             avail_actions=traj_batch.avail_actions,
                             hstate=init_hstate,
                             rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here

--- a/teammate_generation/BRDiv.py
+++ b/teammate_generation/BRDiv.py
@@ -1,24 +1,25 @@
-'''Implementation of the BRDiv teammate generation algorithm (Rahman et al., TMLR 2023)
+"""Implementation of the BRDiv teammate generation algorithm (Rahman et al., TMLR 2023)
 https://arxiv.org/abs/2207.14138
 
 Command to run BRDiv only on LBF:
 python teammate_generation/run.py algorithm=brdiv/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_brdiv run_heldout_eval=false train_ego=false
 
 Limitations: does not support recurrent actors.
-'''
+"""
+
+import logging
 import shutil
 import time
-import logging
-from typing import NamedTuple
 from functools import partial
+from typing import NamedTuple
 
 import hydra
 import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
-from flax.training.train_state import TrainState
 import wandb
+from flax.training.train_state import TrainState
 
 from agents.mlp_actor_critic_agent import ActorWithConditionalCriticPolicy
 from agents.population_interface import AgentPopulation
@@ -27,10 +28,11 @@ from common.run_episodes import run_episodes
 from common.save_load_utils import save_train_run
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from marl.ppo_utils import unbatchify, _create_minibatches
+from marl.ppo_utils import _create_minibatches, unbatchify
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
+
 
 class XPTransition(NamedTuple):
     done: jnp.ndarray  # done at t+1 (post-step); used for GAE
@@ -45,15 +47,14 @@ class XPTransition(NamedTuple):
     avail_actions: jnp.ndarray
     prev_done: jnp.ndarray = None  # done at t (pre-step); RNN reset signal for replay
 
+
 def _get_all_ids(pop_size):
-    cross_product = np.meshgrid(
-        np.arange(pop_size),
-        np.arange(pop_size)
-    )
+    cross_product = np.meshgrid(np.arange(pop_size), np.arange(pop_size))
     agent_id_cartesian_product = np.stack([g.ravel() for g in cross_product], axis=-1)
     all_conf_ids = agent_id_cartesian_product[:, 1]
     all_br_ids = agent_id_cartesian_product[:, 0]
     return all_conf_ids, all_br_ids
+
 
 def gather_params(partner_params_pytree, idx_vec):
     """
@@ -63,15 +64,18 @@ def gather_params(partner_params_pytree, idx_vec):
     Return a new pytree where each leaf has shape (num_envs, ...). Each leaf has a sampled
     partner's parameters for each environment.
     """
+
     # We'll define a function that gathers from each leaf
     # where leaf has shape (n_seeds, m_ckpts, ...), we want [idx_vec[i]] for each i.
     # We'll vmap a slicing function.
     def gather_leaf(leaf):
         def slice_one(idx):
             return leaf[idx]  # shape (...)
+
         return jax.vmap(slice_one)(idx_vec)
 
     return jax.tree.map(gather_leaf, partner_params_pytree)
+
 
 def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
     num_agents = env.num_agents
@@ -81,16 +85,24 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
     config["NUM_GAME_AGENTS"] = num_agents
     config["NUM_CONF_ACTORS"] = config["NUM_ENVS"]
     config["NUM_BR_ACTORS"] = config["NUM_ENVS"]
-    config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // (config["ROLLOUT_LENGTH"] * config["NUM_ENVS"])
+    config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // (
+        config["ROLLOUT_LENGTH"] * config["NUM_ENVS"]
+    )
 
     def make_brdiv_agents(config):
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng):
             rng, init_conf_rng, init_br_rng = jax.random.split(rng, 3)
-            all_conf_init_rngs = jax.random.split(init_conf_rng, config["PARTNER_POP_SIZE"])
+            all_conf_init_rngs = jax.random.split(
+                init_conf_rng, config["PARTNER_POP_SIZE"]
+            )
             all_br_init_rngs = jax.random.split(init_br_rng, config["PARTNER_POP_SIZE"])
             identity_matrix = jnp.eye(config["PARTNER_POP_SIZE"])
 
@@ -104,18 +116,28 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     return init_params_conf, init_params_br
 
                 init_all_networks_and_optimizers = jax.vmap(init_single_pair_optimizers)
-                all_conf_params, all_br_params = init_all_networks_and_optimizers(rng_agents, rng_brs)
+                all_conf_params, all_br_params = init_all_networks_and_optimizers(
+                    rng_agents, rng_brs
+                )
 
                 # Define optimizers for both confederate and BR policy
                 tx = optax.chain(
                     optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                    optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"],
-                    eps=1e-5),
+                    optax.adam(
+                        learning_rate=linear_schedule
+                        if config["ANNEAL_LR"]
+                        else config["LR"],
+                        eps=1e-5,
+                    ),
                 )
                 tx_br = optax.chain(
                     optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                    optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"],
-                    eps=1e-5),
+                    optax.adam(
+                        learning_rate=linear_schedule
+                        if config["ANNEAL_LR"]
+                        else config["LR"],
+                        eps=1e-5,
+                    ),
                 )
 
                 train_state_conf = TrainState.create(
@@ -144,7 +166,7 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     avail_actions=avail_actions,
                     hstate=hstate,
                     rng=rng,
-                    aux_obs=id[jnp.newaxis, ...]
+                    aux_obs=id[jnp.newaxis, ...],
                 )
                 return act, val, pi, new_hstate
 
@@ -156,7 +178,7 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     avail_actions=avail_actions,
                     hstate=hstate,
                     rng=rng,
-                    aux_obs=id[jnp.newaxis, ...]
+                    aux_obs=id[jnp.newaxis, ...],
                 )
                 return act, val, pi, new_hstate
 
@@ -166,52 +188,75 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 Returns updated runner_state, and Transitions for agent_0 and agent_1
                 """
                 (
-                    all_train_state_conf, all_train_state_br, last_conf_ids, last_br_ids,
-                    env_state, last_obs, last_done, last_conf_h, last_br_h, rng
+                    all_train_state_conf,
+                    all_train_state_br,
+                    last_conf_ids,
+                    last_br_ids,
+                    env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
                 ) = runner_state
-                rng, act0_rng, act1_rng, step_rng, conf_sampling_rng, br_sampling_rng = jax.random.split(rng, 6)
+                (
+                    rng,
+                    act0_rng,
+                    act1_rng,
+                    step_rng,
+                    conf_sampling_rng,
+                    br_sampling_rng,
+                ) = jax.random.split(rng, 6)
 
                 # For done envs, resample both conf and brs
                 needs_resample = last_done["__all__"]
-                resampled_conf_ids = jax.random.randint(conf_sampling_rng, (config["NUM_CONF_ACTORS"],), 0, config["PARTNER_POP_SIZE"])
-                resampled_br_ids = jax.random.randint(br_sampling_rng, (config["NUM_BR_ACTORS"],), 0, config["PARTNER_POP_SIZE"])
+                resampled_conf_ids = jax.random.randint(
+                    conf_sampling_rng,
+                    (config["NUM_CONF_ACTORS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
+                resampled_br_ids = jax.random.randint(
+                    br_sampling_rng,
+                    (config["NUM_BR_ACTORS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
 
                 # Determine final indices based on whether resampling was needed for each env
                 updated_conf_ids = jnp.where(
                     needs_resample,
-                    resampled_conf_ids,     # Use newly sampled index if True
-                    last_conf_ids           # Else, keep index from previous step
+                    resampled_conf_ids,  # Use newly sampled index if True
+                    last_conf_ids,  # Else, keep index from previous step
                 )
 
                 updated_br_ids = jnp.where(
                     needs_resample,
-                    resampled_br_ids,       # Use newly sampled index if True
-                    last_br_ids             # Else, keep index from previous step
+                    resampled_br_ids,  # Use newly sampled index if True
+                    last_br_ids,  # Else, keep index from previous step
                 )
 
                 # Reset the hidden states for resampled conf and br if they are not None
                 # WARNING: BRDiv was not tested with recurrent actors, so the code for if the hstate is not None may not work
                 if last_conf_h is not None:
                     updated_conf_h = jnp.where(
-                        needs_resample,
-                        init_conf_hstate,
-                        last_conf_h
+                        needs_resample, init_conf_hstate, last_conf_h
                     )
                 else:
                     updated_conf_h = last_conf_h
 
                 if last_br_h is not None:
-                    updated_br_h = jnp.where(
-                        needs_resample,
-                        init_br_hstate,
-                        last_br_h
-                    )
+                    updated_br_h = jnp.where(needs_resample, init_br_hstate, last_br_h)
                 else:
                     updated_br_h = last_br_h
 
                 # Get the corresponding conf and br params
-                updated_conf_params = gather_params(all_train_state_conf.params, updated_conf_ids)
-                updated_br_params = gather_params(all_train_state_br.params, updated_br_ids)
+                updated_conf_params = gather_params(
+                    all_train_state_conf.params, updated_conf_ids
+                )
+                updated_br_params = gather_params(
+                    all_train_state_br.params, updated_br_ids
+                )
 
                 updated_conf_onehot_ids = identity_matrix[updated_conf_ids]
                 updated_br_onehot_ids = identity_matrix[updated_br_ids]
@@ -224,45 +269,72 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
 
                 # Agent_0 action
                 act0_rng = jax.random.split(act0_rng, config["NUM_ENVS"])
-                act_0, val_0, pi_0, new_conf_h = jax.vmap(forward_pass_conf)(updated_conf_params,
-                        last_obs["agent_0"], updated_br_onehot_ids, last_done["agent_0"], avail_actions_0,
-                        updated_conf_h, act0_rng)
+                act_0, val_0, pi_0, new_conf_h = jax.vmap(forward_pass_conf)(
+                    updated_conf_params,
+                    last_obs["agent_0"],
+                    updated_br_onehot_ids,
+                    last_done["agent_0"],
+                    avail_actions_0,
+                    updated_conf_h,
+                    act0_rng,
+                )
                 logp_0 = pi_0.log_prob(act_0)
-                act_0, val_0, logp_0 = act_0.squeeze(), val_0.squeeze(), logp_0.squeeze()
+                act_0, val_0, logp_0 = (
+                    act_0.squeeze(),
+                    val_0.squeeze(),
+                    logp_0.squeeze(),
+                )
 
                 # Agent_1 action
                 act1_rng = jax.random.split(act1_rng, config["NUM_ENVS"])
-                act_1, val_1, pi_1, new_br_h = jax.vmap(forward_pass_br)(updated_br_params,
-                        last_obs["agent_1"], updated_conf_onehot_ids, last_done["agent_1"], avail_actions_1,
-                        updated_br_h, act1_rng)
+                act_1, val_1, pi_1, new_br_h = jax.vmap(forward_pass_br)(
+                    updated_br_params,
+                    last_obs["agent_1"],
+                    updated_conf_onehot_ids,
+                    last_done["agent_1"],
+                    avail_actions_1,
+                    updated_br_h,
+                    act1_rng,
+                )
                 logp_1 = pi_1.log_prob(act_1)
-                act_1, val_1, logp_1 = act_1.squeeze(), val_1.squeeze(), logp_1.squeeze()
+                act_1, val_1, logp_1 = (
+                    act_1.squeeze(),
+                    val_1.squeeze(),
+                    logp_1.squeeze(),
+                )
 
                 # Combine actions into the env format
                 combined_actions = jnp.concatenate([act_0, act_1], axis=0)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
 
                 # Step env
                 step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state, env_act
-                )
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 # note that num_actors = num_envs * num_agents
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
                 info_1 = jax.tree.map(lambda x: x[:, 1], info)
 
                 def _compute_rewards(conf_id, br_id, agent_rew):
-                    return jax.lax.cond(jnp.equal(
-                        jnp.argmax(conf_id, axis=-1), jnp.argmax(br_id, axis=-1)
-                    ),
-                    lambda x: x,
-                    lambda x: -x,
-                    agent_rew
+                    return jax.lax.cond(
+                        jnp.equal(
+                            jnp.argmax(conf_id, axis=-1), jnp.argmax(br_id, axis=-1)
+                        ),
+                        lambda x: x,
+                        lambda x: -x,
+                        agent_rew,
                     )
 
-                agent_0_rews = jax.vmap(_compute_rewards)(updated_conf_onehot_ids, updated_br_onehot_ids, reward["agent_1"])
-                agent_1_rews = jax.vmap(_compute_rewards)(updated_conf_onehot_ids, updated_br_onehot_ids, reward["agent_0"])
+                agent_0_rews = jax.vmap(_compute_rewards)(
+                    updated_conf_onehot_ids, updated_br_onehot_ids, reward["agent_1"]
+                )
+                agent_1_rews = jax.vmap(_compute_rewards)(
+                    updated_conf_onehot_ids, updated_br_onehot_ids, reward["agent_0"]
+                )
 
                 # Store agent_0 data in transition
                 transition_0 = XPTransition(
@@ -276,7 +348,7 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     obs=last_obs["agent_0"],
                     info=info_0,
                     avail_actions=avail_actions_0,
-                    prev_done=last_done["agent_0"]
+                    prev_done=last_done["agent_0"],
                 )
 
                 transition_1 = XPTransition(
@@ -290,10 +362,20 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     obs=last_obs["agent_1"],
                     info=info_1,
                     avail_actions=avail_actions_1,
-                    prev_done=last_done["agent_1"]
+                    prev_done=last_done["agent_1"],
                 )
-                new_runner_state = (all_train_state_conf, all_train_state_br, updated_conf_ids, updated_br_ids,
-                                    env_state_next, obs_next, done, new_conf_h, new_br_h, rng)
+                new_runner_state = (
+                    all_train_state_conf,
+                    all_train_state_br,
+                    updated_conf_ids,
+                    updated_br_ids,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_conf_h,
+                    new_br_h,
+                    rng,
+                )
                 return new_runner_state, (transition_0, transition_1)
 
             def _calculate_gae(traj_batch, last_val):
@@ -322,19 +404,30 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
 
             def run_all_episodes(rng, train_state_conf, train_state_br):
                 conf_ids, br_ids = _get_all_ids(config["PARTNER_POP_SIZE"])
-                gathered_conf_model_params = gather_params(train_state_conf.params, conf_ids)
+                gathered_conf_model_params = gather_params(
+                    train_state_conf.params, conf_ids
+                )
                 gathered_br_model_params = gather_params(train_state_br.params, br_ids)
 
                 rng, eval_rng = jax.random.split(rng)
+
                 def run_episodes_fixed_rng(conf_param, br_param):
                     return run_episodes(
-                        eval_rng, env,
-                        conf_param, conf_policy,
-                        br_param, br_policy,
-                        config["ROLLOUT_LENGTH"], config["NUM_EVAL_EPISODES"],
+                        eval_rng,
+                        env,
+                        conf_param,
+                        conf_policy,
+                        br_param,
+                        br_policy,
+                        config["ROLLOUT_LENGTH"],
+                        config["NUM_EVAL_EPISODES"],
                     )
-                ep_infos = jax.vmap(run_episodes_fixed_rng)(
-                    gathered_conf_model_params, gathered_br_model_params, # leaves where shape is (pop_size*pop_size, ...)
+
+                ep_infos = jax.vmap(
+                    run_episodes_fixed_rng
+                )(
+                    gathered_conf_model_params,
+                    gathered_br_model_params,  # leaves where shape is (pop_size*pop_size, ...)
                 )
                 return ep_infos
 
@@ -344,40 +437,45 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     minbatch_conf, minbatch_br = all_data
 
                     def _loss_fn(param, agent_policy, minbatch, agent_id):
-                        '''Compute loss for agent corresponding to agent_id.
-                        '''
+                        """Compute loss for agent corresponding to agent_id."""
                         init_hstate, traj_batch, gae, target_v = minbatch
                         # get policy and value of confederate versus ego and best response agents respectively
-                        squeezed_param = jax.tree.map(lambda x: jnp.squeeze(x, 0), param)
+                        squeezed_param = jax.tree.map(
+                            lambda x: jnp.squeeze(x, 0), param
+                        )
                         _, value, pi, _ = agent_policy.get_action_value_policy(
                             params=squeezed_param,
                             obs=traj_batch.obs,
                             done=traj_batch.prev_done,
                             avail_actions=traj_batch.avail_actions,
                             hstate=init_hstate,
-                            rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                            aux_obs=traj_batch.oppo_onehot_id
+                            rng=jax.random.PRNGKey(
+                                0
+                            ),  # only used for action sampling, which is not used here
+                            aux_obs=traj_batch.oppo_onehot_id,
                         )
                         log_prob = pi.log_prob(traj_batch.action)
 
                         is_relevant = jnp.equal(
-                            jnp.argmax(traj_batch.self_onehot_id, axis=-1),
-                            agent_id
+                            jnp.argmax(traj_batch.self_onehot_id, axis=-1), agent_id
                         )
                         loss_weights = jnp.where(is_relevant, 1, 0).astype(jnp.float32)
 
                         # Value loss
                         value_pred_clipped = traj_batch.value + (
                             value - traj_batch.value
-                            ).clip(
-                            -config["CLIP_EPS"], config["CLIP_EPS"])
+                        ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                         value_losses = jnp.square(value - target_v)
                         value_losses_clipped = jnp.square(value_pred_clipped - target_v)
                         value_loss = jax.lax.cond(
                             loss_weights.sum() == 0,
                             lambda x: jnp.zeros_like(x).astype(jnp.float32),
                             lambda x: x,
-                            (loss_weights * jnp.maximum(value_losses, value_losses_clipped)).sum() / (loss_weights.sum() + 1e-8)
+                            (
+                                loss_weights
+                                * jnp.maximum(value_losses, value_losses_clipped)
+                            ).sum()
+                            / (loss_weights.sum() + 1e-8),
                         )
 
                         n = config["PARTNER_POP_SIZE"]
@@ -388,26 +486,33 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         # To prevent the XP loss term from dominating the SP loss term, we would like P(SP) = P(XP) = 1/2.
                         # Thus, we set the 2nd term of the SP weight to n/2, and the 2nd term of the XP weight to n/(2 * (n-1)).
 
-                        is_sp = jnp.equal(jnp.argmax(traj_batch.self_onehot_id, axis=-1), jnp.argmax(traj_batch.oppo_onehot_id, axis=-1))
-                        sp_weight = (1 + 2*config["XP_LOSS_WEIGHTS"]) * (n/2)
-                        xp_weight = config["XP_LOSS_WEIGHTS"] * (n / (2 * (n-1)))
+                        is_sp = jnp.equal(
+                            jnp.argmax(traj_batch.self_onehot_id, axis=-1),
+                            jnp.argmax(traj_batch.oppo_onehot_id, axis=-1),
+                        )
+                        sp_weight = (1 + 2 * config["XP_LOSS_WEIGHTS"]) * (n / 2)
+                        xp_weight = config["XP_LOSS_WEIGHTS"] * (n / (2 * (n - 1)))
                         actor_weights = jnp.where(is_sp, sp_weight, xp_weight)
 
                         # Policy gradient loss
                         ratio = jnp.exp(log_prob - traj_batch.log_prob)
                         gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                         pg_loss_1 = ratio * gae_norm * actor_weights
-                        pg_loss_2 = jnp.clip(
-                            ratio,
-                            1.0 - config["CLIP_EPS"],
-                            1.0 + config["CLIP_EPS"]) * gae_norm * actor_weights
+                        pg_loss_2 = (
+                            jnp.clip(
+                                ratio,
+                                1.0 - config["CLIP_EPS"],
+                                1.0 + config["CLIP_EPS"],
+                            )
+                            * gae_norm
+                            * actor_weights
+                        )
                         pg_loss = jax.lax.cond(
                             loss_weights.sum() == 0,
                             lambda x: jnp.zeros_like(x).astype(jnp.float32),
                             lambda x: x,
-                            -(
-                                loss_weights*jnp.minimum(pg_loss_1, pg_loss_2)
-                            ).sum()/(loss_weights.sum() + 1e-8)
+                            -(loss_weights * jnp.minimum(pg_loss_1, pg_loss_2)).sum()
+                            / (loss_weights.sum() + 1e-8),
                         )
 
                         # Entropy
@@ -415,13 +520,20 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                             loss_weights.sum() == 0,
                             lambda x: jnp.zeros_like(x).astype(jnp.float32),
                             lambda x: x,
-                            (loss_weights * pi.entropy()).sum()/(loss_weights.sum() + 1e-8)
+                            (loss_weights * pi.entropy()).sum()
+                            / (loss_weights.sum() + 1e-8),
                         )
 
-                        total_loss = pg_loss + config["VF_COEF"] * value_loss - config["ENT_COEF"] * entropy
+                        total_loss = (
+                            pg_loss
+                            + config["VF_COEF"] * value_loss
+                            - config["ENT_COEF"] * entropy
+                        )
                         return total_loss, (value_loss, pg_loss, entropy)
 
-                    possible_agent_ids = jnp.expand_dims(jnp.arange(config["PARTNER_POP_SIZE"]), 1)
+                    possible_agent_ids = jnp.expand_dims(
+                        jnp.arange(config["PARTNER_POP_SIZE"]), 1
+                    )
                     grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
 
                     def gather_conf_params_and_return_grads(agent_id):
@@ -438,39 +550,75 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         )
                         return (loss_val_br, aux_vals_br), grads_br
 
-                    (loss_val_conf, aux_vals_conf), grads_conf = jax.vmap(gather_conf_params_and_return_grads)(possible_agent_ids)
-                    (loss_val_br, aux_vals_br), grads_br = jax.vmap(gather_br_params_and_return_grads)(possible_agent_ids)
+                    (loss_val_conf, aux_vals_conf), grads_conf = jax.vmap(
+                        gather_conf_params_and_return_grads
+                    )(possible_agent_ids)
+                    (loss_val_br, aux_vals_br), grads_br = jax.vmap(
+                        gather_br_params_and_return_grads
+                    )(possible_agent_ids)
 
-                    grads_conf_new = jax.tree.map(lambda x: jnp.squeeze(x, 1), grads_conf)
+                    grads_conf_new = jax.tree.map(
+                        lambda x: jnp.squeeze(x, 1), grads_conf
+                    )
                     grads_br_new = jax.tree.map(lambda x: jnp.squeeze(x, 1), grads_br)
-                    train_state_conf = train_state_conf.apply_gradients(grads=grads_conf_new)
+                    train_state_conf = train_state_conf.apply_gradients(
+                        grads=grads_conf_new
+                    )
                     train_state_br = train_state_br.apply_gradients(grads=grads_br_new)
-                    return (train_state_conf, train_state_br), ((loss_val_conf, aux_vals_conf), (loss_val_br, aux_vals_br))
+                    return (train_state_conf, train_state_br), (
+                        (loss_val_conf, aux_vals_conf),
+                        (loss_val_br, aux_vals_br),
+                    )
 
                 (
-                    train_state_conf, train_state_br,
-                    traj_batch_conf, traj_batch_br,
-                    advantages_conf, advantages_br,
-                    targets_conf, targets_br,
-                    rng
+                    train_state_conf,
+                    train_state_br,
+                    traj_batch_conf,
+                    traj_batch_br,
+                    advantages_conf,
+                    advantages_br,
+                    targets_conf,
+                    targets_br,
+                    rng,
                 ) = update_state
                 rng, perm_rng_conf, perm_rng_br = jax.random.split(rng, 3)
 
-                minibatches_conf = _create_minibatches(traj_batch_conf, advantages_conf, targets_conf, init_conf_hstate,
-                                                       config["NUM_CONF_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_conf)
-                minibatches_br = _create_minibatches(traj_batch_br, advantages_br, targets_br, init_br_hstate,
-                                                     config["NUM_BR_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_br)
+                minibatches_conf = _create_minibatches(
+                    traj_batch_conf,
+                    advantages_conf,
+                    targets_conf,
+                    init_conf_hstate,
+                    config["NUM_CONF_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_conf,
+                )
+                minibatches_br = _create_minibatches(
+                    traj_batch_br,
+                    advantages_br,
+                    targets_br,
+                    init_br_hstate,
+                    config["NUM_BR_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_br,
+                )
 
                 # Update both policies
                 (train_state_conf, train_state_br), all_losses = jax.lax.scan(
-                    _update_minbatch, (train_state_conf, train_state_br), (minibatches_conf, minibatches_br)
+                    _update_minbatch,
+                    (train_state_conf, train_state_br),
+                    (minibatches_conf, minibatches_br),
                 )
 
-                update_state = (train_state_conf, train_state_br,
-                    traj_batch_conf, traj_batch_br,
-                    advantages_conf, advantages_br,
-                    targets_conf, targets_br,
-                    rng
+                update_state = (
+                    train_state_conf,
+                    train_state_br,
+                    traj_batch_conf,
+                    traj_batch_br,
+                    advantages_conf,
+                    advantages_br,
+                    targets_conf,
+                    targets_br,
+                    rng,
                 )
                 return update_state, all_losses
 
@@ -481,27 +629,64 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 3. PPO updates
                 """
                 (
-                    all_train_state_conf, all_train_state_br,
-                    last_env_state, last_obs, last_done, last_conf_h, last_br_h,
-                    rng, update_steps
+                    all_train_state_conf,
+                    all_train_state_br,
+                    last_env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
+                    update_steps,
                 ) = update_runner_state
 
                 rng, conf_sampling_rng, br_sampling_rng = jax.random.split(rng, 3)
 
-                conf_ids = jax.random.randint(conf_sampling_rng, (config["NUM_ENVS"],), 0, config["PARTNER_POP_SIZE"])
-                br_ids = jax.random.randint(br_sampling_rng, (config["NUM_ENVS"],), 0, config["PARTNER_POP_SIZE"])
+                conf_ids = jax.random.randint(
+                    conf_sampling_rng,
+                    (config["NUM_ENVS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
+                br_ids = jax.random.randint(
+                    br_sampling_rng,
+                    (config["NUM_ENVS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
 
                 runner_state = (
-                    all_train_state_conf, all_train_state_br, conf_ids, br_ids,
-                    last_env_state, last_obs, last_done, last_conf_h, last_br_h, rng
+                    all_train_state_conf,
+                    all_train_state_br,
+                    conf_ids,
+                    br_ids,
+                    last_env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
                 )
                 runner_state, traj_batch = jax.lax.scan(
-                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"])
-                (all_train_state_conf, all_train_state_br, last_conf_ids, last_br_ids,
-                 last_env_state, last_obs, last_done, last_conf_h, last_br_h, rng) = runner_state
+                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    all_train_state_conf,
+                    all_train_state_br,
+                    last_conf_ids,
+                    last_br_ids,
+                    last_env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
+                ) = runner_state
 
                 # Get the last conf and br params and ids
-                last_conf_params = gather_params(all_train_state_conf.params, last_conf_ids)
+                last_conf_params = gather_params(
+                    all_train_state_conf.params, last_conf_ids
+                )
                 last_br_params = gather_params(all_train_state_br.params, last_br_ids)
 
                 last_conf_one_hots = identity_matrix[last_conf_ids]
@@ -511,7 +696,9 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 traj_batch_conf, traj_batch_br = traj_batch
 
                 # Compute advantage for confederate agent from interaction with br policy
-                avail_actions_0 = jax.vmap(env.get_avail_actions)(last_env_state.env_state)["agent_0"].astype(jnp.float32)
+                avail_actions_0 = jax.vmap(env.get_avail_actions)(
+                    last_env_state.env_state
+                )["agent_0"].astype(jnp.float32)
                 _, last_val_conf, _, _ = jax.vmap(forward_pass_conf)(
                     params=last_conf_params,
                     obs=last_obs["agent_0"],
@@ -519,13 +706,19 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     done=last_done["agent_0"],
                     avail_actions=avail_actions_0,
                     hstate=last_conf_h,
-                    rng=jax.random.split(jax.random.PRNGKey(0), config["NUM_ENVS"])  # Dummy key since we're just extracting the value
+                    rng=jax.random.split(
+                        jax.random.PRNGKey(0), config["NUM_ENVS"]
+                    ),  # Dummy key since we're just extracting the value
                 )
                 last_val_conf = last_val_conf.squeeze()
-                advantages_conf, targets_conf = _calculate_gae(traj_batch_conf, last_val_conf)
+                advantages_conf, targets_conf = _calculate_gae(
+                    traj_batch_conf, last_val_conf
+                )
 
                 # Compute advantage for br policy from interaction with confederate agent
-                avail_actions_1 = jax.vmap(env.get_avail_actions)(last_env_state.env_state)["agent_1"].astype(jnp.float32)
+                avail_actions_1 = jax.vmap(env.get_avail_actions)(
+                    last_env_state.env_state
+                )["agent_1"].astype(jnp.float32)
                 _, last_val_br, _, _ = jax.vmap(forward_pass_br)(
                     params=last_br_params,
                     obs=last_obs["agent_1"],
@@ -533,7 +726,9 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     done=last_done["agent_1"],
                     avail_actions=avail_actions_1,
                     hstate=last_br_h,
-                    rng=jax.random.split(jax.random.PRNGKey(0), config["NUM_ENVS"])  # Dummy key since we're just extracting the value
+                    rng=jax.random.split(
+                        jax.random.PRNGKey(0), config["NUM_ENVS"]
+                    ),  # Dummy key since we're just extracting the value
                 )
                 last_val_br = last_val_br.squeeze()
                 advantages_br, targets_br = _calculate_gae(traj_batch_br, last_val_br)
@@ -541,24 +736,36 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 # 3) PPO update
                 rng, update_rng = jax.random.split(rng, 2)
                 update_state = (
-                    all_train_state_conf, all_train_state_br,
-                    traj_batch_conf, traj_batch_br,
-                    advantages_conf, advantages_br,
-                    targets_conf, targets_br,
-                    update_rng
+                    all_train_state_conf,
+                    all_train_state_br,
+                    traj_batch_conf,
+                    traj_batch_br,
+                    advantages_conf,
+                    advantages_br,
+                    targets_conf,
+                    targets_br,
+                    update_rng,
                 )
 
                 update_state, all_losses = jax.lax.scan(
-                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                )
                 all_train_state_conf, all_train_state_br = update_state[:2]
-                (_, (value_loss_conf, pg_loss_conf, entropy_conf)), (_, (value_loss_br, pg_loss_br, entropy_br)) = all_losses
+                (
+                    (_, (value_loss_conf, pg_loss_conf, entropy_conf)),
+                    (_, (value_loss_br, pg_loss_br, entropy_br)),
+                ) = all_losses
 
                 # Metrics
                 def mask_and_mean(x, mask):
                     return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
-                
-                mask = traj_batch_conf.info.get("returned_episode", jnp.ones_like(traj_batch_conf.reward))
-                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_conf.info)
+
+                mask = traj_batch_conf.info.get(
+                    "returned_episode", jnp.ones_like(traj_batch_conf.reward)
+                )
+                metric = jax.tree.map(
+                    lambda x: mask_and_mean(x, mask), traj_batch_conf.info
+                )
                 metric["update_steps"] = update_steps
                 metric["value_loss_conf_agent"] = value_loss_conf.mean(axis=(0, 1))
                 metric["value_loss_br_agent"] = value_loss_br.mean(axis=(0, 1))
@@ -570,55 +777,88 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 metric["entropy_br"] = entropy_br.mean(axis=(0, 1))
 
                 new_runner_state = (
-                    all_train_state_conf, all_train_state_br,
-                    last_env_state, last_obs, last_done, last_conf_h, last_br_h,
-                    rng, update_steps + 1
+                    all_train_state_conf,
+                    all_train_state_br,
+                    last_env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
+                    update_steps + 1,
                 )
                 return (new_runner_state, metric)
 
             # --------------------------
             # PPO Update and Checkpoint saving
             # --------------------------
-            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)  # -1 because we store a ckpt at the last update
+            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                1, config["NUM_CHECKPOINTS"] - 1
+            )  # -1 because we store a ckpt at the last update
             num_ckpts = config["NUM_CHECKPOINTS"]
 
             # Build a PyTree that holds parameters for all conf agent checkpoints
             def init_ckpt_array(params_pytree):
                 return jax.tree.map(
-                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype),
-                    params_pytree)
+                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
+                )
 
             def _update_step_with_ckpt(state_with_ckpt, unused):
-                (update_runner_state, checkpoint_array_conf, checkpoint_array_br, ckpt_idx,
-                    eval_info) = state_with_ckpt
+                (
+                    update_runner_state,
+                    checkpoint_array_conf,
+                    checkpoint_array_br,
+                    ckpt_idx,
+                    eval_info,
+                ) = state_with_ckpt
 
                 # Single PPO update
                 new_runner_state, metric = _update_step(update_runner_state, None)
 
-                train_state_conf, train_state_br, last_env_state, last_obs, last_done, last_conf_h, last_br_h, rng, update_steps = new_runner_state
+                (
+                    train_state_conf,
+                    train_state_br,
+                    last_env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
+                    update_steps,
+                ) = new_runner_state
 
                 # Decide if we store a checkpoint
                 # update steps is 1-indexed because it was incremented at the end of the update step
-                to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                        jnp.equal(update_steps, config["NUM_UPDATES"]))
+                to_store = jnp.logical_or(
+                    jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
+                )
 
                 def store_and_eval_ckpt(args):
                     ckpt_arr_and_ep_infos, rng, cidx = args
                     ckpt_arr_conf, ckpt_arr_br, _ = ckpt_arr_and_ep_infos
                     new_ckpt_arr_conf = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_conf, train_state_conf.params
+                        ckpt_arr_conf,
+                        train_state_conf.params,
                     )
                     new_ckpt_arr_br = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_br, train_state_br.params
+                        ckpt_arr_br,
+                        train_state_br.params,
                     )
 
                     rng, eval_rng = jax.random.split(rng)
-                    ep_last_info = jax.tree.map(lambda x: x.mean(axis=(-2, -1)),
-                        run_all_episodes(eval_rng, train_state_conf, train_state_br))
+                    ep_last_info = jax.tree.map(
+                        lambda x: x.mean(axis=(-2, -1)),
+                        run_all_episodes(eval_rng, train_state_conf, train_state_br),
+                    )
 
-                    return ((new_ckpt_arr_conf, new_ckpt_arr_br, ep_last_info), rng, cidx + 1)
+                    return (
+                        (new_ckpt_arr_conf, new_ckpt_arr_br, ep_last_info),
+                        rng,
+                        cidx + 1,
+                    )
 
                 def skip_ckpt(args):
                     return args
@@ -627,16 +867,35 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     to_store,
                     store_and_eval_ckpt,
                     skip_ckpt,
-                    ((checkpoint_array_conf, checkpoint_array_br, eval_info), rng, ckpt_idx)
+                    (
+                        (checkpoint_array_conf, checkpoint_array_br, eval_info),
+                        rng,
+                        ckpt_idx,
+                    ),
                 )
-                checkpoint_array_conf, checkpoint_array_br, eval_ep_last_info = checkpoint_array_and_infos
+                checkpoint_array_conf, checkpoint_array_br, eval_ep_last_info = (
+                    checkpoint_array_and_infos
+                )
 
-                metric["eval_ep_last_info"] = eval_ep_last_info # return of confederate
+                metric["eval_ep_last_info"] = eval_ep_last_info  # return of confederate
 
-                return ((train_state_conf, train_state_br,
-                         last_env_state, last_obs, last_done, last_conf_h, last_br_h, rng, update_steps),
-                        checkpoint_array_conf, checkpoint_array_br, ckpt_idx,
-                        eval_ep_last_info), metric
+                return (
+                    (
+                        train_state_conf,
+                        train_state_br,
+                        last_env_state,
+                        last_obs,
+                        last_done,
+                        last_conf_h,
+                        last_br_h,
+                        rng,
+                        update_steps,
+                    ),
+                    checkpoint_array_conf,
+                    checkpoint_array_br,
+                    ckpt_idx,
+                    eval_ep_last_info,
+                ), metric
 
             # Initialize checkpoint array
             checkpoint_array_conf = init_ckpt_array(all_conf_optims.params)
@@ -647,28 +906,42 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
             update_steps = 0
 
             rng, rng_eval = jax.random.split(rng, 2)
-            eval_ep_last_info = jax.tree.map(lambda x: x.mean(axis=(-2, -1)),
-                run_all_episodes(rng_eval, all_conf_optims, all_br_optims))
+            eval_ep_last_info = jax.tree.map(
+                lambda x: x.mean(axis=(-2, -1)),
+                run_all_episodes(rng_eval, all_conf_optims, all_br_optims),
+            )
 
             # Initialize environment
             rng, reset_rng = jax.random.split(rng)
             reset_rngs = jax.random.split(reset_rng, config["NUM_ENVS"])
             init_obs, init_env_state = jax.vmap(env.reset, in_axes=(0,))(reset_rngs)
-            init_done = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
+            init_done = {
+                k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                for k in env.agents + ["__all__"]
+            }
 
             # Initialize conf and br hstates
             init_conf_h = conf_policy.init_hstate(config["NUM_CONF_ACTORS"])
             init_br_h = br_policy.init_hstate(config["NUM_BR_ACTORS"])
 
             update_runner_state = (
-                all_conf_optims, all_br_optims,
-                init_env_state, init_obs, init_done, init_conf_h, init_br_h,
-                rng, update_steps
+                all_conf_optims,
+                all_br_optims,
+                init_env_state,
+                init_obs,
+                init_done,
+                init_conf_h,
+                init_br_h,
+                rng,
+                update_steps,
             )
 
             state_with_ckpt = (
-                update_runner_state, checkpoint_array_conf,
-                checkpoint_array_br, ckpt_idx, eval_ep_last_info
+                update_runner_state,
+                checkpoint_array_conf,
+                checkpoint_array_br,
+                ckpt_idx,
+                eval_ep_last_info,
             )
 
             # run training
@@ -676,12 +949,15 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 _update_step_with_ckpt,
                 state_with_ckpt,
                 xs=None,
-                length=config["NUM_UPDATES"]
+                length=config["NUM_UPDATES"],
             )
 
             (
-                final_runner_state, checkpoint_array_conf, checkpoint_array_br,
-                final_ckpt_idx, all_ep_infos
+                final_runner_state,
+                checkpoint_array_conf,
+                checkpoint_array_br,
+                _final_ckpt_idx,
+                all_ep_infos,
             ) = state_with_ckpt
 
             out = {
@@ -689,12 +965,13 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 "final_params_br": final_runner_state[1].params,
                 "checkpoints_conf": checkpoint_array_conf,
                 "checkpoints_br": checkpoint_array_br,
-                "metrics": metrics, # metrics is from the perspective of the confederate agent (averaged over population)
-                "all_pair_returns": all_ep_infos
+                "metrics": metrics,  # metrics is from the perspective of the confederate agent (averaged over population)
+                "all_pair_returns": all_ep_infos,
             }
             return out
 
         return train
+
     # ------------------------------
     # Actually run the adversarial teammate training
     # ------------------------------
@@ -702,29 +979,30 @@ def train_brdiv_partners(train_rng, env, config, conf_policy, br_policy):
     out = train_fn(train_rng)
     return out
 
+
 def get_brdiv_population(config, out, env):
-    '''
+    """
     Get the partner params and partner population for ego training.
-    '''
+    """
     brdiv_pop_size = config["algorithm"]["PARTNER_POP_SIZE"]
 
     # partner_params has shape (num_seeds, brdiv_pop_size, ...)
-    partner_params = out['final_params_conf']
+    partner_params = out["final_params_conf"]
 
     partner_policy = ActorWithConditionalCriticPolicy(
         action_dim=env.action_space(env.agents[1]).n,
         obs_dim=env.observation_space(env.agents[1]).shape[0],
-        pop_size=brdiv_pop_size, # used to create onehot agent id
-        activation=config["algorithm"].get("ACTIVATION", "tanh")
+        pop_size=brdiv_pop_size,  # used to create onehot agent id
+        activation=config["algorithm"].get("ACTIVATION", "tanh"),
     )
 
     # Create partner population
     partner_population = AgentPopulation(
-        pop_size=brdiv_pop_size,
-        policy_cls=partner_policy
+        pop_size=brdiv_pop_size, policy_cls=partner_policy
     )
 
     return partner_params, partner_population
+
 
 def run_brdiv(config, wandb_logger):
     algorithm_config = dict(config["algorithm"])
@@ -755,7 +1033,13 @@ def run_brdiv(config, wandb_logger):
     with jax.disable_jit(False):
         vmapped_train_fn = jax.jit(
             jax.vmap(
-                partial(train_brdiv_partners, env=env, config=algorithm_config, conf_policy=conf_policy, br_policy=br_policy)
+                partial(
+                    train_brdiv_partners,
+                    env=env,
+                    config=algorithm_config,
+                    conf_policy=conf_policy,
+                    br_policy=br_policy,
+                )
             )
         )
         out = vmapped_train_fn(rngs)
@@ -774,7 +1058,9 @@ def run_brdiv(config, wandb_logger):
 def log_metrics(config, outs, logger, metric_names: tuple):
     metrics = outs["metrics"]
     # metrics now has shape (num_seeds, num_updates, pop_size)
-    num_seeds, num_updates, pop_size = metrics["pg_loss_conf_agent"].shape # number of trained pairs
+    _num_seeds, num_updates, pop_size = metrics[
+        "pg_loss_conf_agent"
+    ].shape  # number of trained pairs
 
     ### Log evaluation metrics
     # we plot XP return curves separately from SP return curves
@@ -783,7 +1069,7 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     xs = list(range(num_updates))
 
     all_conf_ids, all_br_ids = _get_all_ids(pop_size)
-    sp_mask = (all_conf_ids == all_br_ids)
+    sp_mask = all_conf_ids == all_br_ids
     sp_returns = all_returns[:, :, sp_mask]
     xp_returns = all_returns[:, :, ~sp_mask]
 
@@ -805,10 +1091,16 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     # shape (num_seeds, num_updates, update_epochs, num_minibatches, pop_size)
     # Average over seeds
     processed_losses = {
-        "ConfPGLoss": np.asarray(metrics["pg_loss_conf_agent"]).mean(axis=0).transpose(),
+        "ConfPGLoss": np.asarray(metrics["pg_loss_conf_agent"])
+        .mean(axis=0)
+        .transpose(),
         "BRPGLoss": np.asarray(metrics["pg_loss_br_agent"]).mean(axis=0).transpose(),
-        "ConfValLoss": np.asarray(metrics["value_loss_conf_agent"]).mean(axis=0).transpose(),
-        "BRValLoss": np.asarray(metrics["value_loss_br_agent"]).mean(axis=0).transpose(),
+        "ConfValLoss": np.asarray(metrics["value_loss_conf_agent"])
+        .mean(axis=0)
+        .transpose(),
+        "BRValLoss": np.asarray(metrics["value_loss_br_agent"])
+        .mean(axis=0)
+        .transpose(),
         "ConfEntropy": np.asarray(metrics["entropy_conf"]).mean(axis=0).transpose(),
         "BREntropy": np.asarray(metrics["entropy_br"]).mean(axis=0).transpose(),
     }
@@ -818,9 +1110,11 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     for loss_name, loss_data in processed_losses.items():
         if np.isnan(loss_data).any():
             raise ValueError(f"Found nan in loss {loss_name}")
-        logger.log_item(f"Losses/{loss_name}",
-            wandb.plot.line_series(xs=xs, ys=loss_data, keys=keys,
-            title=loss_name, xname="train_step")
+        logger.log_item(
+            f"Losses/{loss_name}",
+            wandb.plot.line_series(
+                xs=xs, ys=loss_data, keys=keys, title=loss_name, xname="train_step"
+            ),
         )
 
     ### Log artifacts
@@ -828,7 +1122,9 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     # Save train run output and log to wandb as artifact
     out_savepath = save_train_run(outs, savedir, savename="saved_train_run")
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="saved_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="saved_train_run", path=out_savepath, type_name="train_run"
+        )
 
     # Cleanup locally logged out files
     if not config["local_logger"]["save_train_out"]:

--- a/teammate_generation/CoMeDi.py
+++ b/teammate_generation/CoMeDi.py
@@ -1,42 +1,45 @@
-'''Implementation of the CoMeDi teammate generation algorithm (Sarkar et al. NeurIPS 2023)
+"""Implementation of the CoMeDi teammate generation algorithm (Sarkar et al. NeurIPS 2023)
 https://openreview.net/forum?id=MljeRycu9s
 
 Command to run CoMeDi only on LBF:
 python teammate_generation/run.py algorithm=comedi/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels label=test_comedi run_heldout_eval=false train_ego=false
 
 Limitations: does not support recurrent actors.
-'''
-from functools import partial
+"""
+
 import logging
 import shutil
 import time
+from functools import partial
 from typing import NamedTuple
 
-from flax.training.train_state import TrainState
 import hydra
 import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
 import wandb
+from flax.training.train_state import TrainState
 
-from agents.mlp_actor_critic_agent import ActorWithConditionalCriticPolicy
 from agents.initialize_agents import initialize_actor_with_conditional_critic
-from agents.population_interface import AgentPopulation
+from agents.mlp_actor_critic_agent import ActorWithConditionalCriticPolicy
 from agents.population_buffer import BufferedPopulation
-from common.save_load_utils import save_train_run
+from agents.population_interface import AgentPopulation
 from common.plot_utils import get_metric_names
 from common.run_episodes import run_episodes
+from common.save_load_utils import save_train_run
 from envs import make_env
-from envs.log_wrapper import LogWrapper, LogEnvState
+from envs.log_wrapper import LogEnvState, LogWrapper
 from marl.ippo import make_train as make_ppo_train
-from marl.ppo_utils import Transition, unbatchify, _create_minibatches
+from marl.ppo_utils import Transition, _create_minibatches, unbatchify
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+
 class ResetTransition(NamedTuple):
-    '''Stores extra information for resetting agents to a point in some trajectory.'''
+    """Stores extra information for resetting agents to a point in some trajectory."""
+
     env_state: LogEnvState
     conf_obs: jnp.ndarray
     partner_obs: jnp.ndarray
@@ -44,6 +47,7 @@ class ResetTransition(NamedTuple):
     partner_done: jnp.ndarray
     conf_hstate: jnp.ndarray
     partner_hstate: jnp.ndarray
+
 
 def train_comedi_partners(train_rng, wandb_logger, env, config):
     num_agents = env.num_agents
@@ -59,27 +63,38 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
     # Compute numbber of updates PER outermost iteration
     # Calculate timesteps per update
     # 1. Overhead from population selection rollouts
-    # We divide by 2 because for ease in Jax, this implementation uses a vmap over PARTNER_POP_SIZE to 
-    # evaluate the agent generated at each outermost iteration against all previously 
-    # generated agents, but a non-Jax implementation would only need to evaluate against 
+    # We divide by 2 because for ease in Jax, this implementation uses a vmap over PARTNER_POP_SIZE to
+    # evaluate the agent generated at each outermost iteration against all previously
+    # generated agents, but a non-Jax implementation would only need to evaluate against
     # *previously* generated agents.
-    selection_steps = config["PARTNER_POP_SIZE"] * config["NUM_ARGMAX_ROLLOUT_EPS"] * config["ROLLOUT_LENGTH"] // 2
+    selection_steps = (
+        config["PARTNER_POP_SIZE"]
+        * config["NUM_ARGMAX_ROLLOUT_EPS"]
+        * config["ROLLOUT_LENGTH"]
+        // 2
+    )
     # 2. Training rollouts: 4 distinct rollout phases (SP, XP, MP, MP2) each using NUM_ENVS
     training_steps = 4 * config["ROLLOUT_LENGTH"] * config["NUM_ENVS"]
 
     steps_per_update = selection_steps + training_steps
-    config["NUM_UPDATES"] = int(config["TOTAL_TIMESTEPS_PER_ITERATION"] // steps_per_update)
+    config["NUM_UPDATES"] = int(
+        config["TOTAL_TIMESTEPS_PER_ITERATION"] // steps_per_update
+    )
 
     def make_comedi_agents(config):
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train_init_ippo_partners(config, partner_rng, env):
-            '''
+            """
             Train a pool IPPO agents w/parameter sharing.
             Returns out, a dictionary of the model checkpoints, final parameters, and metrics.
-            '''
+            """
             # POP_SIZE is referenced throughout the CoMeDi training loops
             config["POP_SIZE"] = config["PARTNER_POP_SIZE"]
             # Use a local copy for warmup-specific overrides to avoid
@@ -97,14 +112,18 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
             init_ppo_partner = train_init_ippo_partners(config, init_ppo_rng, env)
 
             # Initialize a population buffer
-            dummy_policy, dummy_init_params = initialize_actor_with_conditional_critic(config, env, init_conf_rng)
+            dummy_policy, dummy_init_params = initialize_actor_with_conditional_critic(
+                config, env, init_conf_rng
+            )
             partner_population = BufferedPopulation(
                 max_pop_size=config["PARTNER_POP_SIZE"],
                 policy_cls=dummy_policy,
             )
 
             population_buffer = partner_population.reset_buffer(dummy_init_params)
-            population_buffer = partner_population.add_agent(population_buffer, init_ppo_partner["final_params"])
+            population_buffer = partner_population.add_agent(
+                population_buffer, init_ppo_partner["final_params"]
+            )
 
             def add_conf_policy(pop_buffer, func_input):
                 num_existing_agents, rng = func_input
@@ -124,7 +143,8 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                 else:
                     tx = optax.chain(
                         optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                        optax.adam(config["LR"], eps=1e-5))
+                        optax.adam(config["LR"], eps=1e-5),
+                    )
 
                 train_state = TrainState.create(
                     apply_fn=policy.network.apply,
@@ -133,79 +153,120 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                 )
 
                 # Reset envs for SP, XP, and MP
-                rng, reset_rng_eval, reset_rng_sp, reset_rng_xp, reset_rng_mp, reset_rng_mp2 = jax.random.split(rng, 6)
+                (
+                    rng,
+                    _reset_rng_eval,
+                    reset_rng_sp,
+                    reset_rng_xp,
+                    reset_rng_mp,
+                    reset_rng_mp2,
+                ) = jax.random.split(rng, 6)
 
                 reset_rngs_sps = jax.random.split(reset_rng_sp, config["NUM_ENVS"])
                 reset_rngs_xps = jax.random.split(reset_rng_xp, config["NUM_ENVS"])
                 reset_rngs_mps = jax.random.split(reset_rng_mp, config["NUM_ENVS"])
                 reset_rngs_mps2 = jax.random.split(reset_rng_mp2, config["NUM_ENVS"])
 
-                obsv_xp, env_state_xp = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_sps)
-                obsv_sp, env_state_sp = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_xps)
-                obsv_mp, env_state_mp = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_mps)
-                obsv_mp2, env_state_mp2 = jax.vmap(env.reset, in_axes=(0,))(reset_rngs_mps2)
+                obsv_xp, env_state_xp = jax.vmap(env.reset, in_axes=(0,))(
+                    reset_rngs_sps
+                )
+                obsv_sp, env_state_sp = jax.vmap(env.reset, in_axes=(0,))(
+                    reset_rngs_xps
+                )
+                obsv_mp, env_state_mp = jax.vmap(env.reset, in_axes=(0,))(
+                    reset_rngs_mps
+                )
+                obsv_mp2, env_state_mp2 = jax.vmap(env.reset, in_axes=(0,))(
+                    reset_rngs_mps2
+                )
 
                 # build a pytree that can hold the parameters for all checkpoints.
-                ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)
+                ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                    1, config["NUM_CHECKPOINTS"] - 1
+                )
                 num_ckpts = config["NUM_CHECKPOINTS"]
+
                 def init_ckpt_array(params_pytree):
                     return jax.tree.map(
                         lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype),
-                        params_pytree
+                        params_pytree,
                     )
 
                 # define evaluation function
                 rng, eval_rng = jax.random.split(rng, 2)
+
                 def per_id_run_episode_fixed_rng(agent0_param, agent1_id):
-                    agent1_param = partner_population.gather_agent_params(pop_buffer,
-                                        agent_indices=agent1_id * jnp.ones((1,), dtype=np.int32))
-                    agent1_param = jax.tree_map(lambda y: jnp.squeeze(y, 0), agent1_param)
-                    all_outs =  run_episodes(
-                        rng=eval_rng, env=env,
-                        agent_0_param=agent0_param, agent_0_policy=policy,
-                        agent_1_param=agent1_param, agent_1_policy=policy,
+                    agent1_param = partner_population.gather_agent_params(
+                        pop_buffer,
+                        agent_indices=agent1_id * jnp.ones((1,), dtype=np.int32),
+                    )
+                    agent1_param = jax.tree_map(
+                        lambda y: jnp.squeeze(y, 0), agent1_param
+                    )
+                    all_outs = run_episodes(
+                        rng=eval_rng,
+                        env=env,
+                        agent_0_param=agent0_param,
+                        agent_0_policy=policy,
+                        agent_1_param=agent1_param,
+                        agent_1_policy=policy,
                         max_episode_steps=config["ROLLOUT_LENGTH"],
-                        num_eps=config["NUM_ARGMAX_ROLLOUT_EPS"]
+                        num_eps=config["NUM_ARGMAX_ROLLOUT_EPS"],
                     )
                     return all_outs
 
                 def _update_step(update_with_ckpt_runner_state, unused):
-                    update_runner_state, checkpoint_array, ckpt_idx = update_with_ckpt_runner_state
+                    update_runner_state, checkpoint_array, ckpt_idx = (
+                        update_with_ckpt_runner_state
+                    )
                     (
-                        train_state, pop_buffer,
-                        env_state_sp, obsv_sp,
-                        env_state_xp, obsv_xp,
-                        env_state_mp, obsv_mp,
-                        env_state_mp2, obsv_mp2,
+                        train_state,
+                        pop_buffer,
+                        env_state_sp,
+                        obsv_sp,
+                        env_state_xp,
+                        obsv_xp,
+                        env_state_mp,
+                        obsv_mp,
+                        env_state_mp2,
+                        obsv_mp2,
                         last_dones_xp,
                         last_dones_sp,
                         last_dones_mp,
                         last_dones_mp2,
-                        rng, update_steps,
-                        num_prev_trained_conf
+                        rng,
+                        update_steps,
+                        num_prev_trained_conf,
                     ) = update_runner_state
 
                     # Identify the expected returns from the newly trained policy
                     # when interacting with the previously generated confederate
                     # policies
                     valid_sampling_indices = jnp.arange(config["POP_SIZE"])
-                    run_all_rollouts = jax.vmap(per_id_run_episode_fixed_rng, in_axes=(None, 0))(
-                        train_state.params,valid_sampling_indices)
+                    run_all_rollouts = jax.vmap(
+                        per_id_run_episode_fixed_rng, in_axes=(None, 0)
+                    )(train_state.params, valid_sampling_indices)
 
                     # Mask out the XP returns against invalid policies
                     # resulting from IDs that are yet set to a specific
                     # confederate params
-                    all_mean_returns = run_all_rollouts["returned_episode_returns"][:, :, 0].mean(axis=-1)
+                    all_mean_returns = run_all_rollouts["returned_episode_returns"][
+                        :, :, 0
+                    ].mean(axis=-1)
                     masked_mean_returns = jnp.where(
-                        valid_sampling_indices >= num_prev_trained_conf, -jnp.inf, all_mean_returns
+                        valid_sampling_indices >= num_prev_trained_conf,
+                        -jnp.inf,
+                        all_mean_returns,
                     )
 
                     # Pick the right confederate params to act as the XP agent
                     max_means_id = masked_mean_returns.argmax()
                     xp_param = jax.tree_map(
                         lambda x: jnp.squeeze(x, 0),
-                        partner_population.gather_agent_params(pop_buffer,
-                                                               agent_indices=max_means_id * jnp.ones((1,), dtype=np.int32))
+                        partner_population.gather_agent_params(
+                            pop_buffer,
+                            agent_indices=max_means_id * jnp.ones((1,), dtype=np.int32),
+                        ),
                     )
 
                     rng, rng_xp, rng_sp, rng_mp, rng_mp2 = jax.random.split(rng, 5)
@@ -215,23 +276,31 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                         agent_0 = confederate, agent_1 = ego
                         Returns updated runner_state and a Transition for the confederate.
                         """
-                        train_state, xp_param, xp_id, env_state, last_obs, last_dones, rng = runner_state
+                        (
+                            train_state,
+                            xp_param,
+                            xp_id,
+                            env_state,
+                            last_obs,
+                            last_dones,
+                            rng,
+                        ) = runner_state
                         rng, act_rng, partner_rng, step_rng = jax.random.split(rng, 4)
 
                         obs_0 = last_obs["agent_0"]
                         obs_1 = last_obs["agent_1"]
 
                         # Get available actions for agent 0 from environment state
-                        avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)
+                        avail_actions = jax.vmap(env.get_avail_actions)(
+                            env_state.env_state
+                        )
                         avail_actions_0 = avail_actions["agent_0"].astype(jnp.float32)
                         avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
                         # Add one-hot ID of XP teammate
                         xp_one_hot_id = jnp.eye(config["POP_SIZE"])[xp_id]
                         xp_one_hot_id = jnp.expand_dims(
-                            jnp.expand_dims(
-                                xp_one_hot_id, 0
-                            ), 0
+                            jnp.expand_dims(xp_one_hot_id, 0), 0
                         )
 
                         # Agent_0 (confederate) action using policy interface
@@ -243,7 +312,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             avail_actions=jax.lax.stop_gradient(avail_actions_0),
                             hstate=None,
                             rng=act_rng,
-                            aux_obs=aux_obs
+                            aux_obs=aux_obs,
                         )
                         logp_0 = pi_0.log_prob(act_0)
 
@@ -259,20 +328,24 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             avail_actions=jax.lax.stop_gradient(avail_actions_1),
                             hstate=None,
                             rng=partner_rng,
-                            aux_obs=aux_obs
+                            aux_obs=aux_obs,
                         )
                         act_1 = act_1.squeeze()
 
                         # Combine actions into the env format
-                        combined_actions = jnp.concatenate([act_0, act_1], axis=0)  # shape (2*num_envs,)
-                        env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                        combined_actions = jnp.concatenate(
+                            [act_0, act_1], axis=0
+                        )  # shape (2*num_envs,)
+                        env_act = unbatchify(
+                            combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                        )
                         env_act = {k: v.flatten() for k, v in env_act.items()}
 
                         # Step env
                         step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                        obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                            step_rngs, env_state, env_act
-                        )
+                        obs_next, env_state_next, reward, done, info = jax.vmap(
+                            env.step, in_axes=(0, 0, 0)
+                        )(step_rngs, env_state, env_act)
                         # note that num_actors = num_envs * num_agents
                         info_0 = jax.tree.map(lambda x: x[:, 0], info)
 
@@ -286,9 +359,17 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             obs=obs_0,
                             info=info_0,
                             avail_actions=avail_actions_0,
-                            prev_done=last_dones["agent_0"]
+                            prev_done=last_dones["agent_0"],
                         )
-                        new_runner_state = (train_state, xp_param, xp_id, env_state_next, obs_next, done, rng)
+                        new_runner_state = (
+                            train_state,
+                            xp_param,
+                            xp_id,
+                            env_state_next,
+                            obs_next,
+                            done,
+                            rng,
+                        )
                         return new_runner_state, transition
 
                     def _env_step_conf_br(runner_state, unused):
@@ -296,64 +377,126 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                         agent_0 = confederate, agent_1 = best response
                         Returns updated runner_state, and Transitions for the confederate and best response.
                         """
-                        train_state, env_state, last_obs, last_dones, rng, current_trained_pop_id, reset_traj_batch = runner_state
+                        (
+                            train_state,
+                            env_state,
+                            last_obs,
+                            last_dones,
+                            rng,
+                            current_trained_pop_id,
+                            reset_traj_batch,
+                        ) = runner_state
                         rng, conf_rng, br_rng, step_rng = jax.random.split(rng, 4)
 
-                        def gather_sampled(data_pytree, flat_indices, first_nonbatch_dim: int):
-                            '''Will treat all dimensions up to the first_nonbatch_dim as batch dimensions. '''
+                        def gather_sampled(
+                            data_pytree, flat_indices, first_nonbatch_dim: int
+                        ):
+                            """Will treat all dimensions up to the first_nonbatch_dim as batch dimensions."""
                             batch_size = config["ROLLOUT_LENGTH"] * config["NUM_ENVS"]
-                            flat_data = jax.tree.map(lambda x: x.reshape(batch_size, *x.shape[first_nonbatch_dim:]), data_pytree)
-                            sampled_data = jax.tree.map(lambda x: x[flat_indices], flat_data) # Shape (N, ...)
+                            flat_data = jax.tree.map(
+                                lambda x: x.reshape(
+                                    batch_size, *x.shape[first_nonbatch_dim:]
+                                ),
+                                data_pytree,
+                            )
+                            sampled_data = jax.tree.map(
+                                lambda x: x[flat_indices], flat_data
+                            )  # Shape (N, ...)
                             return sampled_data
 
                         if reset_traj_batch is not None:
                             rng, sample_rng = jax.random.split(rng)
-                            needs_resample = last_dones["__all__"] # shape (N,) bool
+                            needs_resample = last_dones["__all__"]  # shape (N,) bool
 
-                            total_reset_states = config["ROLLOUT_LENGTH"] * config["NUM_ENVS"]
-                            sampled_indices = jax.random.randint(sample_rng, shape=(config["NUM_ENVS"],), minval=0,
-                                                                maxval=total_reset_states)
+                            total_reset_states = (
+                                config["ROLLOUT_LENGTH"] * config["NUM_ENVS"]
+                            )
+                            sampled_indices = jax.random.randint(
+                                sample_rng,
+                                shape=(config["NUM_ENVS"],),
+                                minval=0,
+                                maxval=total_reset_states,
+                            )
 
                             # Gather sampled leaves from each data pytree
-                            sampled_env_state = gather_sampled(reset_traj_batch.env_state, sampled_indices, first_nonbatch_dim=2)
-                            sampled_conf_obs = gather_sampled(reset_traj_batch.conf_obs, sampled_indices, first_nonbatch_dim=2)
-                            sampled_br_obs = gather_sampled(reset_traj_batch.partner_obs, sampled_indices, first_nonbatch_dim=2)
-                            sampled_conf_done = gather_sampled(reset_traj_batch.conf_done, sampled_indices, first_nonbatch_dim=2)
-                            sampled_br_done = gather_sampled(reset_traj_batch.partner_done, sampled_indices, first_nonbatch_dim=2)
+                            sampled_env_state = gather_sampled(
+                                reset_traj_batch.env_state,
+                                sampled_indices,
+                                first_nonbatch_dim=2,
+                            )
+                            sampled_conf_obs = gather_sampled(
+                                reset_traj_batch.conf_obs,
+                                sampled_indices,
+                                first_nonbatch_dim=2,
+                            )
+                            sampled_br_obs = gather_sampled(
+                                reset_traj_batch.partner_obs,
+                                sampled_indices,
+                                first_nonbatch_dim=2,
+                            )
+                            sampled_conf_done = gather_sampled(
+                                reset_traj_batch.conf_done,
+                                sampled_indices,
+                                first_nonbatch_dim=2,
+                            )
+                            sampled_br_done = gather_sampled(
+                                reset_traj_batch.partner_done,
+                                sampled_indices,
+                                first_nonbatch_dim=2,
+                            )
 
                             # for done environments, select data corresponding to the reset_traj_batch states
                             env_state = jax.tree.map(
                                 lambda sampled, original: jnp.where(
-                                    needs_resample.reshape((-1,) + (1,) * (original.ndim - 1)),
-                                    sampled, original
+                                    needs_resample.reshape(
+                                        (-1,) + (1,) * (original.ndim - 1)
+                                    ),
+                                    sampled,
+                                    original,
                                 ),
                                 sampled_env_state,
-                                env_state
+                                env_state,
                             )
-                            obs_0 = jnp.where(needs_resample[:, jnp.newaxis], sampled_conf_obs, last_obs["agent_0"])
-                            obs_1 = jnp.where(needs_resample[:, jnp.newaxis], sampled_br_obs, last_obs["agent_1"])
+                            obs_0 = jnp.where(
+                                needs_resample[:, jnp.newaxis],
+                                sampled_conf_obs,
+                                last_obs["agent_0"],
+                            )
+                            obs_1 = jnp.where(
+                                needs_resample[:, jnp.newaxis],
+                                sampled_br_obs,
+                                last_obs["agent_1"],
+                            )
 
-                            dones_0 = jnp.where(needs_resample, sampled_conf_done, last_dones["agent_0"])
-                            dones_1 = jnp.where(needs_resample, sampled_br_done, last_dones["agent_1"])
+                            dones_0 = jnp.where(
+                                needs_resample, sampled_conf_done, last_dones["agent_0"]
+                            )
+                            dones_1 = jnp.where(
+                                needs_resample, sampled_br_done, last_dones["agent_1"]
+                            )
 
                         else:
-
                             # Reset conf-br data collection from conf-ego states
                             obs_0, obs_1 = last_obs["agent_0"], last_obs["agent_1"]
-                            dones_0, dones_1 = last_dones["agent_0"], last_dones["agent_1"]
+                            dones_0, dones_1 = (
+                                last_dones["agent_0"],
+                                last_dones["agent_1"],
+                            )
 
                         # Get available actions for agent 0 from environment state
-                        avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)
+                        avail_actions = jax.vmap(env.get_avail_actions)(
+                            env_state.env_state
+                        )
                         avail_actions_0 = avail_actions["agent_0"].astype(jnp.float32)
                         avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
                         # Agent_0 (confederate) action
                         # Add one-hot ID of XP teammate
-                        sp_one_hot_id = jnp.eye(config["POP_SIZE"])[current_trained_pop_id]
+                        sp_one_hot_id = jnp.eye(config["POP_SIZE"])[
+                            current_trained_pop_id
+                        ]
                         sp_one_hot_id = jnp.expand_dims(
-                            jnp.expand_dims(
-                                sp_one_hot_id, 0
-                            ), 0
+                            jnp.expand_dims(sp_one_hot_id, 0), 0
                         )
 
                         aux_obs = jnp.repeat(sp_one_hot_id, config["NUM_ENVS"], 1)
@@ -364,7 +507,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             avail_actions=jax.lax.stop_gradient(avail_actions_0),
                             hstate=None,
                             rng=conf_rng,
-                            aux_obs=aux_obs
+                            aux_obs=aux_obs,
                         )
                         logp_0 = pi_0.log_prob(act_0)
 
@@ -380,7 +523,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             avail_actions=jax.lax.stop_gradient(avail_actions_1),
                             hstate=None,
                             rng=br_rng,
-                            aux_obs=aux_obs
+                            aux_obs=aux_obs,
                         )
                         logp_1 = pi_1.log_prob(act_1)
 
@@ -389,15 +532,19 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                         val_1 = val_1.squeeze()
 
                         # Combine actions into the env format
-                        combined_actions = jnp.concatenate([act_0, act_1], axis=0)  # shape (2*num_envs,)
-                        env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                        combined_actions = jnp.concatenate(
+                            [act_0, act_1], axis=0
+                        )  # shape (2*num_envs,)
+                        env_act = unbatchify(
+                            combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                        )
                         env_act = {k: v.flatten() for k, v in env_act.items()}
 
                         # Step env
                         step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                        obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                            step_rngs, env_state, env_act
-                        )
+                        obs_next, env_state_next, reward, done, info = jax.vmap(
+                            env.step, in_axes=(0, 0, 0)
+                        )(step_rngs, env_state, env_act)
                         info_0 = jax.tree.map(lambda x: x[:, 0], info)
                         info_1 = jax.tree.map(lambda x: x[:, 1], info)
 
@@ -411,7 +558,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             obs=obs_0,
                             info=info_0,
                             avail_actions=avail_actions_0,
-                            prev_done=dones_0
+                            prev_done=dones_0,
                         )
                         # Store agent_1 (best response) data in transition
                         transition_1 = Transition(
@@ -423,10 +570,18 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             obs=obs_1,
                             info=info_1,
                             avail_actions=avail_actions_1,
-                            prev_done=dones_1
+                            prev_done=dones_1,
                         )
                         # Pass reset_traj_batch and init_br_hstate through unchanged in the state tuple
-                        new_runner_state = (train_state, env_state_next, obs_next, done, rng, current_trained_pop_id, reset_traj_batch)
+                        new_runner_state = (
+                            train_state,
+                            env_state_next,
+                            obs_next,
+                            done,
+                            rng,
+                            current_trained_pop_id,
+                            reset_traj_batch,
+                        )
                         return new_runner_state, (transition_0, transition_1)
 
                     def _env_step_mixed(runner_state, unused):
@@ -434,22 +589,39 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                         agent_0 = confederate, agent_1 = ego OR best response
                         Returns a ResetTransition for resetting to env states encountered here.
                         """
-                        train_state_conf, ego_param, env_state, last_obs, last_dones, rng, current_trained_pop_id = runner_state
-                        rng, act_rng, ego_act_rng, br_act_rng, partner_choice_rng, step_rng = jax.random.split(rng, 6)
+                        (
+                            train_state_conf,
+                            ego_param,
+                            env_state,
+                            last_obs,
+                            last_dones,
+                            rng,
+                            current_trained_pop_id,
+                        ) = runner_state
+                        (
+                            rng,
+                            act_rng,
+                            ego_act_rng,
+                            br_act_rng,
+                            partner_choice_rng,
+                            step_rng,
+                        ) = jax.random.split(rng, 6)
 
                         obs_0 = last_obs["agent_0"]
                         obs_1 = last_obs["agent_1"]
 
                         # Get available actions for agent 0 from environment state
-                        avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)
+                        avail_actions = jax.vmap(env.get_avail_actions)(
+                            env_state.env_state
+                        )
                         avail_actions_0 = avail_actions["agent_0"].astype(jnp.float32)
                         avail_actions_1 = avail_actions["agent_1"].astype(jnp.float32)
 
-                        xp_one_hot_id = jnp.eye(config["POP_SIZE"])[current_trained_pop_id]
+                        xp_one_hot_id = jnp.eye(config["POP_SIZE"])[
+                            current_trained_pop_id
+                        ]
                         xp_one_hot_id = jnp.expand_dims(
-                            jnp.expand_dims(
-                                xp_one_hot_id, 0
-                            ), 0
+                            jnp.expand_dims(xp_one_hot_id, 0), 0
                         )
 
                         # Agent_0 (confederate) action using policy interface
@@ -463,7 +635,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             avail_actions=jax.lax.stop_gradient(avail_actions_0),
                             hstate=None,
                             rng=act_rng,
-                            aux_obs=aux_obs
+                            aux_obs=aux_obs,
                         )
                         logp_0 = pi_0.log_prob(act_0)
 
@@ -479,7 +651,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             avail_actions=jax.lax.stop_gradient(avail_actions_1),
                             hstate=None,
                             rng=ego_act_rng,
-                            aux_obs=aux_obs
+                            aux_obs=aux_obs,
                         )
                         act_br, _, _, _ = policy.get_action_value_policy(
                             params=train_state.params,
@@ -488,25 +660,32 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             avail_actions=jax.lax.stop_gradient(avail_actions_1),
                             hstate=None,
                             rng=br_act_rng,
-                            aux_obs=aux_obs
+                            aux_obs=aux_obs,
                         )
 
                         act_ego = act_ego.squeeze()
                         act_br = act_br.squeeze()
                         # Agent 1 (ego or best response) action - choose between ego and best response
-                        partner_choice = jax.random.randint(partner_choice_rng, shape=(config["NUM_ENVS"],), minval=0, maxval=2)
+                        partner_choice = jax.random.randint(
+                            partner_choice_rng,
+                            shape=(config["NUM_ENVS"],),
+                            minval=0,
+                            maxval=2,
+                        )
                         act_1 = jnp.where(partner_choice == 0, act_ego, act_br)
 
                         # Combine actions into the env format
                         combined_actions = jnp.concatenate([act_0, act_1], axis=0)
-                        env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                        env_act = unbatchify(
+                            combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                        )
                         env_act = {k: v.flatten() for k, v in env_act.items()}
 
                         # Step env
                         step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                        obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                            step_rngs, env_state, env_act
-                        )
+                        obs_next, env_state_next, _reward, done, _info = jax.vmap(
+                            env.step, in_axes=(0, 0, 0)
+                        )(step_rngs, env_state, env_act)
 
                         reset_transition = ResetTransition(
                             # all of these are from before env step
@@ -517,34 +696,121 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             partner_done=last_dones["agent_1"],
                             conf_hstate=None,
                             # we record the best response hstate because we use it to reset the best response
-                            partner_hstate=None
+                            partner_hstate=None,
                         )
-                        new_runner_state = (train_state_conf, ego_param, env_state_next, obs_next, done, rng, current_trained_pop_id)
+                        new_runner_state = (
+                            train_state_conf,
+                            ego_param,
+                            env_state_next,
+                            obs_next,
+                            done,
+                            rng,
+                            current_trained_pop_id,
+                        )
                         return new_runner_state, reset_transition
 
                     # Do XP rollout (based on train_state params and the param in pop_buffer identified in Step 1)
-                    runner_state_xp = (train_state, xp_param, max_means_id, env_state_xp, obsv_xp, last_dones_xp, rng_xp)
+                    runner_state_xp = (
+                        train_state,
+                        xp_param,
+                        max_means_id,
+                        env_state_xp,
+                        obsv_xp,
+                        last_dones_xp,
+                        rng_xp,
+                    )
                     runner_state_xp, traj_batch_xp = jax.lax.scan(
-                        _env_step_conf_ego, runner_state_xp, None, config["ROLLOUT_LENGTH"])
-                    (train_state, xp_param, max_means_id, env_state_xp, last_obs_xp, last_dones_xp, rng_xp) = runner_state_xp
+                        _env_step_conf_ego,
+                        runner_state_xp,
+                        None,
+                        config["ROLLOUT_LENGTH"],
+                    )
+                    (
+                        train_state,
+                        xp_param,
+                        max_means_id,
+                        env_state_xp,
+                        last_obs_xp,
+                        last_dones_xp,
+                        rng_xp,
+                    ) = runner_state_xp
 
                     # Do self-play (based on train_state params) rollout like in the IPPO code
-                    runner_state_sp = (train_state, env_state_sp, obsv_sp, last_dones_sp, rng_sp, num_prev_trained_conf, None)
-                    runner_state_sp, (traj_batch_sp_agent0, traj_batch_sp_agent1) = jax.lax.scan(
-                        _env_step_conf_br, runner_state_sp, None, config["ROLLOUT_LENGTH"])
-                    (train_state, env_state_sp, last_obs_sp, last_dones_sp, rng_sp, num_prev_trained_conf, mp_traj_batch) = runner_state_sp
+                    runner_state_sp = (
+                        train_state,
+                        env_state_sp,
+                        obsv_sp,
+                        last_dones_sp,
+                        rng_sp,
+                        num_prev_trained_conf,
+                        None,
+                    )
+                    runner_state_sp, (traj_batch_sp_agent0, traj_batch_sp_agent1) = (
+                        jax.lax.scan(
+                            _env_step_conf_br,
+                            runner_state_sp,
+                            None,
+                            config["ROLLOUT_LENGTH"],
+                        )
+                    )
+                    (
+                        train_state,
+                        env_state_sp,
+                        last_obs_sp,
+                        last_dones_sp,
+                        rng_sp,
+                        num_prev_trained_conf,
+                        _mp_traj_batch,
+                    ) = runner_state_sp
 
                     # Step 4
                     # Do MP rollout (based on train_state params and the param in pop_buffer identified in Step 1)
-                    runner_state_mp = (train_state, xp_param, env_state_mp, obsv_mp, last_dones_mp, rng_mp, num_prev_trained_conf)
+                    runner_state_mp = (
+                        train_state,
+                        xp_param,
+                        env_state_mp,
+                        obsv_mp,
+                        last_dones_mp,
+                        rng_mp,
+                        num_prev_trained_conf,
+                    )
                     runner_state_mp, traj_batch_mp = jax.lax.scan(
-                        _env_step_mixed, runner_state_mp, None, config["ROLLOUT_LENGTH"])
-                    (train_state, xp_param, env_state_mp, last_obs_mp, last_dones_mp, rng_mp, num_prev_trained_conf) = runner_state_mp
+                        _env_step_mixed, runner_state_mp, None, config["ROLLOUT_LENGTH"]
+                    )
+                    (
+                        train_state,
+                        xp_param,
+                        env_state_mp,
+                        last_obs_mp,
+                        last_dones_mp,
+                        rng_mp,
+                        num_prev_trained_conf,
+                    ) = runner_state_mp
 
-                    runner_state_smp = (train_state, env_state_mp2, obsv_mp2, last_dones_mp2, rng_mp2, num_prev_trained_conf, traj_batch_mp)
+                    runner_state_smp = (
+                        train_state,
+                        env_state_mp2,
+                        obsv_mp2,
+                        last_dones_mp2,
+                        rng_mp2,
+                        num_prev_trained_conf,
+                        traj_batch_mp,
+                    )
                     runner_state_smp, (traj_batch_smp0, traj_batch_smp1) = jax.lax.scan(
-                        _env_step_conf_br, runner_state_smp, None, config["ROLLOUT_LENGTH"])
-                    (train_state, env_state_mp2, last_obs_mp2, last_dones_mp2, rng_mp2, num_prev_trained_conf, mp2_traj_batch) = runner_state_smp
+                        _env_step_conf_br,
+                        runner_state_smp,
+                        None,
+                        config["ROLLOUT_LENGTH"],
+                    )
+                    (
+                        train_state,
+                        env_state_mp2,
+                        last_obs_mp2,
+                        last_dones_mp2,
+                        rng_mp2,
+                        num_prev_trained_conf,
+                        _mp2_traj_batch,
+                    ) = runner_state_smp
 
                     def _calculate_gae(traj_batch, last_val):
                         def _get_advantages(gae_and_next_value, transition):
@@ -554,10 +820,17 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                                 transition.value,
                                 transition.reward,
                             )
-                            delta = reward + config["GAMMA"] * next_value * (1 - done) - value
+                            delta = (
+                                reward
+                                + config["GAMMA"] * next_value * (1 - done)
+                                - value
+                            )
                             gae = (
                                 delta
-                                + config["GAMMA"] * config["GAE_LAMBDA"] * (1 - done) * gae
+                                + config["GAMMA"]
+                                * config["GAE_LAMBDA"]
+                                * (1 - done)
+                                * gae
                             )
                             return (gae, value), gae
 
@@ -570,116 +843,213 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                         )
                         return advantages, advantages + traj_batch.value
 
-                    def _compute_advantages_and_targets(env_state, policy, policy_params, policy_hstate,
-                                                    last_obs, last_dones, traj_batch, agent_name, value_idx=None):
-                        '''Value_idx argument is to support the ActorWithDoubleCritic (confederate) policy, which
-                        has two value heads. Value head 0 models the ego agent while value head 1 models the best response.'''
-                        avail_actions = jax.vmap(env.get_avail_actions)(env_state.env_state)[agent_name].astype(jnp.float32)
+                    def _compute_advantages_and_targets(
+                        env_state,
+                        policy,
+                        policy_params,
+                        policy_hstate,
+                        last_obs,
+                        last_dones,
+                        traj_batch,
+                        agent_name,
+                        value_idx=None,
+                    ):
+                        """Value_idx argument is to support the ActorWithDoubleCritic (confederate) policy, which
+                        has two value heads. Value head 0 models the ego agent while value head 1 models the best response."""
+                        avail_actions = jax.vmap(env.get_avail_actions)(
+                            env_state.env_state
+                        )[agent_name].astype(jnp.float32)
 
                         # Add one-hot ID of interaction teammate
                         xp_one_hot_id = jnp.eye(config["POP_SIZE"])[value_idx]
                         xp_one_hot_id = jnp.expand_dims(
-                            jnp.expand_dims(
-                                xp_one_hot_id, 0
-                            ), 0
+                            jnp.expand_dims(xp_one_hot_id, 0), 0
                         )
 
                         # Agent_0 (confederate) action using policy interface
-                        aux_obs = jnp.repeat(xp_one_hot_id, last_obs[agent_name].shape[0], axis=1)
+                        aux_obs = jnp.repeat(
+                            xp_one_hot_id, last_obs[agent_name].shape[0], axis=1
+                        )
 
                         _, vals, _, _ = policy.get_action_value_policy(
                             params=policy_params,
-                            obs=last_obs[agent_name].reshape(1, last_obs[agent_name].shape[0], -1),
-                            done=last_dones[agent_name].reshape(1, last_obs[agent_name].shape[0]),
+                            obs=last_obs[agent_name].reshape(
+                                1, last_obs[agent_name].shape[0], -1
+                            ),
+                            done=last_dones[agent_name].reshape(
+                                1, last_obs[agent_name].shape[0]
+                            ),
                             avail_actions=jax.lax.stop_gradient(avail_actions),
                             hstate=policy_hstate,
-                            rng=jax.random.PRNGKey(0),  # dummy key as we don't sample actions
-                            aux_obs=aux_obs
+                            rng=jax.random.PRNGKey(
+                                0
+                            ),  # dummy key as we don't sample actions
+                            aux_obs=aux_obs,
                         )
                         last_val = vals.squeeze()
                         advantages, targets = _calculate_gae(traj_batch, last_val)
                         return advantages, targets
 
                     # 5a) Compute conf advantages for XP (conf-ego) interaction
-                    advantages_xp_conf, targets_xp_conf = _compute_advantages_and_targets(
-                        env_state_xp, policy, train_state.params, None,
-                        last_obs_xp, last_dones_xp, traj_batch_xp, "agent_0", value_idx=max_means_id)
+                    advantages_xp_conf, targets_xp_conf = (
+                        _compute_advantages_and_targets(
+                            env_state_xp,
+                            policy,
+                            train_state.params,
+                            None,
+                            last_obs_xp,
+                            last_dones_xp,
+                            traj_batch_xp,
+                            "agent_0",
+                            value_idx=max_means_id,
+                        )
+                    )
 
                     # 5b) Compute conf and br advantages for SP (conf-br) interaction
-                    advantages_sp_conf, targets_sp_conf = _compute_advantages_and_targets(
-                        env_state_sp, policy, train_state.params, None,
-                        last_obs_sp, last_dones_sp, traj_batch_sp_agent0, "agent_0", value_idx=num_prev_trained_conf)
+                    advantages_sp_conf, targets_sp_conf = (
+                        _compute_advantages_and_targets(
+                            env_state_sp,
+                            policy,
+                            train_state.params,
+                            None,
+                            last_obs_sp,
+                            last_dones_sp,
+                            traj_batch_sp_agent0,
+                            "agent_0",
+                            value_idx=num_prev_trained_conf,
+                        )
+                    )
 
                     advantages_sp_br, targets_sp_br = _compute_advantages_and_targets(
-                        env_state_sp, policy, train_state.params, None,
-                        last_obs_sp, last_dones_sp, traj_batch_sp_agent1, "agent_1", value_idx=num_prev_trained_conf)
+                        env_state_sp,
+                        policy,
+                        train_state.params,
+                        None,
+                        last_obs_sp,
+                        last_dones_sp,
+                        traj_batch_sp_agent1,
+                        "agent_1",
+                        value_idx=num_prev_trained_conf,
+                    )
 
                     # 5c) Compute advantages from MP interactions
-                    advantages_mp_conf, targets_mp_conf = _compute_advantages_and_targets(
-                        env_state_mp2, policy, train_state.params, None,
-                        last_obs_mp2, last_dones_mp2, traj_batch_smp0, "agent_0", value_idx=num_prev_trained_conf)
+                    advantages_mp_conf, targets_mp_conf = (
+                        _compute_advantages_and_targets(
+                            env_state_mp2,
+                            policy,
+                            train_state.params,
+                            None,
+                            last_obs_mp2,
+                            last_dones_mp2,
+                            traj_batch_smp0,
+                            "agent_0",
+                            value_idx=num_prev_trained_conf,
+                        )
+                    )
 
                     advantages_mp_br, targets_mp_br = _compute_advantages_and_targets(
-                        env_state_mp2, policy, train_state.params, None,
-                        last_obs_mp2, last_dones_mp2, traj_batch_smp1, "agent_1", value_idx=num_prev_trained_conf)
+                        env_state_mp2,
+                        policy,
+                        train_state.params,
+                        None,
+                        last_obs_mp2,
+                        last_dones_mp2,
+                        traj_batch_smp1,
+                        "agent_1",
+                        value_idx=num_prev_trained_conf,
+                    )
 
                     def _update_epoch(update_state, unused):
                         def _compute_ppo_value_loss(pred_value, traj_batch, target_v):
-                            '''Value loss function for PPO'''
+                            """Value loss function for PPO"""
                             value_pred_clipped = traj_batch.value + (
                                 pred_value - traj_batch.value
-                                ).clip(
-                                -config["CLIP_EPS"], config["CLIP_EPS"])
+                            ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                             value_losses = jnp.square(pred_value - target_v)
-                            value_losses_clipped = jnp.square(value_pred_clipped - target_v)
-                            value_loss = (
-                                jnp.maximum(value_losses, value_losses_clipped).mean()
+                            value_losses_clipped = jnp.square(
+                                value_pred_clipped - target_v
                             )
+                            value_loss = jnp.maximum(
+                                value_losses, value_losses_clipped
+                            ).mean()
                             return value_loss
 
                         def _compute_ppo_pg_loss(log_prob, traj_batch, gae):
-                            '''Policy gradient loss function for PPO'''
+                            """Policy gradient loss function for PPO"""
                             ratio = jnp.exp(log_prob - traj_batch.log_prob)
                             gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                             pg_loss_1 = ratio * gae_norm
-                            pg_loss_2 = jnp.clip(
-                                ratio,
-                                1.0 - config["CLIP_EPS"],
-                                1.0 + config["CLIP_EPS"]) * gae_norm
+                            pg_loss_2 = (
+                                jnp.clip(
+                                    ratio,
+                                    1.0 - config["CLIP_EPS"],
+                                    1.0 + config["CLIP_EPS"],
+                                )
+                                * gae_norm
+                            )
                             pg_loss = -jnp.mean(jnp.minimum(pg_loss_1, pg_loss_2))
                             return pg_loss
 
                         def _update_minbatch_conf(train_state_conf, batch_infos):
-                            minbatch_xp, minbatch_sp1, minbatch_sp2, minbatch_mp1,  minbatch_mp2, xp_id, sp_id = batch_infos
+                            (
+                                minbatch_xp,
+                                minbatch_sp1,
+                                minbatch_sp2,
+                                minbatch_mp1,
+                                minbatch_mp2,
+                                xp_id,
+                                sp_id,
+                            ) = batch_infos
                             _, traj_batch_xp, advantages_xp, returns_xp = minbatch_xp
-                            _, traj_batch_sp1, advantages_sp1, returns_sp1 = minbatch_sp1
-                            _, traj_batch_sp2, advantages_sp2, returns_sp2 = minbatch_sp2
-                            _, traj_batch_mp1, advantages_mp1, returns_mp1 = minbatch_mp1
-                            _, traj_batch_mp2, advantages_mp2, returns_mp2 = minbatch_mp2
+                            _, traj_batch_sp1, advantages_sp1, returns_sp1 = (
+                                minbatch_sp1
+                            )
+                            _, traj_batch_sp2, advantages_sp2, returns_sp2 = (
+                                minbatch_sp2
+                            )
+                            _, traj_batch_mp1, advantages_mp1, returns_mp1 = (
+                                minbatch_mp1
+                            )
+                            _, traj_batch_mp2, advantages_mp2, returns_mp2 = (
+                                minbatch_mp2
+                            )
 
-                            def _loss_fn_conf(params, traj_batch_xp, gae_xp, target_v_xp,
-                                            traj_batch_sp, gae_sp, target_v_sp,
-                                            traj_batch_sp2, gae_sp2, target_v_sp2,
-                                            traj_batch_mp, gae_mp, target_v_mp,
-                                            traj_batch_mp2, gae_mp2, target_v_mp2):
+                            def _loss_fn_conf(
+                                params,
+                                traj_batch_xp,
+                                gae_xp,
+                                target_v_xp,
+                                traj_batch_sp,
+                                gae_sp,
+                                target_v_sp,
+                                traj_batch_sp2,
+                                gae_sp2,
+                                target_v_sp2,
+                                traj_batch_mp,
+                                gae_mp,
+                                target_v_mp,
+                                traj_batch_mp2,
+                                gae_mp2,
+                                target_v_mp2,
+                            ):
                                 # get policy and value of confederate versus ego and best response agents respectively
                                 xp_one_hot_id = jnp.eye(config["POP_SIZE"])[xp_id]
                                 xp_one_hot_id = jnp.expand_dims(
-                                    jnp.expand_dims(
-                                        xp_one_hot_id, 0
-                                    ), 0
+                                    jnp.expand_dims(xp_one_hot_id, 0), 0
                                 )
 
                                 sp_one_hot_id = jnp.eye(config["POP_SIZE"])[sp_id]
                                 sp_one_hot_id = jnp.expand_dims(
-                                    jnp.expand_dims(
-                                        sp_one_hot_id, 0
-                                    ), 0
+                                    jnp.expand_dims(sp_one_hot_id, 0), 0
                                 )
 
                                 # Agent_0 (confederate) action using policy interface
-                                aux_obs_xp = jnp.repeat(xp_one_hot_id, traj_batch_xp.obs.shape[1], axis=1)
-                                aux_obs_xp = jnp.repeat(aux_obs_xp, traj_batch_xp.obs.shape[0], axis=0)
+                                aux_obs_xp = jnp.repeat(
+                                    xp_one_hot_id, traj_batch_xp.obs.shape[1], axis=1
+                                )
+                                aux_obs_xp = jnp.repeat(
+                                    aux_obs_xp, traj_batch_xp.obs.shape[0], axis=0
+                                )
 
                                 _, value_xp, pi_xp, _ = policy.get_action_value_policy(
                                     params=params,
@@ -687,30 +1057,42 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                                     done=traj_batch_xp.prev_done,
                                     avail_actions=traj_batch_xp.avail_actions,
                                     hstate=None,
-                                    rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                                    aux_obs=aux_obs_xp
+                                    rng=jax.random.PRNGKey(
+                                        0
+                                    ),  # only used for action sampling, which is not used here
+                                    aux_obs=aux_obs_xp,
                                 )
 
-                                aux_obs_sp = jnp.repeat(xp_one_hot_id, traj_batch_sp.obs.shape[1], axis=1)
-                                aux_obs_sp = jnp.repeat(aux_obs_sp, traj_batch_sp.obs.shape[0], axis=0)
+                                aux_obs_sp = jnp.repeat(
+                                    xp_one_hot_id, traj_batch_sp.obs.shape[1], axis=1
+                                )
+                                aux_obs_sp = jnp.repeat(
+                                    aux_obs_sp, traj_batch_sp.obs.shape[0], axis=0
+                                )
                                 _, value_sp, pi_sp, _ = policy.get_action_value_policy(
                                     params=params,
                                     obs=traj_batch_sp.obs,
                                     done=traj_batch_sp.prev_done,
                                     avail_actions=traj_batch_sp.avail_actions,
                                     hstate=None,
-                                    rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                                    aux_obs=aux_obs_sp
+                                    rng=jax.random.PRNGKey(
+                                        0
+                                    ),  # only used for action sampling, which is not used here
+                                    aux_obs=aux_obs_sp,
                                 )
 
-                                _, value_sp2, pi_sp2, _ = policy.get_action_value_policy(
-                                    params=params,
-                                    obs=traj_batch_sp2.obs,
-                                    done=traj_batch_sp2.prev_done,
-                                    avail_actions=traj_batch_sp2.avail_actions,
-                                    hstate=None,
-                                    rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                                    aux_obs=aux_obs_sp
+                                _, value_sp2, pi_sp2, _ = (
+                                    policy.get_action_value_policy(
+                                        params=params,
+                                        obs=traj_batch_sp2.obs,
+                                        done=traj_batch_sp2.prev_done,
+                                        avail_actions=traj_batch_sp2.avail_actions,
+                                        hstate=None,
+                                        rng=jax.random.PRNGKey(
+                                            0
+                                        ),  # only used for action sampling, which is not used here
+                                        aux_obs=aux_obs_sp,
+                                    )
                                 )
 
                                 _, value_mp, pi_mp, _ = policy.get_action_value_policy(
@@ -719,18 +1101,24 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                                     done=traj_batch_mp.prev_done,
                                     avail_actions=traj_batch_mp.avail_actions,
                                     hstate=None,
-                                    rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                                    aux_obs=aux_obs_sp
+                                    rng=jax.random.PRNGKey(
+                                        0
+                                    ),  # only used for action sampling, which is not used here
+                                    aux_obs=aux_obs_sp,
                                 )
 
-                                _, value_mp2, pi_mp2, _ = policy.get_action_value_policy(
-                                    params=params,
-                                    obs=traj_batch_mp2.obs,
-                                    done=traj_batch_mp2.prev_done,
-                                    avail_actions=traj_batch_mp2.avail_actions,
-                                    hstate=None,
-                                    rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                                    aux_obs=aux_obs_sp
+                                _, value_mp2, pi_mp2, _ = (
+                                    policy.get_action_value_policy(
+                                        params=params,
+                                        obs=traj_batch_mp2.obs,
+                                        done=traj_batch_mp2.prev_done,
+                                        avail_actions=traj_batch_mp2.avail_actions,
+                                        hstate=None,
+                                        rng=jax.random.PRNGKey(
+                                            0
+                                        ),  # only used for action sampling, which is not used here
+                                        aux_obs=aux_obs_sp,
+                                    )
                                 )
 
                                 log_prob_xp = pi_xp.log_prob(traj_batch_xp.action)
@@ -739,19 +1127,37 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                                 log_prob_mp = pi_mp.log_prob(traj_batch_mp.action)
                                 log_prob_mp2 = pi_mp2.log_prob(traj_batch_mp2.action)
 
+                                value_loss_xp = _compute_ppo_value_loss(
+                                    value_xp, traj_batch_xp, target_v_xp
+                                )
+                                value_loss_sp = _compute_ppo_value_loss(
+                                    value_sp, traj_batch_sp, target_v_sp
+                                )
+                                value_loss_sp2 = _compute_ppo_value_loss(
+                                    value_sp2, traj_batch_sp2, target_v_sp2
+                                )
+                                value_loss_mp = _compute_ppo_value_loss(
+                                    value_mp, traj_batch_mp, target_v_mp
+                                )
+                                value_loss_mp2 = _compute_ppo_value_loss(
+                                    value_mp2, traj_batch_mp2, target_v_mp2
+                                )
 
-                                value_loss_xp = _compute_ppo_value_loss(value_xp, traj_batch_xp, target_v_xp)
-                                value_loss_sp = _compute_ppo_value_loss(value_sp, traj_batch_sp, target_v_sp)
-                                value_loss_sp2 = _compute_ppo_value_loss(value_sp2, traj_batch_sp2, target_v_sp2)
-                                value_loss_mp = _compute_ppo_value_loss(value_mp, traj_batch_mp, target_v_mp)
-                                value_loss_mp2 = _compute_ppo_value_loss(value_mp2, traj_batch_mp2, target_v_mp2)
-
-                                pg_loss_xp = _compute_ppo_pg_loss(log_prob_xp, traj_batch_xp, gae_xp)
-                                pg_loss_sp = _compute_ppo_pg_loss(log_prob_sp, traj_batch_sp, gae_sp)
-                                pg_loss_sp2 = _compute_ppo_pg_loss(log_prob_sp2, traj_batch_sp2, gae_sp2)
-                                pg_loss_mp = _compute_ppo_pg_loss(log_prob_mp, traj_batch_mp, gae_mp)
-                                pg_loss_mp2 = _compute_ppo_pg_loss(log_prob_mp2, traj_batch_mp2, gae_mp2)
-
+                                pg_loss_xp = _compute_ppo_pg_loss(
+                                    log_prob_xp, traj_batch_xp, gae_xp
+                                )
+                                pg_loss_sp = _compute_ppo_pg_loss(
+                                    log_prob_sp, traj_batch_sp, gae_sp
+                                )
+                                pg_loss_sp2 = _compute_ppo_pg_loss(
+                                    log_prob_sp2, traj_batch_sp2, gae_sp2
+                                )
+                                pg_loss_mp = _compute_ppo_pg_loss(
+                                    log_prob_mp, traj_batch_mp, gae_mp
+                                )
+                                pg_loss_mp2 = _compute_ppo_pg_loss(
+                                    log_prob_mp2, traj_batch_mp2, gae_mp2
+                                )
 
                                 # Entropy for interaction with ego agent
                                 entropy_xp = jnp.mean(pi_xp.entropy())
@@ -760,83 +1166,196 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                                 entropy_mp = jnp.mean(pi_mp.entropy())
                                 entropy_mp2 = jnp.mean(pi_mp2.entropy())
 
-                                xp_pg_weight = -config["COMEDI_ALPHA"] # negate to minimize the ego agent's PG objective
+                                xp_pg_weight = -config[
+                                    "COMEDI_ALPHA"
+                                ]  # negate to minimize the ego agent's PG objective
                                 sp_pg_weight = 1.0
                                 mp2_pg_weight = config["COMEDI_BETA"]
 
-                                xp_loss = xp_pg_weight * pg_loss_xp + config["VF_COEF"] * value_loss_xp - config["ENT_COEF"] * entropy_xp
-                                sp_loss = sp_pg_weight * pg_loss_sp + config["VF_COEF"] * value_loss_sp - config["ENT_COEF"] * entropy_sp
-                                sp2_loss = sp_pg_weight * pg_loss_sp2 + config["VF_COEF"] * value_loss_sp2 - config["ENT_COEF"] * entropy_sp2
-                                mp_loss = mp2_pg_weight * pg_loss_mp + config["VF_COEF"] * value_loss_mp - config["ENT_COEF"] * entropy_mp
-                                mp2_loss = mp2_pg_weight * pg_loss_mp2 + config["VF_COEF"] * value_loss_mp2 - config["ENT_COEF"] * entropy_mp2
+                                xp_loss = (
+                                    xp_pg_weight * pg_loss_xp
+                                    + config["VF_COEF"] * value_loss_xp
+                                    - config["ENT_COEF"] * entropy_xp
+                                )
+                                sp_loss = (
+                                    sp_pg_weight * pg_loss_sp
+                                    + config["VF_COEF"] * value_loss_sp
+                                    - config["ENT_COEF"] * entropy_sp
+                                )
+                                sp2_loss = (
+                                    sp_pg_weight * pg_loss_sp2
+                                    + config["VF_COEF"] * value_loss_sp2
+                                    - config["ENT_COEF"] * entropy_sp2
+                                )
+                                mp_loss = (
+                                    mp2_pg_weight * pg_loss_mp
+                                    + config["VF_COEF"] * value_loss_mp
+                                    - config["ENT_COEF"] * entropy_mp
+                                )
+                                mp2_loss = (
+                                    mp2_pg_weight * pg_loss_mp2
+                                    + config["VF_COEF"] * value_loss_mp2
+                                    - config["ENT_COEF"] * entropy_mp2
+                                )
 
-                                total_loss = sp_loss + sp2_loss + xp_loss + mp2_loss + mp_loss
-                                return total_loss, (value_loss_xp, value_loss_sp + value_loss_sp2, value_loss_mp + value_loss_mp2,
-                                                    pg_loss_xp, pg_loss_sp + pg_loss_sp2, pg_loss_mp + pg_loss_mp2,
-                                                    entropy_xp, entropy_sp + entropy_sp2, entropy_mp + entropy_mp2)
+                                total_loss = (
+                                    sp_loss + sp2_loss + xp_loss + mp2_loss + mp_loss
+                                )
+                                return total_loss, (
+                                    value_loss_xp,
+                                    value_loss_sp + value_loss_sp2,
+                                    value_loss_mp + value_loss_mp2,
+                                    pg_loss_xp,
+                                    pg_loss_sp + pg_loss_sp2,
+                                    pg_loss_mp + pg_loss_mp2,
+                                    entropy_xp,
+                                    entropy_sp + entropy_sp2,
+                                    entropy_mp + entropy_mp2,
+                                )
 
                             grad_fn = jax.value_and_grad(_loss_fn_conf, has_aux=True)
                             (loss_val, aux_vals), grads = grad_fn(
                                 train_state_conf.params,
-                                traj_batch_xp, advantages_xp, returns_xp,
-                                traj_batch_sp1, advantages_sp1, returns_sp1,
-                                traj_batch_sp2, advantages_sp2, returns_sp2,
-                                traj_batch_mp1, advantages_mp1, returns_mp1,
-                                traj_batch_mp2, advantages_mp2, returns_mp2)
-                            train_state_conf = train_state_conf.apply_gradients(grads=grads)
+                                traj_batch_xp,
+                                advantages_xp,
+                                returns_xp,
+                                traj_batch_sp1,
+                                advantages_sp1,
+                                returns_sp1,
+                                traj_batch_sp2,
+                                advantages_sp2,
+                                returns_sp2,
+                                traj_batch_mp1,
+                                advantages_mp1,
+                                returns_mp1,
+                                traj_batch_mp2,
+                                advantages_mp2,
+                                returns_mp2,
+                            )
+                            train_state_conf = train_state_conf.apply_gradients(
+                                grads=grads
+                            )
                             return train_state_conf, (loss_val, aux_vals)
 
                         (
-                            train_state_conf, traj_batch_xp,
-                            traj_batch_sp_conf, traj_batch_sp_br,
-                            traj_batch_mp_conf, traj_batch_mp_br,
-                            advantages_xp_conf, advantages_sp_conf,
-                            advantages_sp_br, advantages_mp_conf,
-                            advantages_mp_br, targets_xp_conf,
-                            targets_sp_conf, targets_sp_br,
-                            targets_mp_conf, targets_mp_br,
-                            rng, xp_id, sp_id
+                            train_state_conf,
+                            traj_batch_xp,
+                            traj_batch_sp_conf,
+                            traj_batch_sp_br,
+                            traj_batch_mp_conf,
+                            traj_batch_mp_br,
+                            advantages_xp_conf,
+                            advantages_sp_conf,
+                            advantages_sp_br,
+                            advantages_mp_conf,
+                            advantages_mp_br,
+                            targets_xp_conf,
+                            targets_sp_conf,
+                            targets_sp_br,
+                            targets_mp_conf,
+                            targets_mp_br,
+                            rng,
+                            xp_id,
+                            sp_id,
                         ) = update_state
 
-                        rng, perm_rng_xp, perm_rng_sp_conf, perm_rng_sp_br, perm_rng_mp2_conf, perm_rng_mp2_br = jax.random.split(rng, 6)
+                        (
+                            rng,
+                            perm_rng_xp,
+                            perm_rng_sp_conf,
+                            perm_rng_sp_br,
+                            perm_rng_mp2_conf,
+                            perm_rng_mp2_br,
+                        ) = jax.random.split(rng, 6)
 
                         # Create minibatches for each agent and interaction type
                         minibatches_xp = _create_minibatches(
-                            traj_batch_xp, advantages_xp_conf, targets_xp_conf, None,
-                            config["NUM_ENVS"], config["NUM_MINIBATCHES"], perm_rng_xp
+                            traj_batch_xp,
+                            advantages_xp_conf,
+                            targets_xp_conf,
+                            None,
+                            config["NUM_ENVS"],
+                            config["NUM_MINIBATCHES"],
+                            perm_rng_xp,
                         )
                         minibatches_sp_conf = _create_minibatches(
-                            traj_batch_sp_conf, advantages_sp_conf, targets_sp_conf, None,
-                            config["NUM_ENVS"], config["NUM_MINIBATCHES"], perm_rng_sp_conf
+                            traj_batch_sp_conf,
+                            advantages_sp_conf,
+                            targets_sp_conf,
+                            None,
+                            config["NUM_ENVS"],
+                            config["NUM_MINIBATCHES"],
+                            perm_rng_sp_conf,
                         )
                         minibatches_sp_br = _create_minibatches(
-                            traj_batch_sp_br, advantages_sp_br, targets_sp_br, None,
-                            config["NUM_ENVS"], config["NUM_MINIBATCHES"], perm_rng_sp_br
+                            traj_batch_sp_br,
+                            advantages_sp_br,
+                            targets_sp_br,
+                            None,
+                            config["NUM_ENVS"],
+                            config["NUM_MINIBATCHES"],
+                            perm_rng_sp_br,
                         )
                         minibatches_mp_conf = _create_minibatches(
-                            traj_batch_mp_conf, advantages_mp_conf, targets_mp_conf, None,
-                            config["NUM_ENVS"], config["NUM_MINIBATCHES"], perm_rng_mp2_conf
+                            traj_batch_mp_conf,
+                            advantages_mp_conf,
+                            targets_mp_conf,
+                            None,
+                            config["NUM_ENVS"],
+                            config["NUM_MINIBATCHES"],
+                            perm_rng_mp2_conf,
                         )
                         minibatches_mp_br = _create_minibatches(
-                            traj_batch_mp_br, advantages_mp_br, targets_mp_br, None,
-                            config["NUM_ENVS"], config["NUM_MINIBATCHES"], perm_rng_mp2_br
+                            traj_batch_mp_br,
+                            advantages_mp_br,
+                            targets_mp_br,
+                            None,
+                            config["NUM_ENVS"],
+                            config["NUM_MINIBATCHES"],
+                            perm_rng_mp2_br,
                         )
 
                         # Update confederate
-                        repeated_xp_id = jnp.repeat(xp_id, minibatches_xp[1].obs.shape[0], axis=0)
-                        repeated_sp_id = jnp.repeat(sp_id, minibatches_sp_br[1].obs.shape[0], axis=0)
+                        repeated_xp_id = jnp.repeat(
+                            xp_id, minibatches_xp[1].obs.shape[0], axis=0
+                        )
+                        repeated_sp_id = jnp.repeat(
+                            sp_id, minibatches_sp_br[1].obs.shape[0], axis=0
+                        )
                         train_state_conf, total_loss_conf = jax.lax.scan(
-                            _update_minbatch_conf, train_state_conf, (
-                                minibatches_xp, minibatches_sp_conf, minibatches_sp_br,
-                                minibatches_mp_conf, minibatches_mp_br, repeated_xp_id, repeated_sp_id
-                            )
+                            _update_minbatch_conf,
+                            train_state_conf,
+                            (
+                                minibatches_xp,
+                                minibatches_sp_conf,
+                                minibatches_sp_br,
+                                minibatches_mp_conf,
+                                minibatches_mp_br,
+                                repeated_xp_id,
+                                repeated_sp_id,
+                            ),
                         )
 
-                        update_state = (train_state_conf,
-                            traj_batch_xp, traj_batch_sp_conf, traj_batch_sp_br, traj_batch_mp_conf, traj_batch_mp_br,
-                            advantages_xp_conf, advantages_sp_conf, advantages_sp_br, advantages_mp_conf, advantages_mp_br,
-                            targets_xp_conf, targets_sp_conf, targets_sp_br, targets_mp_conf, targets_mp_br,
-                            rng, xp_id, sp_id
+                        update_state = (
+                            train_state_conf,
+                            traj_batch_xp,
+                            traj_batch_sp_conf,
+                            traj_batch_sp_br,
+                            traj_batch_mp_conf,
+                            traj_batch_mp_br,
+                            advantages_xp_conf,
+                            advantages_sp_conf,
+                            advantages_sp_br,
+                            advantages_mp_conf,
+                            advantages_mp_br,
+                            targets_xp_conf,
+                            targets_sp_conf,
+                            targets_sp_br,
+                            targets_mp_conf,
+                            targets_mp_br,
+                            rng,
+                            xp_id,
+                            sp_id,
                         )
                         return update_state, total_loss_conf
 
@@ -844,44 +1363,72 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                     rng, sub_rng = jax.random.split(rng, 2)
                     update_state = (
                         train_state,
-                        traj_batch_xp, traj_batch_sp_agent0,
+                        traj_batch_xp,
+                        traj_batch_sp_agent0,
                         traj_batch_sp_agent1,
-                        traj_batch_smp0, traj_batch_smp1,
+                        traj_batch_smp0,
+                        traj_batch_smp1,
                         advantages_xp_conf,
-                        advantages_sp_conf, advantages_sp_br,
-                        advantages_mp_conf, advantages_mp_br,
-                        targets_xp_conf, targets_sp_conf,
-                        targets_sp_br, targets_mp_conf,
-                        targets_mp_br, sub_rng,
-                        max_means_id, num_prev_trained_conf
+                        advantages_sp_conf,
+                        advantages_sp_br,
+                        advantages_mp_conf,
+                        advantages_mp_br,
+                        targets_xp_conf,
+                        targets_sp_conf,
+                        targets_sp_br,
+                        targets_mp_conf,
+                        targets_mp_br,
+                        sub_rng,
+                        max_means_id,
+                        num_prev_trained_conf,
                     )
                     update_state, conf_losses = jax.lax.scan(
-                        _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                        _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                    )
                     train_state = update_state[0]
 
                     (
-                        conf_value_loss_xp, conf_value_loss_sp, conf_value_loss_mp,
-                        conf_pg_loss_xp, conf_pg_loss_sp, conf_pg_loss_mp,
-                        conf_entropy_xp, conf_entropy_sp, conf_entropy_mp
+                        conf_value_loss_xp,
+                        conf_value_loss_sp,
+                        conf_value_loss_mp,
+                        conf_pg_loss_xp,
+                        conf_pg_loss_sp,
+                        conf_pg_loss_mp,
+                        conf_entropy_xp,
+                        conf_entropy_sp,
+                        conf_entropy_mp,
                     ) = conf_losses[1]
 
                     new_update_runner_state = (
-                        train_state, pop_buffer,
-                        env_state_sp, last_obs_sp,
-                        env_state_xp, last_obs_xp,
-                        env_state_mp, last_obs_mp,
-                        env_state_mp2, last_obs_mp2,
-                        last_dones_xp, last_dones_sp,
-                        last_dones_mp, last_dones_mp2,
-                        rng, update_steps+1, num_prev_trained_conf
+                        train_state,
+                        pop_buffer,
+                        env_state_sp,
+                        last_obs_sp,
+                        env_state_xp,
+                        last_obs_xp,
+                        env_state_mp,
+                        last_obs_mp,
+                        env_state_mp2,
+                        last_obs_mp2,
+                        last_dones_xp,
+                        last_dones_sp,
+                        last_dones_mp,
+                        last_dones_mp2,
+                        rng,
+                        update_steps + 1,
+                        num_prev_trained_conf,
                     )
 
                     # Metrics
                     def mask_and_mean(x, mask):
                         return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
-                    
-                    mask = traj_batch_xp.info.get("returned_episode", jnp.ones_like(traj_batch_xp.reward))
-                    metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_xp.info)
+
+                    mask = traj_batch_xp.info.get(
+                        "returned_episode", jnp.ones_like(traj_batch_xp.reward)
+                    )
+                    metric = jax.tree.map(
+                        lambda x: mask_and_mean(x, mask), traj_batch_xp.info
+                    )
                     metric["update_steps"] = update_steps
                     metric["value_loss_conf_xp"] = conf_value_loss_xp.mean()
                     metric["value_loss_conf_sp"] = conf_value_loss_sp.mean()
@@ -896,120 +1443,218 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                     metric["entropy_conf_mp"] = conf_entropy_mp.mean()
 
                     metric["average_rewards_ego"] = jnp.mean(traj_batch_xp.reward)
-                    metric["average_rewards_br_sp"] = jnp.mean(traj_batch_sp_agent1.reward)
+                    metric["average_rewards_br_sp"] = jnp.mean(
+                        traj_batch_sp_agent1.reward
+                    )
                     metric["average_rewards_br_mp2"] = jnp.mean(traj_batch_smp1.reward)
 
-                    return (new_update_runner_state, checkpoint_array, ckpt_idx+1), metric
+                    return (
+                        new_update_runner_state,
+                        checkpoint_array,
+                        ckpt_idx + 1,
+                    ), metric
 
                 # XP eval against all policies in the buffer
-                xp_eval_returns = jax.tree.map(lambda x: x.mean(axis=(-2, -1)),
+                xp_eval_returns = jax.tree.map(
+                    lambda x: x.mean(axis=(-2, -1)),
                     jax.vmap(per_id_run_episode_fixed_rng, in_axes=(None, 0))(
-                        train_state.params,jnp.arange(config["POP_SIZE"])))
+                        train_state.params, jnp.arange(config["POP_SIZE"])
+                    ),
+                )
 
                 # SP performance against itself
-                sp_eval_returns = jax.tree.map(lambda x: x.mean(), run_episodes(
-                    eval_rng, env,
-                    agent_0_param=train_state.params, agent_0_policy=policy,
-                    agent_1_param=train_state.params, agent_1_policy=policy,
-                    max_episode_steps=config["ROLLOUT_LENGTH"],
-                    num_eps=config["NUM_EVAL_EPISODES"]
-                ))
-
+                sp_eval_returns = jax.tree.map(
+                    lambda x: x.mean(),
+                    run_episodes(
+                        eval_rng,
+                        env,
+                        agent_0_param=train_state.params,
+                        agent_0_policy=policy,
+                        agent_1_param=train_state.params,
+                        agent_1_policy=policy,
+                        max_episode_steps=config["ROLLOUT_LENGTH"],
+                        num_eps=config["NUM_EVAL_EPISODES"],
+                    ),
+                )
 
                 update_steps = 0
-                init_done_xp = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
-                init_done_sp = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
-                init_done_mp = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
-                init_done_mp2 = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
+                init_done_xp = {
+                    k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                    for k in env.agents + ["__all__"]
+                }
+                init_done_sp = {
+                    k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                    for k in env.agents + ["__all__"]
+                }
+                init_done_mp = {
+                    k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                    for k in env.agents + ["__all__"]
+                }
+                init_done_mp2 = {
+                    k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                    for k in env.agents + ["__all__"]
+                }
 
                 update_runner_state = (
-                    train_state, pop_buffer,
-                    env_state_sp, obsv_sp,
-                    env_state_xp, obsv_xp,
-                    env_state_mp, obsv_mp,
-                    env_state_mp2, obsv_mp2,
-                    init_done_xp, init_done_sp,
-                    init_done_mp, init_done_mp2,
-                    rng, update_steps,
-                    num_existing_agents
+                    train_state,
+                    pop_buffer,
+                    env_state_sp,
+                    obsv_sp,
+                    env_state_xp,
+                    obsv_xp,
+                    env_state_mp,
+                    obsv_mp,
+                    env_state_mp2,
+                    obsv_mp2,
+                    init_done_xp,
+                    init_done_sp,
+                    init_done_mp,
+                    init_done_mp2,
+                    rng,
+                    update_steps,
+                    num_existing_agents,
                 )
 
                 checkpoint_array = init_ckpt_array(train_state.params)
                 ckpt_idx = 0
-                update_with_ckpt_runner_state = (update_runner_state, checkpoint_array, ckpt_idx, xp_eval_returns, sp_eval_returns)
+                update_with_ckpt_runner_state = (
+                    update_runner_state,
+                    checkpoint_array,
+                    ckpt_idx,
+                    xp_eval_returns,
+                    sp_eval_returns,
+                )
 
                 def _update_step_with_ckpt(state_with_ckpt, unused):
 
-                    (update_runner_state, checkpoint_array, ckpt_idx, xp_eval_returns, sp_eval_returns) = state_with_ckpt
+                    (
+                        update_runner_state,
+                        checkpoint_array,
+                        ckpt_idx,
+                        xp_eval_returns,
+                        sp_eval_returns,
+                    ) = state_with_ckpt
                     train_state = update_runner_state[0]
 
                     # Single PPO update
                     new_state_with_ckpt, metric = _update_step(
-                        (update_runner_state, checkpoint_array, ckpt_idx),
-                        None
+                        (update_runner_state, checkpoint_array, ckpt_idx), None
                     )
                     new_update_runner_state = new_state_with_ckpt[0]
-                    rng, update_steps = new_update_runner_state[-3], new_update_runner_state[-2]
+                    rng, update_steps = (
+                        new_update_runner_state[-3],
+                        new_update_runner_state[-2],
+                    )
 
                     # Decide if we store a checkpoint
                     # update steps is 1-indexed because it was incremented at the end of the update step
-                    to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                            jnp.equal(update_steps, config["NUM_UPDATES"]))
+                    to_store = jnp.logical_or(
+                        jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                        jnp.equal(update_steps, config["NUM_UPDATES"]),
+                    )
 
                     def store_and_eval_ckpt(args):
                         ckpt_arr_conf, rng, cidx, _, _ = args
                         new_ckpt_arr_conf = jax.tree.map(
                             lambda c_arr, p: c_arr.at[cidx].set(p),
-                            ckpt_arr_conf, train_state.params
+                            ckpt_arr_conf,
+                            train_state.params,
                         )
 
                         # Eval trained agent against all params in the pool
-                        xp_eval_returns = jax.tree.map(lambda x: x.mean(axis=(-2, -1)),
+                        xp_eval_returns = jax.tree.map(
+                            lambda x: x.mean(axis=(-2, -1)),
                             jax.vmap(per_id_run_episode_fixed_rng, in_axes=(None, 0))(
-                                train_state.params, jnp.arange(config["POP_SIZE"])))
+                                train_state.params, jnp.arange(config["POP_SIZE"])
+                            ),
+                        )
                         # Eval trained agent against itself
-                        sp_eval_returns = jax.tree.map(lambda x: x.mean(), run_episodes(
-                            eval_rng, env,
-                            agent_0_param=train_state.params, agent_0_policy=policy,
-                            agent_1_param=train_state.params, agent_1_policy=policy,
-                            max_episode_steps=config["ROLLOUT_LENGTH"],
-                            num_eps=config["NUM_EVAL_EPISODES"]
-                        ))
+                        sp_eval_returns = jax.tree.map(
+                            lambda x: x.mean(),
+                            run_episodes(
+                                eval_rng,
+                                env,
+                                agent_0_param=train_state.params,
+                                agent_0_policy=policy,
+                                agent_1_param=train_state.params,
+                                agent_1_policy=policy,
+                                max_episode_steps=config["ROLLOUT_LENGTH"],
+                                num_eps=config["NUM_EVAL_EPISODES"],
+                            ),
+                        )
 
-                        return (new_ckpt_arr_conf, rng, cidx + 1, xp_eval_returns, sp_eval_returns)
+                        return (
+                            new_ckpt_arr_conf,
+                            rng,
+                            cidx + 1,
+                            xp_eval_returns,
+                            sp_eval_returns,
+                        )
 
                     def skip_ckpt(args):
                         return args
 
                     rng, store_and_eval_rng = jax.random.split(rng, 2)
-                    (checkpoint_array, store_and_eval_rng, ckpt_idx, xp_eval_returns, sp_eval_returns) = jax.lax.cond(
+                    (
+                        checkpoint_array,
+                        store_and_eval_rng,
+                        ckpt_idx,
+                        xp_eval_returns,
+                        sp_eval_returns,
+                    ) = jax.lax.cond(
                         to_store,
                         store_and_eval_ckpt,
                         skip_ckpt,
-                        (checkpoint_array, store_and_eval_rng, ckpt_idx, xp_eval_returns, sp_eval_returns)
+                        (
+                            checkpoint_array,
+                            store_and_eval_rng,
+                            ckpt_idx,
+                            xp_eval_returns,
+                            sp_eval_returns,
+                        ),
                     )
 
-                    return (new_update_runner_state, checkpoint_array,
-                            ckpt_idx, xp_eval_returns, sp_eval_returns), (metric, xp_eval_returns, sp_eval_returns)
+                    return (
+                        new_update_runner_state,
+                        checkpoint_array,
+                        ckpt_idx,
+                        xp_eval_returns,
+                        sp_eval_returns,
+                    ), (metric, xp_eval_returns, sp_eval_returns)
 
-                new_update_with_ckpt_runner_state, (metric, xp_eval_returns, sp_eval_returns) = jax.lax.scan(
+                (
+                    new_update_with_ckpt_runner_state,
+                    (metric, xp_eval_returns, sp_eval_returns),
+                ) = jax.lax.scan(
                     _update_step_with_ckpt,
                     update_with_ckpt_runner_state,
                     xs=None,  # No per-step input data
                     length=config["NUM_UPDATES"],
                 )
-                new_update_runner_state, new_checkpoint_array, _, _ ,_ = new_update_with_ckpt_runner_state
+                new_update_runner_state, new_checkpoint_array, _, _, _ = (
+                    new_update_with_ckpt_runner_state
+                )
                 final_train_state = new_update_runner_state[0]
 
-                updated_pop_buffer = partner_population.add_agent(pop_buffer, final_train_state.params)
+                updated_pop_buffer = partner_population.add_agent(
+                    pop_buffer, final_train_state.params
+                )
                 conf_checkpoints = new_checkpoint_array
-                return updated_pop_buffer, (conf_checkpoints, metric, xp_eval_returns, sp_eval_returns)
+                return updated_pop_buffer, (
+                    conf_checkpoints,
+                    metric,
+                    xp_eval_returns,
+                    sp_eval_returns,
+                )
 
             rngs = jax.random.split(rng, config["PARTNER_POP_SIZE"])
             rng, add_conf_iter_rngs = rngs[0], rngs[1:]
 
             iter_ids = jnp.arange(1, config["PARTNER_POP_SIZE"])
-            final_population_buffer, (conf_checkpoints, metric, xp_eval_returns, sp_eval_returns) = jax.lax.scan(
+            (
+                final_population_buffer,
+                (conf_checkpoints, metric, xp_eval_returns, sp_eval_returns),
+            ) = jax.lax.scan(
                 add_conf_policy, population_buffer, (iter_ids, add_conf_iter_rngs)
             )
 
@@ -1018,39 +1663,41 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                 "checkpoints_conf": conf_checkpoints,
                 "metrics": metric,
                 "last_ep_infos_xp": xp_eval_returns,
-                "last_ep_infos_sp": sp_eval_returns
+                "last_ep_infos_sp": sp_eval_returns,
             }
 
             return out
+
         return train
 
     train_fn = make_comedi_agents(config)
     out = train_fn(train_rng)
     return out
 
+
 def get_comedi_population(config, out, env):
-    '''
+    """
     Get the partner params and partner population for ego training.
-    '''
+    """
     comedi_pop_size = config["algorithm"]["PARTNER_POP_SIZE"]
 
     # partner_params has shape (num_seeds, comedi_pop_size, ...)
-    partner_params = out['final_params_conf']
+    partner_params = out["final_params_conf"]
 
     partner_policy = ActorWithConditionalCriticPolicy(
         action_dim=env.action_space(env.agents[1]).n,
         obs_dim=env.observation_space(env.agents[1]).shape[0],
-        pop_size=comedi_pop_size, # used to create onehot agent id
-        activation=config["algorithm"].get("ACTIVATION", "tanh")
+        pop_size=comedi_pop_size,  # used to create onehot agent id
+        activation=config["algorithm"].get("ACTIVATION", "tanh"),
     )
 
     # Create partner population
     partner_population = AgentPopulation(
-        pop_size=comedi_pop_size,
-        policy_cls=partner_policy
+        pop_size=comedi_pop_size, policy_cls=partner_policy
     )
 
     return partner_params, partner_population
+
 
 def run_comedi(config, wandb_logger):
     algorithm_config = dict(config["algorithm"])
@@ -1069,10 +1716,12 @@ def run_comedi(config, wandb_logger):
     with jax.disable_jit(False):
         vmapped_train_fn = jax.jit(
             jax.vmap(
-                partial(train_comedi_partners, 
-                        wandb_logger=wandb_logger,
-                        env=env, 
-                        config=algorithm_config)
+                partial(
+                    train_comedi_partners,
+                    wandb_logger=wandb_logger,
+                    env=env,
+                    config=algorithm_config,
+                )
             )
         )
         out = vmapped_train_fn(rngs)
@@ -1089,27 +1738,28 @@ def run_comedi(config, wandb_logger):
     partner_params, partner_population = get_comedi_population(config, out, env)
     return partner_params, partner_population
 
+
 def compute_sp_mask_and_ids(pop_size):
-    cross_product = np.meshgrid(
-        np.arange(pop_size),
-        np.arange(pop_size)
-    )
+    cross_product = np.meshgrid(np.arange(pop_size), np.arange(pop_size))
     agent_id_cartesian_product = np.stack([g.ravel() for g in cross_product], axis=-1)
     conf_ids = agent_id_cartesian_product[:, 0]
     ego_ids = agent_id_cartesian_product[:, 1]
-    sp_mask = (conf_ids == ego_ids)
+    sp_mask = conf_ids == ego_ids
     return sp_mask, agent_id_cartesian_product
+
 
 def log_metrics(config, outs, logger, metric_names: tuple, out_savepath):
     metrics = outs["metrics"]
     # trained_pop_size excludes the initial policy
-    num_seeds, pop_size, num_updates = metrics["pg_loss_conf_sp"].shape
+    _num_seeds, pop_size, num_updates = metrics["pg_loss_conf_sp"].shape
     # TODO: add the eval_ep_last_info metrics
 
     ### Log evaluation metrics
     # xp_eval_returns and sp_eval_returns logged at each evaluation only.
     algorithm_config = config["algorithm"]
-    ckpt_and_eval_interval = max(1, num_updates // max(1, algorithm_config["NUM_CHECKPOINTS"] - 1))
+    ckpt_and_eval_interval = max(
+        1, num_updates // max(1, algorithm_config["NUM_CHECKPOINTS"] - 1)
+    )
     # Steps at which store_and_eval_ckpt fires (0-indexed, matching the update_step logged below)
     eval_steps = list(range(0, num_updates, ckpt_and_eval_interval))
     if (num_updates - 1) not in eval_steps:
@@ -1122,20 +1772,34 @@ def log_metrics(config, outs, logger, metric_names: tuple, out_savepath):
 
     # Average over seeds only (eval episodes and agents already averaged inside scan)
     sp_return_curve = all_returns_sp.mean(axis=0)  # shape (pop_size - 1, num_updates)
-    xp_return_curve = all_returns_xp.mean(axis=0)  # shape (pop_size - 1, num_updates, pop_size)
+    xp_return_curve = all_returns_xp.mean(
+        axis=0
+    )  # shape (pop_size - 1, num_updates, pop_size)
 
     for num_add_policies in range(pop_size):
         for update_step in eval_steps:
-            logger.log_item("Eval/AvgSPReturnCurve", sp_return_curve[num_add_policies, update_step], train_step=update_step)
-            mean_xp_returns = xp_return_curve[num_add_policies, :, :(num_add_policies+1)].mean(axis=-1)
-            logger.log_item("Eval/AvgXPReturnCurve", mean_xp_returns[update_step], train_step=update_step)
+            logger.log_item(
+                "Eval/AvgSPReturnCurve",
+                sp_return_curve[num_add_policies, update_step],
+                train_step=update_step,
+            )
+            mean_xp_returns = xp_return_curve[
+                num_add_policies, :, : (num_add_policies + 1)
+            ].mean(axis=-1)
+            logger.log_item(
+                "Eval/AvgXPReturnCurve",
+                mean_xp_returns[update_step],
+                train_step=update_step,
+            )
     logger.commit()
 
     ### Log population loss as multi-line plots, where each line is a different population member
     # both xp and xp metrics has shape (num_seeds, pop_size - 1, num_updates, update_epochs, num_minibatches)
     # Average over seeds
     processed_losses = {
-        "ConfPGLossSP": np.asarray(metrics["pg_loss_conf_sp"]).mean(axis=0), # desired shape (pop_size - 1, num_updates)
+        "ConfPGLossSP": np.asarray(metrics["pg_loss_conf_sp"]).mean(
+            axis=0
+        ),  # desired shape (pop_size - 1, num_updates)
         "ConfPGLossXP": np.asarray(metrics["pg_loss_conf_xp"]).mean(axis=0),
         "ConfPGLossMP": np.asarray(metrics["pg_loss_conf_mp"]).mean(axis=0),
         "ConfValLossSP": np.asarray(metrics["value_loss_conf_sp"]).mean(axis=0),
@@ -1150,14 +1814,18 @@ def log_metrics(config, outs, logger, metric_names: tuple, out_savepath):
     keys = [f"pair {i}" for i in range(pop_size)]
 
     for loss_name, loss_data in processed_losses.items():
-        logger.log_item(f"Losses/{loss_name}",
-            wandb.plot.line_series(xs=xs, ys=loss_data, keys=keys,
-            title=loss_name, xname="train_step")
+        logger.log_item(
+            f"Losses/{loss_name}",
+            wandb.plot.line_series(
+                xs=xs, ys=loss_data, keys=keys, title=loss_name, xname="train_step"
+            ),
         )
 
     ### Log artifacts (already saved by caller; just publish to wandb)
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="saved_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="saved_train_run", path=out_savepath, type_name="train_run"
+        )
 
     # Cleanup locally logged out files
     if not config["local_logger"]["save_train_out"]:

--- a/teammate_generation/CoMeDi.py
+++ b/teammate_generation/CoMeDi.py
@@ -285,7 +285,8 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             log_prob=logp_0,
                             obs=obs_0,
                             info=info_0,
-                            avail_actions=avail_actions_0
+                            avail_actions=avail_actions_0,
+                            prev_done=last_dones["agent_0"]
                         )
                         new_runner_state = (train_state, xp_param, xp_id, env_state_next, obs_next, done, rng)
                         return new_runner_state, transition
@@ -409,7 +410,8 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             log_prob=logp_0,
                             obs=obs_0,
                             info=info_0,
-                            avail_actions=avail_actions_0
+                            avail_actions=avail_actions_0,
+                            prev_done=dones_0
                         )
                         # Store agent_1 (best response) data in transition
                         transition_1 = Transition(
@@ -420,7 +422,8 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                             log_prob=logp_1,
                             obs=obs_1,
                             info=info_1,
-                            avail_actions=avail_actions_1
+                            avail_actions=avail_actions_1,
+                            prev_done=dones_1
                         )
                         # Pass reset_traj_batch and init_br_hstate through unchanged in the state tuple
                         new_runner_state = (train_state, env_state_next, obs_next, done, rng, current_trained_pop_id, reset_traj_batch)
@@ -681,7 +684,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                                 _, value_xp, pi_xp, _ = policy.get_action_value_policy(
                                     params=params,
                                     obs=traj_batch_xp.obs,
-                                    done=traj_batch_xp.done,
+                                    done=traj_batch_xp.prev_done,
                                     avail_actions=traj_batch_xp.avail_actions,
                                     hstate=None,
                                     rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
@@ -693,7 +696,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                                 _, value_sp, pi_sp, _ = policy.get_action_value_policy(
                                     params=params,
                                     obs=traj_batch_sp.obs,
-                                    done=traj_batch_sp.done,
+                                    done=traj_batch_sp.prev_done,
                                     avail_actions=traj_batch_sp.avail_actions,
                                     hstate=None,
                                     rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
@@ -703,7 +706,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                                 _, value_sp2, pi_sp2, _ = policy.get_action_value_policy(
                                     params=params,
                                     obs=traj_batch_sp2.obs,
-                                    done=traj_batch_sp2.done,
+                                    done=traj_batch_sp2.prev_done,
                                     avail_actions=traj_batch_sp2.avail_actions,
                                     hstate=None,
                                     rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
@@ -713,7 +716,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                                 _, value_mp, pi_mp, _ = policy.get_action_value_policy(
                                     params=params,
                                     obs=traj_batch_mp.obs,
-                                    done=traj_batch_mp.done,
+                                    done=traj_batch_mp.prev_done,
                                     avail_actions=traj_batch_mp.avail_actions,
                                     hstate=None,
                                     rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
@@ -723,7 +726,7 @@ def train_comedi_partners(train_rng, wandb_logger, env, config):
                                 _, value_mp2, pi_mp2, _ = policy.get_action_value_policy(
                                     params=params,
                                     obs=traj_batch_mp2.obs,
-                                    done=traj_batch_mp2.done,
+                                    done=traj_batch_mp2.prev_done,
                                     avail_actions=traj_batch_mp2.avail_actions,
                                     hstate=None,
                                     rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here

--- a/teammate_generation/LBRDiv.py
+++ b/teammate_generation/LBRDiv.py
@@ -1,4 +1,4 @@
-'''Implementation of the LBRDiv teammate generation algorithm (Rahman et al., AAAI 2024)
+"""Implementation of the LBRDiv teammate generation algorithm (Rahman et al., AAAI 2024)
 https://ojs.aaai.org/index.php/AAAI/article/view/29702
 
 Command to run LBRDiv only on LBF:
@@ -8,10 +8,11 @@ Suggested Debug command:
 python teammate_generation/run.py algorithm=lbrdiv/lbf/lbf_7x7_nolevels task=lbf/lbf_7x7_nolevels logger.mode=disabled label=debug algorithm.TOTAL_TIMESTEPS=1e5 algorithm.PARTNER_POP_SIZE=2 train_ego=false run_heldout_eval=false
 
 Limitations: does not support recurrent actors.
-'''
+"""
+
+import logging
 import shutil
 import time
-import logging
 from functools import partial
 
 import hydra
@@ -19,8 +20,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
-from flax.training.train_state import TrainState
 import wandb
+from flax.training.train_state import TrainState
 
 from agents.mlp_actor_critic_agent import ActorWithConditionalCriticPolicy
 from agents.population_interface import AgentPopulation
@@ -29,8 +30,8 @@ from common.run_episodes import run_episodes
 from common.save_load_utils import save_train_run
 from envs import make_env
 from envs.log_wrapper import LogWrapper
-from marl.ppo_utils import unbatchify, _create_minibatches
-from teammate_generation.BRDiv import _get_all_ids, XPTransition, gather_params
+from marl.ppo_utils import _create_minibatches, unbatchify
+from teammate_generation.BRDiv import XPTransition, _get_all_ids, gather_params
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -44,16 +45,24 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
     config["NUM_GAME_AGENTS"] = num_agents
     config["NUM_CONF_ACTORS"] = config["NUM_ENVS"]
     config["NUM_BR_ACTORS"] = config["NUM_ENVS"]
-    config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // (config["ROLLOUT_LENGTH"] * config["NUM_ENVS"])
+    config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // (
+        config["ROLLOUT_LENGTH"] * config["NUM_ENVS"]
+    )
 
     def make_lbrdiv_agents(config):
         def linear_schedule(count):
-            frac = 1.0 - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"])) / config["NUM_UPDATES"]
+            frac = (
+                1.0
+                - (count // (config["NUM_MINIBATCHES"] * config["UPDATE_EPOCHS"]))
+                / config["NUM_UPDATES"]
+            )
             return config["LR"] * frac
 
         def train(rng):
             rng, init_conf_rng, init_br_rng = jax.random.split(rng, 3)
-            all_conf_init_rngs = jax.random.split(init_conf_rng, config["PARTNER_POP_SIZE"])
+            all_conf_init_rngs = jax.random.split(
+                init_conf_rng, config["PARTNER_POP_SIZE"]
+            )
             all_br_init_rngs = jax.random.split(init_br_rng, config["PARTNER_POP_SIZE"])
             identity_matrix = jnp.eye(config["PARTNER_POP_SIZE"])
 
@@ -67,18 +76,28 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     return init_params_conf, init_params_br
 
                 init_all_networks_and_optimizers = jax.vmap(init_single_pair_optimizers)
-                all_conf_params, all_br_params = init_all_networks_and_optimizers(rng_agents, rng_brs)
+                all_conf_params, all_br_params = init_all_networks_and_optimizers(
+                    rng_agents, rng_brs
+                )
 
                 # Define optimizers for both confederate and BR policy
                 tx = optax.chain(
                     optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                    optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"],
-                    eps=1e-5),
+                    optax.adam(
+                        learning_rate=linear_schedule
+                        if config["ANNEAL_LR"]
+                        else config["LR"],
+                        eps=1e-5,
+                    ),
                 )
                 tx_br = optax.chain(
                     optax.clip_by_global_norm(config["MAX_GRAD_NORM"]),
-                    optax.adam(learning_rate=linear_schedule if config["ANNEAL_LR"] else config["LR"],
-                    eps=1e-5),
+                    optax.adam(
+                        learning_rate=linear_schedule
+                        if config["ANNEAL_LR"]
+                        else config["LR"],
+                        eps=1e-5,
+                    ),
                 )
 
                 train_state_conf = TrainState.create(
@@ -107,7 +126,7 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     avail_actions=avail_actions,
                     hstate=hstate,
                     rng=rng,
-                    aux_obs=id[jnp.newaxis, ...]
+                    aux_obs=id[jnp.newaxis, ...],
                 )
                 return act, val, pi, new_hstate
 
@@ -119,7 +138,7 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     avail_actions=avail_actions,
                     hstate=hstate,
                     rng=rng,
-                    aux_obs=id[jnp.newaxis, ...]
+                    aux_obs=id[jnp.newaxis, ...],
                 )
                 return act, val, pi, new_hstate
 
@@ -129,52 +148,75 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 Returns updated runner_state, and Transitions for agent_0 and agent_1
                 """
                 (
-                    all_train_state_conf, all_train_state_br, last_conf_ids, last_br_ids,
-                    env_state, last_obs, last_done, last_conf_h, last_br_h, rng
+                    all_train_state_conf,
+                    all_train_state_br,
+                    last_conf_ids,
+                    last_br_ids,
+                    env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
                 ) = runner_state
-                rng, act0_rng, act1_rng, step_rng, conf_sampling_rng, br_sampling_rng = jax.random.split(rng, 6)
+                (
+                    rng,
+                    act0_rng,
+                    act1_rng,
+                    step_rng,
+                    conf_sampling_rng,
+                    br_sampling_rng,
+                ) = jax.random.split(rng, 6)
 
                 # For done envs, resample both conf and brs
                 needs_resample = last_done["__all__"]
-                resampled_conf_ids = jax.random.randint(conf_sampling_rng, (config["NUM_CONF_ACTORS"],), 0, config["PARTNER_POP_SIZE"])
-                resampled_br_ids = jax.random.randint(br_sampling_rng, (config["NUM_BR_ACTORS"],), 0, config["PARTNER_POP_SIZE"])
+                resampled_conf_ids = jax.random.randint(
+                    conf_sampling_rng,
+                    (config["NUM_CONF_ACTORS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
+                resampled_br_ids = jax.random.randint(
+                    br_sampling_rng,
+                    (config["NUM_BR_ACTORS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
 
                 # Determine final indices based on whether resampling was needed for each env
                 updated_conf_ids = jnp.where(
                     needs_resample,
-                    resampled_conf_ids,     # Use newly sampled index if True
-                    last_conf_ids           # Else, keep index from previous step
+                    resampled_conf_ids,  # Use newly sampled index if True
+                    last_conf_ids,  # Else, keep index from previous step
                 )
 
                 updated_br_ids = jnp.where(
                     needs_resample,
-                    resampled_br_ids,       # Use newly sampled index if True
-                    last_br_ids             # Else, keep index from previous step
+                    resampled_br_ids,  # Use newly sampled index if True
+                    last_br_ids,  # Else, keep index from previous step
                 )
 
                 # Reset the hidden states for resampled conf and br if they are not None
                 # WARNING: (L)BRDiv was not tested with recurrent actors, so the code for if the hstate is not None may not work
                 if last_conf_h is not None:
                     updated_conf_h = jnp.where(
-                        needs_resample,
-                        init_conf_hstate,
-                        last_conf_h
+                        needs_resample, init_conf_hstate, last_conf_h
                     )
                 else:
                     updated_conf_h = last_conf_h
 
                 if last_br_h is not None:
-                    updated_br_h = jnp.where(
-                        needs_resample,
-                        init_br_hstate,
-                        last_br_h
-                    )
+                    updated_br_h = jnp.where(needs_resample, init_br_hstate, last_br_h)
                 else:
                     updated_br_h = last_br_h
 
                 # Get the corresponding conf and br params
-                updated_conf_params = gather_params(all_train_state_conf.params, updated_conf_ids)
-                updated_br_params = gather_params(all_train_state_br.params, updated_br_ids)
+                updated_conf_params = gather_params(
+                    all_train_state_conf.params, updated_conf_ids
+                )
+                updated_br_params = gather_params(
+                    all_train_state_br.params, updated_br_ids
+                )
 
                 updated_conf_onehot_ids = identity_matrix[updated_conf_ids]
                 updated_br_onehot_ids = identity_matrix[updated_br_ids]
@@ -187,30 +229,52 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
 
                 # Agent_0 action
                 act0_rng = jax.random.split(act0_rng, config["NUM_ENVS"])
-                act_0, val_0, pi_0, new_conf_h = jax.vmap(forward_pass_conf)(updated_conf_params,
-                        last_obs["agent_0"], updated_br_onehot_ids, last_done["agent_0"], avail_actions_0,
-                        updated_conf_h, act0_rng)
+                act_0, val_0, pi_0, new_conf_h = jax.vmap(forward_pass_conf)(
+                    updated_conf_params,
+                    last_obs["agent_0"],
+                    updated_br_onehot_ids,
+                    last_done["agent_0"],
+                    avail_actions_0,
+                    updated_conf_h,
+                    act0_rng,
+                )
                 logp_0 = pi_0.log_prob(act_0)
-                act_0, val_0, logp_0 = act_0.squeeze(), val_0.squeeze(), logp_0.squeeze()
+                act_0, val_0, logp_0 = (
+                    act_0.squeeze(),
+                    val_0.squeeze(),
+                    logp_0.squeeze(),
+                )
 
                 # Agent_1 action
                 act1_rng = jax.random.split(act1_rng, config["NUM_ENVS"])
-                act_1, val_1, pi_1, new_br_h = jax.vmap(forward_pass_br)(updated_br_params,
-                        last_obs["agent_1"], updated_conf_onehot_ids, last_done["agent_1"], avail_actions_1,
-                        updated_br_h, act1_rng)
+                act_1, val_1, pi_1, new_br_h = jax.vmap(forward_pass_br)(
+                    updated_br_params,
+                    last_obs["agent_1"],
+                    updated_conf_onehot_ids,
+                    last_done["agent_1"],
+                    avail_actions_1,
+                    updated_br_h,
+                    act1_rng,
+                )
                 logp_1 = pi_1.log_prob(act_1)
-                act_1, val_1, logp_1 = act_1.squeeze(), val_1.squeeze(), logp_1.squeeze()
+                act_1, val_1, logp_1 = (
+                    act_1.squeeze(),
+                    val_1.squeeze(),
+                    logp_1.squeeze(),
+                )
 
                 # Combine actions into the env format
                 combined_actions = jnp.concatenate([act_0, act_1], axis=0)
-                env_act = unbatchify(combined_actions, env.agents, config["NUM_ENVS"], num_agents)
+                env_act = unbatchify(
+                    combined_actions, env.agents, config["NUM_ENVS"], num_agents
+                )
                 env_act = {k: v.flatten() for k, v in env_act.items()}
 
                 # Step env
                 step_rngs = jax.random.split(step_rng, config["NUM_ENVS"])
-                obs_next, env_state_next, reward, done, info = jax.vmap(env.step, in_axes=(0,0,0))(
-                    step_rngs, env_state, env_act
-                )
+                obs_next, env_state_next, reward, done, info = jax.vmap(
+                    env.step, in_axes=(0, 0, 0)
+                )(step_rngs, env_state, env_act)
                 # note that num_actors = num_envs * num_agents
                 info_0 = jax.tree.map(lambda x: x[:, 0], info)
                 info_1 = jax.tree.map(lambda x: x[:, 1], info)
@@ -227,7 +291,7 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     obs=last_obs["agent_0"],
                     info=info_0,
                     avail_actions=avail_actions_0,
-                    prev_done=last_done["agent_0"]
+                    prev_done=last_done["agent_0"],
                 )
 
                 transition_1 = XPTransition(
@@ -241,10 +305,20 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     obs=last_obs["agent_1"],
                     info=info_1,
                     avail_actions=avail_actions_1,
-                    prev_done=last_done["agent_1"]
+                    prev_done=last_done["agent_1"],
                 )
-                new_runner_state = (all_train_state_conf, all_train_state_br, updated_conf_ids, updated_br_ids,
-                                    env_state_next, obs_next, done, new_conf_h, new_br_h, rng)
+                new_runner_state = (
+                    all_train_state_conf,
+                    all_train_state_br,
+                    updated_conf_ids,
+                    updated_br_ids,
+                    env_state_next,
+                    obs_next,
+                    done,
+                    new_conf_h,
+                    new_br_h,
+                    rng,
+                )
                 return new_runner_state, (transition_0, transition_1)
 
             def _calculate_gae(traj_batch, last_val):
@@ -273,19 +347,30 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
 
             def run_all_episodes(rng, train_state_conf, train_state_br):
                 conf_ids, br_ids = _get_all_ids(config["PARTNER_POP_SIZE"])
-                gathered_conf_model_params = gather_params(train_state_conf.params, conf_ids)
+                gathered_conf_model_params = gather_params(
+                    train_state_conf.params, conf_ids
+                )
                 gathered_br_model_params = gather_params(train_state_br.params, br_ids)
 
                 rng, eval_rng = jax.random.split(rng)
+
                 def run_episodes_fixed_rng(conf_param, br_param):
                     return run_episodes(
-                        eval_rng, env,
-                        conf_param, conf_policy,
-                        br_param, br_policy,
-                        config["ROLLOUT_LENGTH"], config["NUM_EVAL_EPISODES"],
+                        eval_rng,
+                        env,
+                        conf_param,
+                        conf_policy,
+                        br_param,
+                        br_policy,
+                        config["ROLLOUT_LENGTH"],
+                        config["NUM_EVAL_EPISODES"],
                     )
-                ep_infos = jax.vmap(run_episodes_fixed_rng)(
-                    gathered_conf_model_params, gathered_br_model_params, # leaves where shape is (pop_size*pop_size, ...)
+
+                ep_infos = jax.vmap(
+                    run_episodes_fixed_rng
+                )(
+                    gathered_conf_model_params,
+                    gathered_br_model_params,  # leaves where shape is (pop_size*pop_size, ...)
                 )
                 return ep_infos
 
@@ -294,26 +379,35 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     train_state_conf, train_state_br = all_train_states
                     minbatch_conf, minbatch_br, lms_vertical, lms_horizontal = all_data
 
-                    def _loss_fn(param, agent_policy, minbatch, agent_id, lms_vertical, lms_horizontal):
-                        '''Compute loss for agent corresponding to agent_id.
-                        '''
+                    def _loss_fn(
+                        param,
+                        agent_policy,
+                        minbatch,
+                        agent_id,
+                        lms_vertical,
+                        lms_horizontal,
+                    ):
+                        """Compute loss for agent corresponding to agent_id."""
                         init_hstate, traj_batch, gae, target_v = minbatch
                         # get policy and value of confederate versus ego and best response agents respectively
-                        squeezed_param = jax.tree.map(lambda x: jnp.squeeze(x, 0), param)
+                        squeezed_param = jax.tree.map(
+                            lambda x: jnp.squeeze(x, 0), param
+                        )
                         _, value, pi, _ = agent_policy.get_action_value_policy(
                             params=squeezed_param,
                             obs=traj_batch.obs,
                             done=traj_batch.prev_done,
                             avail_actions=traj_batch.avail_actions,
                             hstate=init_hstate,
-                            rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                            aux_obs=traj_batch.oppo_onehot_id
+                            rng=jax.random.PRNGKey(
+                                0
+                            ),  # only used for action sampling, which is not used here
+                            aux_obs=traj_batch.oppo_onehot_id,
                         )
                         log_prob = pi.log_prob(traj_batch.action)
 
                         is_relevant = jnp.equal(
-                            jnp.argmax(traj_batch.self_onehot_id, axis=-1),
-                            agent_id
+                            jnp.argmax(traj_batch.self_onehot_id, axis=-1), agent_id
                         )
                         loss_weights = jnp.where(is_relevant, 1, 0).astype(jnp.float32)
                         int_self_id = jnp.argmax(traj_batch.self_onehot_id, axis=-1)
@@ -326,7 +420,9 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
 
                         def _gather_sp_weights(ids):
                             s_id, _ = ids
-                            return jnp.sum(lms_vertical, axis=-1)[s_id], jnp.sum(lms_horizontal, axis=-1)[s_id]
+                            return jnp.sum(lms_vertical, axis=-1)[s_id], jnp.sum(
+                                lms_horizontal, axis=-1
+                            )[s_id]
 
                         # Given a pair of policies that generate XP trajectories,
                         # compute the pair's total Lagrange multiplier in the Lagrange dual.
@@ -336,28 +432,33 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
 
                         def _gather_xp_weights(ids):
                             s_id, o_id = ids
-                            return -lms_vertical[s_id][o_id], -lms_horizontal[o_id][s_id]
+                            return -lms_vertical[s_id][o_id], -lms_horizontal[o_id][
+                                s_id
+                            ]
 
                         def _get_weights(s_id, o_id):
                             return jax.lax.cond(
                                 jnp.equal(s_id, o_id),
                                 _gather_sp_weights,
                                 _gather_xp_weights,
-                                (s_id, o_id)
+                                (s_id, o_id),
                             )
 
                         # Value loss
                         value_pred_clipped = traj_batch.value + (
                             value - traj_batch.value
-                            ).clip(
-                            -config["CLIP_EPS"], config["CLIP_EPS"])
+                        ).clip(-config["CLIP_EPS"], config["CLIP_EPS"])
                         value_losses = jnp.square(value - target_v)
                         value_losses_clipped = jnp.square(value_pred_clipped - target_v)
                         value_loss = jax.lax.cond(
                             loss_weights.sum() == 0,
                             lambda x: jnp.zeros_like(x).astype(jnp.float32),
                             lambda x: x,
-                            (loss_weights * jnp.maximum(value_losses, value_losses_clipped)).sum() / (loss_weights.sum() + 1e-8)
+                            (
+                                loss_weights
+                                * jnp.maximum(value_losses, value_losses_clipped)
+                            ).sum()
+                            / (loss_weights.sum() + 1e-8),
                         )
 
                         # # Apply different loss weights for SP and XP data
@@ -371,31 +472,44 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         # # Thus, we set the 2nd term of the SP weight to n/2, and the 2nd term of the XP weight to n/(2 * (n-1)).
 
                         n = config["PARTNER_POP_SIZE"]
-                        is_sp = jnp.equal(jnp.argmax(traj_batch.self_onehot_id, axis=-1), jnp.argmax(traj_batch.oppo_onehot_id, axis=-1))
-                        weights1, weights2 = jax.vmap(jax.vmap(_get_weights))(int_self_id, int_oppo_id)
-                        actor_weights_sp = (weights1 + weights2) * (n/2)
-                        actor_weights_xp = (weights1 + weights2) * (n / (2 * (n-1)))
-                        actor_weights = jnp.where(is_sp, actor_weights_sp, actor_weights_xp)
+                        is_sp = jnp.equal(
+                            jnp.argmax(traj_batch.self_onehot_id, axis=-1),
+                            jnp.argmax(traj_batch.oppo_onehot_id, axis=-1),
+                        )
+                        weights1, weights2 = jax.vmap(jax.vmap(_get_weights))(
+                            int_self_id, int_oppo_id
+                        )
+                        actor_weights_sp = (weights1 + weights2) * (n / 2)
+                        actor_weights_xp = (weights1 + weights2) * (n / (2 * (n - 1)))
+                        actor_weights = jnp.where(
+                            is_sp, actor_weights_sp, actor_weights_xp
+                        )
 
                         # Policy gradient loss
                         ratio = jnp.exp(log_prob - traj_batch.log_prob)
                         gae_norm = (gae - gae.mean()) / (gae.std() + 1e-8)
                         pg_loss_1 = ratio * actor_weights * gae_norm
-                        pg_loss_2 = jnp.clip(
-                            ratio,
-                            1.0 - config["CLIP_EPS"],
-                            1.0 + config["CLIP_EPS"]) * actor_weights * gae_norm
+                        pg_loss_2 = (
+                            jnp.clip(
+                                ratio,
+                                1.0 - config["CLIP_EPS"],
+                                1.0 + config["CLIP_EPS"],
+                            )
+                            * actor_weights
+                            * gae_norm
+                        )
                         pg_loss = jax.lax.cond(
                             loss_weights.sum() == 0,
                             lambda x: jnp.zeros_like(x).astype(jnp.float32),
                             lambda x: x,
-                            -(
-                                loss_weights * jnp.minimum(pg_loss_1, pg_loss_2)
-                            ).sum()/(loss_weights.sum() + 1e-8)
+                            -(loss_weights * jnp.minimum(pg_loss_1, pg_loss_2)).sum()
+                            / (loss_weights.sum() + 1e-8),
                         )
 
                         # Weight entropy based on actor weights
-                        all_sp_weights1, all_sp_weights2 = jax.vmap(_gather_sp_weights)((int_self_id, int_self_id))
+                        all_sp_weights1, all_sp_weights2 = jax.vmap(_gather_sp_weights)(
+                            (int_self_id, int_self_id)
+                        )
                         entropy_scaler = jnp.maximum(all_sp_weights1, all_sp_weights2)
 
                         # Compute entropy loss
@@ -403,13 +517,20 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                             loss_weights.sum() == 0,
                             lambda x: jnp.zeros_like(x).astype(jnp.float32),
                             lambda x: x,
-                            (loss_weights * entropy_scaler * pi.entropy()).sum()/(loss_weights.sum() + 1e-8)
+                            (loss_weights * entropy_scaler * pi.entropy()).sum()
+                            / (loss_weights.sum() + 1e-8),
                         )
 
-                        total_loss = pg_loss + config["VF_COEF"] * value_loss - config["ENT_COEF"] * entropy
+                        total_loss = (
+                            pg_loss
+                            + config["VF_COEF"] * value_loss
+                            - config["ENT_COEF"] * entropy
+                        )
                         return total_loss, (value_loss, pg_loss, entropy)
 
-                    possible_agent_ids = jnp.expand_dims(jnp.arange(config["PARTNER_POP_SIZE"]), 1)
+                    possible_agent_ids = jnp.expand_dims(
+                        jnp.arange(config["PARTNER_POP_SIZE"]), 1
+                    )
                     grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
 
                     def gather_conf_params_and_return_grads(agent_id):
@@ -419,58 +540,114 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         # the policy gradient loss.
                         param_vector = gather_params(train_state_conf.params, agent_id)
                         (loss_val_conf, aux_vals_conf), grads_conf = grad_fn(
-                            param_vector, conf_policy, minbatch_conf, agent_id,
-                            jnp.transpose(lms_vertical), jnp.transpose(lms_horizontal)
+                            param_vector,
+                            conf_policy,
+                            minbatch_conf,
+                            agent_id,
+                            jnp.transpose(lms_vertical),
+                            jnp.transpose(lms_horizontal),
                         )
                         return (loss_val_conf, aux_vals_conf), grads_conf
 
                     def gather_br_params_and_return_grads(agent_id):
                         param_vector = gather_params(train_state_br.params, agent_id)
                         (loss_val_br, aux_vals_br), grads_br = grad_fn(
-                            param_vector, br_policy, minbatch_br, agent_id,
-                            lms_vertical, lms_horizontal
+                            param_vector,
+                            br_policy,
+                            minbatch_br,
+                            agent_id,
+                            lms_vertical,
+                            lms_horizontal,
                         )
                         return (loss_val_br, aux_vals_br), grads_br
 
-                    (loss_val_conf, aux_vals_conf), grads_conf = jax.vmap(gather_conf_params_and_return_grads)(possible_agent_ids)
-                    (loss_val_br, aux_vals_br), grads_br = jax.vmap(gather_br_params_and_return_grads)(possible_agent_ids)
+                    (loss_val_conf, aux_vals_conf), grads_conf = jax.vmap(
+                        gather_conf_params_and_return_grads
+                    )(possible_agent_ids)
+                    (loss_val_br, aux_vals_br), grads_br = jax.vmap(
+                        gather_br_params_and_return_grads
+                    )(possible_agent_ids)
 
-                    grads_conf_new = jax.tree.map(lambda x: jnp.squeeze(x, 1), grads_conf)
+                    grads_conf_new = jax.tree.map(
+                        lambda x: jnp.squeeze(x, 1), grads_conf
+                    )
                     grads_br_new = jax.tree.map(lambda x: jnp.squeeze(x, 1), grads_br)
-                    train_state_conf = train_state_conf.apply_gradients(grads=grads_conf_new)
+                    train_state_conf = train_state_conf.apply_gradients(
+                        grads=grads_conf_new
+                    )
                     train_state_br = train_state_br.apply_gradients(grads=grads_br_new)
-                    return (train_state_conf, train_state_br), ((loss_val_conf, aux_vals_conf), (loss_val_br, aux_vals_br))
+                    return (train_state_conf, train_state_br), (
+                        (loss_val_conf, aux_vals_conf),
+                        (loss_val_br, aux_vals_br),
+                    )
 
                 (
-                    train_state_conf, train_state_br,
-                    traj_batch_conf, traj_batch_br,
-                    advantages_conf, advantages_br,
-                    targets_conf, targets_br,
-                    rng, lms_vertical, lms_horizontal
+                    train_state_conf,
+                    train_state_br,
+                    traj_batch_conf,
+                    traj_batch_br,
+                    advantages_conf,
+                    advantages_br,
+                    targets_conf,
+                    targets_br,
+                    rng,
+                    lms_vertical,
+                    lms_horizontal,
                 ) = update_state
                 rng, perm_rng_conf, perm_rng_br = jax.random.split(rng, 3)
 
-                minibatches_conf = _create_minibatches(traj_batch_conf, advantages_conf, targets_conf, init_conf_hstate,
-                                                       config["NUM_CONF_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_conf)
-                minibatches_br = _create_minibatches(traj_batch_br, advantages_br, targets_br, init_br_hstate,
-                                                     config["NUM_BR_ACTORS"], config["NUM_MINIBATCHES"], perm_rng_br)
+                minibatches_conf = _create_minibatches(
+                    traj_batch_conf,
+                    advantages_conf,
+                    targets_conf,
+                    init_conf_hstate,
+                    config["NUM_CONF_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_conf,
+                )
+                minibatches_br = _create_minibatches(
+                    traj_batch_br,
+                    advantages_br,
+                    targets_br,
+                    init_br_hstate,
+                    config["NUM_BR_ACTORS"],
+                    config["NUM_MINIBATCHES"],
+                    perm_rng_br,
+                )
 
                 # Update both policies
                 num_minibatches = minibatches_br[1].obs.shape[0]
 
-                repeated_lms_vertical = lms_vertical[jnp.newaxis, ...].repeat(num_minibatches, axis=0)
-                repeated_lms_horizontal = lms_horizontal[jnp.newaxis, ...].repeat(num_minibatches, axis=0)
-
-                (train_state_conf, train_state_br), all_losses = jax.lax.scan(
-                    _update_minbatch, (train_state_conf, train_state_br),
-                    (minibatches_conf, minibatches_br, repeated_lms_vertical, repeated_lms_horizontal)
+                repeated_lms_vertical = lms_vertical[jnp.newaxis, ...].repeat(
+                    num_minibatches, axis=0
+                )
+                repeated_lms_horizontal = lms_horizontal[jnp.newaxis, ...].repeat(
+                    num_minibatches, axis=0
                 )
 
-                update_state = (train_state_conf, train_state_br,
-                    traj_batch_conf, traj_batch_br,
-                    advantages_conf, advantages_br,
-                    targets_conf, targets_br,
-                    rng, lms_vertical, lms_horizontal
+                (train_state_conf, train_state_br), all_losses = jax.lax.scan(
+                    _update_minbatch,
+                    (train_state_conf, train_state_br),
+                    (
+                        minibatches_conf,
+                        minibatches_br,
+                        repeated_lms_vertical,
+                        repeated_lms_horizontal,
+                    ),
+                )
+
+                update_state = (
+                    train_state_conf,
+                    train_state_br,
+                    traj_batch_conf,
+                    traj_batch_br,
+                    advantages_conf,
+                    advantages_br,
+                    targets_conf,
+                    targets_br,
+                    rng,
+                    lms_vertical,
+                    lms_horizontal,
                 )
                 return update_state, all_losses
 
@@ -482,27 +659,66 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 4. Lagrange multiplier update (once, after all PPO epochs)
                 """
                 (
-                    all_train_state_conf, all_train_state_br,
-                    last_env_state, last_obs, last_done, last_conf_h, last_br_h,
-                    rng, update_steps, lms_vertical, lms_horizontal
+                    all_train_state_conf,
+                    all_train_state_br,
+                    last_env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
+                    update_steps,
+                    lms_vertical,
+                    lms_horizontal,
                 ) = update_runner_state
 
                 rng, conf_sampling_rng, br_sampling_rng = jax.random.split(rng, 3)
 
-                conf_ids = jax.random.randint(conf_sampling_rng, (config["NUM_ENVS"],), 0, config["PARTNER_POP_SIZE"])
-                br_ids = jax.random.randint(br_sampling_rng, (config["NUM_ENVS"],), 0, config["PARTNER_POP_SIZE"])
+                conf_ids = jax.random.randint(
+                    conf_sampling_rng,
+                    (config["NUM_ENVS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
+                br_ids = jax.random.randint(
+                    br_sampling_rng,
+                    (config["NUM_ENVS"],),
+                    0,
+                    config["PARTNER_POP_SIZE"],
+                )
 
                 runner_state = (
-                    all_train_state_conf, all_train_state_br, conf_ids, br_ids,
-                    last_env_state, last_obs, last_done, last_conf_h, last_br_h, rng
+                    all_train_state_conf,
+                    all_train_state_br,
+                    conf_ids,
+                    br_ids,
+                    last_env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
                 )
                 runner_state, traj_batch = jax.lax.scan(
-                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"])
-                (all_train_state_conf, all_train_state_br, last_conf_ids, last_br_ids,
-                 last_env_state, last_obs, last_done, last_conf_h, last_br_h, rng) = runner_state
+                    _env_step, runner_state, None, config["ROLLOUT_LENGTH"]
+                )
+                (
+                    all_train_state_conf,
+                    all_train_state_br,
+                    last_conf_ids,
+                    last_br_ids,
+                    last_env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
+                ) = runner_state
 
                 # Get the last conf and br params and ids
-                last_conf_params = gather_params(all_train_state_conf.params, last_conf_ids)
+                last_conf_params = gather_params(
+                    all_train_state_conf.params, last_conf_ids
+                )
                 last_br_params = gather_params(all_train_state_br.params, last_br_ids)
 
                 last_conf_one_hots = identity_matrix[last_conf_ids]
@@ -512,7 +728,9 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 traj_batch_conf, traj_batch_br = traj_batch
 
                 # Compute advantage for confederate agent from interaction with br policy
-                avail_actions_0 = jax.vmap(env.get_avail_actions)(last_env_state.env_state)["agent_0"].astype(jnp.float32)
+                avail_actions_0 = jax.vmap(env.get_avail_actions)(
+                    last_env_state.env_state
+                )["agent_0"].astype(jnp.float32)
                 _, last_val_conf, _, _ = jax.vmap(forward_pass_conf)(
                     params=last_conf_params,
                     obs=last_obs["agent_0"],
@@ -520,13 +738,19 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     done=last_done["agent_0"],
                     avail_actions=avail_actions_0,
                     hstate=last_conf_h,
-                    rng=jax.random.split(jax.random.PRNGKey(0), config["NUM_ENVS"])  # Dummy key since we're just extracting the value
+                    rng=jax.random.split(
+                        jax.random.PRNGKey(0), config["NUM_ENVS"]
+                    ),  # Dummy key since we're just extracting the value
                 )
                 last_val_conf = last_val_conf.squeeze()
-                advantages_conf, targets_conf = _calculate_gae(traj_batch_conf, last_val_conf)
+                advantages_conf, targets_conf = _calculate_gae(
+                    traj_batch_conf, last_val_conf
+                )
 
                 # Compute advantage for br policy from interaction with confederate agent
-                avail_actions_1 = jax.vmap(env.get_avail_actions)(last_env_state.env_state)["agent_1"].astype(jnp.float32)
+                avail_actions_1 = jax.vmap(env.get_avail_actions)(
+                    last_env_state.env_state
+                )["agent_1"].astype(jnp.float32)
                 _, last_val_br, _, _ = jax.vmap(forward_pass_br)(
                     params=last_br_params,
                     obs=last_obs["agent_1"],
@@ -534,7 +758,9 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     done=last_done["agent_1"],
                     avail_actions=avail_actions_1,
                     hstate=last_br_h,
-                    rng=jax.random.split(jax.random.PRNGKey(0), config["NUM_ENVS"])  # Dummy key since we're just extracting the value
+                    rng=jax.random.split(
+                        jax.random.PRNGKey(0), config["NUM_ENVS"]
+                    ),  # Dummy key since we're just extracting the value
                 )
                 last_val_br = last_val_br.squeeze()
                 advantages_br, targets_br = _calculate_gae(traj_batch_br, last_val_br)
@@ -542,15 +768,22 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 # 3) PPO update
                 rng, update_rng = jax.random.split(rng, 2)
                 update_state = (
-                    all_train_state_conf, all_train_state_br,
-                    traj_batch_conf, traj_batch_br,
-                    advantages_conf, advantages_br,
-                    targets_conf, targets_br,
-                    update_rng, lms_vertical, lms_horizontal
+                    all_train_state_conf,
+                    all_train_state_br,
+                    traj_batch_conf,
+                    traj_batch_br,
+                    advantages_conf,
+                    advantages_br,
+                    targets_conf,
+                    targets_br,
+                    update_rng,
+                    lms_vertical,
+                    lms_horizontal,
                 )
 
                 update_state, all_losses = jax.lax.scan(
-                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"])
+                    _update_epoch, update_state, None, config["UPDATE_EPOCHS"]
+                )
                 all_train_state_conf, all_train_state_br = update_state[:2]
                 lms_vertical, lms_horizontal = update_state[-2:]
 
@@ -558,20 +791,29 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 # Diagonal and off-diagonal pairs use separate vmaps to avoid evaluating both
                 # branches of lax.cond for all pop_size^2 elements under vmap.
                 def compute_lagrange_grads_same(params_br, batch, target_value, ids):
-                    conf_id, br_id = ids
+                    conf_id, _br_id = ids
 
                     all_target_value = jnp.reshape(target_value, (-1, 1))
                     repeated_value_sp = jnp.repeat(
                         jnp.reshape(all_target_value, (1, -1)),
                         config["PARTNER_POP_SIZE"],
-                        axis=0
+                        axis=0,
                     )
 
-                    relevant_conf_params = gather_params(params_br, jnp.reshape(conf_id, (1,)))
-                    relevant_conf_params = jax.tree.map(lambda x: jnp.squeeze(x, 0), relevant_conf_params)
+                    relevant_conf_params = gather_params(
+                        params_br, jnp.reshape(conf_id, (1,))
+                    )
+                    relevant_conf_params = jax.tree.map(
+                        lambda x: jnp.squeeze(x, 0), relevant_conf_params
+                    )
+
                     def _get_value_xp_vary_conf(param, agent_onehot_id):
                         ts, bs = batch.obs.shape[:2]
-                        agent_onehot_id = agent_onehot_id[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
+                        agent_onehot_id = (
+                            agent_onehot_id[jnp.newaxis, jnp.newaxis, ...]
+                            .repeat(ts, axis=0)
+                            .repeat(bs, axis=1)
+                        )
                         _, value_xp_vary_conf, _, _ = br_policy.get_action_value_policy(
                             params=param,
                             obs=batch.obs,
@@ -579,23 +821,34 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                             avail_actions=batch.avail_actions,
                             hstate=init_br_hstate,
                             rng=jax.random.PRNGKey(0),
-                            aux_obs=agent_onehot_id
+                            aux_obs=agent_onehot_id,
                         )
-                        return value_xp_vary_conf.reshape(ts*bs)
+                        return value_xp_vary_conf.reshape(ts * bs)
 
                     all_possible_value_xp_vary_conf = jax.vmap(
-                        lambda agent_id: _get_value_xp_vary_conf(relevant_conf_params, agent_id)
+                        lambda agent_id: _get_value_xp_vary_conf(
+                            relevant_conf_params, agent_id
+                        )
                     )(jnp.eye(config["PARTNER_POP_SIZE"]))
-                    all_possible_value_xp_vary_conf = all_possible_value_xp_vary_conf.at[conf_id].set(
-                        repeated_value_sp[conf_id]
+                    all_possible_value_xp_vary_conf = (
+                        all_possible_value_xp_vary_conf.at[conf_id].set(
+                            repeated_value_sp[conf_id]
+                        )
                     )
 
                     offsetting_thresholds = jnp.zeros_like(repeated_value_sp)
                     offsetting_thresholds = offsetting_thresholds.at[conf_id].set(
-                        config["TOLERANCE_FACTOR"] * jnp.ones_like(offsetting_thresholds[conf_id])
+                        config["TOLERANCE_FACTOR"]
+                        * jnp.ones_like(offsetting_thresholds[conf_id])
                     )
-                    grad_sp_vary_conf = repeated_value_sp + offsetting_thresholds - (
-                        all_possible_value_xp_vary_conf + config["TOLERANCE_FACTOR"] * jnp.ones_like(offsetting_thresholds)
+                    grad_sp_vary_conf = (
+                        repeated_value_sp
+                        + offsetting_thresholds
+                        - (
+                            all_possible_value_xp_vary_conf
+                            + config["TOLERANCE_FACTOR"]
+                            * jnp.ones_like(offsetting_thresholds)
+                        )
                     )
 
                     ##### Compute grad_sp_vary_br
@@ -615,21 +868,30 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     # Vary the BR policy parameters (j) used in value computation
                     # Use the experience generating pop id (batch.self_onehot_id) <i> as the conf ID.
 
-                    relevant_params = gather_params(params_br, jnp.arange(config["PARTNER_POP_SIZE"]))
+                    relevant_params = gather_params(
+                        params_br, jnp.arange(config["PARTNER_POP_SIZE"])
+                    )
+
                     def _get_value_xp_vary_br(param):
                         ts, bs = batch.obs.shape[:2]
                         conf_one_hot = jnp.eye(config["PARTNER_POP_SIZE"])[conf_id]
-                        conf_one_hot = conf_one_hot[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
+                        conf_one_hot = (
+                            conf_one_hot[jnp.newaxis, jnp.newaxis, ...]
+                            .repeat(ts, axis=0)
+                            .repeat(bs, axis=1)
+                        )
                         _, value_xp_vary_br, _, _ = br_policy.get_action_value_policy(
                             params=param,
                             obs=batch.obs,
                             done=batch.prev_done,
                             avail_actions=batch.avail_actions,
                             hstate=init_br_hstate,
-                            rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
-                            aux_obs=conf_one_hot
+                            rng=jax.random.PRNGKey(
+                                0
+                            ),  # only used for action sampling, which is not used here
+                            aux_obs=conf_one_hot,
                         )
-                        return value_xp_vary_br.reshape(ts*bs)
+                        return value_xp_vary_br.reshape(ts * bs)
 
                     all_possible_value_xp_vary_br = jax.vmap(
                         lambda param: _get_value_xp_vary_br(param)
@@ -637,12 +899,18 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     all_possible_value_xp_vary_br = jnp.reshape(
                         all_possible_value_xp_vary_br, (config["PARTNER_POP_SIZE"], -1)
                     )
-                    all_possible_value_xp_vary_br = all_possible_value_xp_vary_br.at[conf_id].set(
-                        repeated_value_sp[conf_id]
-                    )
+                    all_possible_value_xp_vary_br = all_possible_value_xp_vary_br.at[
+                        conf_id
+                    ].set(repeated_value_sp[conf_id])
 
-                    grad_sp_vary_br = repeated_value_sp + offsetting_thresholds - (
-                        all_possible_value_xp_vary_br + config["TOLERANCE_FACTOR"] * jnp.ones_like(offsetting_thresholds)
+                    grad_sp_vary_br = (
+                        repeated_value_sp
+                        + offsetting_thresholds
+                        - (
+                            all_possible_value_xp_vary_br
+                            + config["TOLERANCE_FACTOR"]
+                            * jnp.ones_like(offsetting_thresholds)
+                        )
                     )
 
                     all_self_id_int = jnp.reshape(
@@ -652,23 +920,39 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         batch.oppo_onehot_id, (-1, jnp.shape(batch.oppo_onehot_id)[-1])
                     ).argmax(axis=-1)
 
-                    self_is_conf = jnp.equal(all_self_id_int, conf_id).astype(jnp.float32)
-                    oppo_is_conf = jnp.equal(all_oppo_id_int, conf_id).astype(jnp.float32)
+                    self_is_conf = jnp.equal(all_self_id_int, conf_id).astype(
+                        jnp.float32
+                    )
+                    oppo_is_conf = jnp.equal(all_oppo_id_int, conf_id).astype(
+                        jnp.float32
+                    )
                     loss_weights = self_is_conf * oppo_is_conf
                     repeated_loss_weights = jnp.repeat(
                         jnp.expand_dims(loss_weights, axis=0),
                         config["PARTNER_POP_SIZE"],
-                        axis=0
+                        axis=0,
                     )
 
                     # Compute vertical and horizontal gradient
-                    vertical_grads = jnp.sum(grad_sp_vary_conf * repeated_loss_weights, axis=-1) / (jnp.sum(loss_weights) + 1e-8)
-                    horizontal_grads = jnp.sum(grad_sp_vary_br * repeated_loss_weights, axis=-1) / (jnp.sum(loss_weights) + 1e-8)
+                    vertical_grads = jnp.sum(
+                        grad_sp_vary_conf * repeated_loss_weights, axis=-1
+                    ) / (jnp.sum(loss_weights) + 1e-8)
+                    horizontal_grads = jnp.sum(
+                        grad_sp_vary_br * repeated_loss_weights, axis=-1
+                    ) / (jnp.sum(loss_weights) + 1e-8)
 
-                    output_grad_matrix_vertical = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
-                    output_grad_matrix_horizontal = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
-                    output_grad_matrix_vertical = output_grad_matrix_vertical.at[conf_id].set(vertical_grads)
-                    output_grad_matrix_horizontal = output_grad_matrix_horizontal.at[conf_id].set(horizontal_grads)
+                    output_grad_matrix_vertical = jnp.zeros(
+                        (config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"])
+                    )
+                    output_grad_matrix_horizontal = jnp.zeros(
+                        (config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"])
+                    )
+                    output_grad_matrix_vertical = output_grad_matrix_vertical.at[
+                        conf_id
+                    ].set(vertical_grads)
+                    output_grad_matrix_horizontal = output_grad_matrix_horizontal.at[
+                        conf_id
+                    ].set(horizontal_grads)
                     return output_grad_matrix_vertical, output_grad_matrix_horizontal
 
                 def compute_lagrange_grads_diff(params_br, batch, target_returns, ids):
@@ -676,7 +960,9 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     param_conf_id = gather_params(params_br, jnp.reshape(conf_id, (1,)))
                     param_br_id = gather_params(params_br, jnp.reshape(br_id, (1,)))
                     param_br_id = jax.tree.map(lambda x: jnp.squeeze(x, 0), param_br_id)
-                    param_conf_id = jax.tree.map(lambda x: jnp.squeeze(x, 0), param_conf_id)
+                    param_conf_id = jax.tree.map(
+                        lambda x: jnp.squeeze(x, 0), param_conf_id
+                    )
 
                     all_self_id_int = jnp.reshape(
                         batch.self_onehot_id, (-1, jnp.shape(batch.self_onehot_id)[-1])
@@ -688,15 +974,25 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
 
                     # Compute data weights based on whether selected ID
                     # is relevant for the gradient computation process
-                    oppo_is_conf = jnp.equal(all_oppo_id_int, conf_id).astype(jnp.float32)
+                    oppo_is_conf = jnp.equal(all_oppo_id_int, conf_id).astype(
+                        jnp.float32
+                    )
                     self_is_br = jnp.equal(all_self_id_int, br_id).astype(jnp.float32)
                     loss_weights = oppo_is_conf * self_is_br
 
                     ts, bs = batch.obs.shape[:2]
                     conf_one_hot = jnp.eye(config["PARTNER_POP_SIZE"])[conf_id]
-                    conf_one_hot = conf_one_hot[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
+                    conf_one_hot = (
+                        conf_one_hot[jnp.newaxis, jnp.newaxis, ...]
+                        .repeat(ts, axis=0)
+                        .repeat(bs, axis=1)
+                    )
                     br_one_hot = jnp.eye(config["PARTNER_POP_SIZE"])[br_id]
-                    br_one_hot = br_one_hot[jnp.newaxis, jnp.newaxis, ...].repeat(ts, axis=0).repeat(bs, axis=1)
+                    br_one_hot = (
+                        br_one_hot[jnp.newaxis, jnp.newaxis, ...]
+                        .repeat(ts, axis=0)
+                        .repeat(bs, axis=1)
+                    )
 
                     _, value_sp_pop_is_br, _, _ = br_policy.get_action_value_policy(
                         params=param_br_id,
@@ -705,9 +1001,9 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         avail_actions=batch.avail_actions,
                         hstate=init_br_hstate,
                         rng=jax.random.PRNGKey(0),
-                        aux_obs=br_one_hot
+                        aux_obs=br_one_hot,
                     )
-                    value_sp_pop_is_br = value_sp_pop_is_br.reshape(bs*ts)
+                    value_sp_pop_is_br = value_sp_pop_is_br.reshape(bs * ts)
 
                     _, value_sp_pop_is_not_br, _, _ = br_policy.get_action_value_policy(
                         params=param_conf_id,
@@ -716,75 +1012,110 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         avail_actions=batch.avail_actions,
                         hstate=init_br_hstate,
                         rng=jax.random.PRNGKey(0),
-                        aux_obs=conf_one_hot
+                        aux_obs=conf_one_hot,
                     )
-                    value_sp_pop_is_not_br = value_sp_pop_is_not_br.reshape(bs*ts)
+                    value_sp_pop_is_not_br = value_sp_pop_is_not_br.reshape(bs * ts)
 
-                    vertical_diff = value_sp_pop_is_br - all_target_returns - config["TOLERANCE_FACTOR"]
-                    horizontal_diff = value_sp_pop_is_not_br - all_target_returns - config["TOLERANCE_FACTOR"]
+                    vertical_diff = (
+                        value_sp_pop_is_br
+                        - all_target_returns
+                        - config["TOLERANCE_FACTOR"]
+                    )
+                    horizontal_diff = (
+                        value_sp_pop_is_not_br
+                        - all_target_returns
+                        - config["TOLERANCE_FACTOR"]
+                    )
 
-                    total_grad_vertical = (loss_weights * vertical_diff).sum() / (loss_weights.sum() + 1e-8)
-                    total_grad_horizontal = (loss_weights * horizontal_diff).sum() / (loss_weights.sum() + 1e-8)
+                    total_grad_vertical = (loss_weights * vertical_diff).sum() / (
+                        loss_weights.sum() + 1e-8
+                    )
+                    total_grad_horizontal = (loss_weights * horizontal_diff).sum() / (
+                        loss_weights.sum() + 1e-8
+                    )
 
-                    output_grad_matrix_vertical = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
-                    output_grad_matrix_horizontal = jnp.zeros((config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"]))
-                    output_grad_matrix_vertical = output_grad_matrix_vertical.at[br_id, conf_id].set(total_grad_vertical)
-                    output_grad_matrix_horizontal = output_grad_matrix_horizontal.at[conf_id, br_id].set(total_grad_horizontal)
+                    output_grad_matrix_vertical = jnp.zeros(
+                        (config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"])
+                    )
+                    output_grad_matrix_horizontal = jnp.zeros(
+                        (config["PARTNER_POP_SIZE"], config["PARTNER_POP_SIZE"])
+                    )
+                    output_grad_matrix_vertical = output_grad_matrix_vertical.at[
+                        br_id, conf_id
+                    ].set(total_grad_vertical)
+                    output_grad_matrix_horizontal = output_grad_matrix_horizontal.at[
+                        conf_id, br_id
+                    ].set(total_grad_horizontal)
                     return output_grad_matrix_vertical, output_grad_matrix_horizontal
 
                 # Diagonal pairs (conf_id == br_id): vmap over pop_size elements only
                 diag_ids = np.arange(config["PARTNER_POP_SIZE"])
                 diag_lagrange_grads = jax.vmap(
                     lambda conf_id, br_id: compute_lagrange_grads_same(
-                        all_train_state_br.params, traj_batch_br, targets_br, (conf_id, br_id)
+                        all_train_state_br.params,
+                        traj_batch_br,
+                        targets_br,
+                        (conf_id, br_id),
                     )
                 )(diag_ids, diag_ids)
 
                 # Off-diagonal pairs (conf_id != br_id): vmap over pop_size*(pop_size-1) elements only
-                all_conf_ids_np, all_br_ids_np = _get_all_ids(config["PARTNER_POP_SIZE"])
+                all_conf_ids_np, all_br_ids_np = _get_all_ids(
+                    config["PARTNER_POP_SIZE"]
+                )
                 off_diag_mask = all_conf_ids_np != all_br_ids_np
                 off_diag_conf_ids = all_conf_ids_np[off_diag_mask]
                 off_diag_br_ids = all_br_ids_np[off_diag_mask]
                 off_diag_lagrange_grads = jax.vmap(
                     lambda conf_id, br_id: compute_lagrange_grads_diff(
-                        all_train_state_br.params, traj_batch_br, targets_br, (conf_id, br_id)
+                        all_train_state_br.params,
+                        traj_batch_br,
+                        targets_br,
+                        (conf_id, br_id),
                     )
                 )(off_diag_conf_ids, off_diag_br_ids)
 
-                averaged_grad_vertical = (
-                    jnp.sum(diag_lagrange_grads[0], axis=0) +
-                    jnp.sum(off_diag_lagrange_grads[0], axis=0)
-                )
-                averaged_grad_horizontal = (
-                    jnp.sum(diag_lagrange_grads[1], axis=0) +
-                    jnp.sum(off_diag_lagrange_grads[1], axis=0)
-                )
+                averaged_grad_vertical = jnp.sum(
+                    diag_lagrange_grads[0], axis=0
+                ) + jnp.sum(off_diag_lagrange_grads[0], axis=0)
+                averaged_grad_horizontal = jnp.sum(
+                    diag_lagrange_grads[1], axis=0
+                ) + jnp.sum(off_diag_lagrange_grads[1], axis=0)
 
                 lms_vertical = jnp.maximum(
                     lms_vertical - config["LAGRANGE_LR"] * averaged_grad_vertical,
-                    0.5 * jnp.eye(config["PARTNER_POP_SIZE"])
+                    0.5 * jnp.eye(config["PARTNER_POP_SIZE"]),
                 )
                 lms_vertical = jnp.fill_diagonal(
-                    lms_vertical, 0.5 * jnp.ones((config["PARTNER_POP_SIZE"]), dtype=jnp.float32),
-                    inplace=False
+                    lms_vertical,
+                    0.5 * jnp.ones((config["PARTNER_POP_SIZE"]), dtype=jnp.float32),
+                    inplace=False,
                 )
                 lms_horizontal = jnp.maximum(
                     lms_horizontal - config["LAGRANGE_LR"] * averaged_grad_horizontal,
                     0.5 * jnp.eye(config["PARTNER_POP_SIZE"]),
                 )
                 lms_horizontal = jnp.fill_diagonal(
-                    lms_horizontal, 0.5 * jnp.ones((config["PARTNER_POP_SIZE"]), dtype=jnp.float32),
-                    inplace=False
+                    lms_horizontal,
+                    0.5 * jnp.ones((config["PARTNER_POP_SIZE"]), dtype=jnp.float32),
+                    inplace=False,
                 )
 
-                (_, (value_loss_conf, pg_loss_conf, entropy_conf)), (_, (value_loss_br, pg_loss_br, entropy_br)) = all_losses
+                (
+                    (_, (value_loss_conf, pg_loss_conf, entropy_conf)),
+                    (_, (value_loss_br, pg_loss_br, entropy_br)),
+                ) = all_losses
 
                 # Metrics
                 def mask_and_mean(x, mask):
                     return jnp.where(mask, x, 0).sum() / jnp.maximum(1, mask.sum())
-                
-                mask = traj_batch_conf.info.get("returned_episode", jnp.ones_like(traj_batch_conf.reward))
-                metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_conf.info)
+
+                mask = traj_batch_conf.info.get(
+                    "returned_episode", jnp.ones_like(traj_batch_conf.reward)
+                )
+                metric = jax.tree.map(
+                    lambda x: mask_and_mean(x, mask), traj_batch_conf.info
+                )
                 metric["lms_vertical"] = lms_vertical
                 metric["lms_horizontal"] = lms_horizontal
                 metric["update_steps"] = update_steps
@@ -798,60 +1129,92 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 metric["entropy_br"] = entropy_br.mean(axis=(0, 1))
 
                 new_runner_state = (
-                    all_train_state_conf, all_train_state_br,
-                    last_env_state, last_obs, last_done, last_conf_h, last_br_h,
-                    rng, update_steps + 1,
-                    lms_vertical, lms_horizontal
+                    all_train_state_conf,
+                    all_train_state_br,
+                    last_env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
+                    update_steps + 1,
+                    lms_vertical,
+                    lms_horizontal,
                 )
                 return (new_runner_state, metric)
 
             # --------------------------
             # PPO Update and Checkpoint saving
             # --------------------------
-            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(1, config["NUM_CHECKPOINTS"] - 1)  # -1 because we store a ckpt at the last update
+            ckpt_and_eval_interval = config["NUM_UPDATES"] // max(
+                1, config["NUM_CHECKPOINTS"] - 1
+            )  # -1 because we store a ckpt at the last update
             num_ckpts = config["NUM_CHECKPOINTS"]
 
             # Build a PyTree that holds parameters for all conf agent checkpoints
             def init_ckpt_array(params_pytree):
                 return jax.tree.map(
-                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype),
-                    params_pytree)
+                    lambda x: jnp.zeros((num_ckpts,) + x.shape, x.dtype), params_pytree
+                )
 
             def _update_step_with_ckpt(state_with_ckpt, unused):
-                (update_runner_state, checkpoint_array_conf, checkpoint_array_br, ckpt_idx,
-                    eval_info) = state_with_ckpt
+                (
+                    update_runner_state,
+                    checkpoint_array_conf,
+                    checkpoint_array_br,
+                    ckpt_idx,
+                    eval_info,
+                ) = state_with_ckpt
 
                 # Single PPO update
                 new_runner_state, metric = _update_step(update_runner_state, None)
 
                 (
-                    train_state_conf, train_state_br,
-                    last_env_state, last_obs, last_done, last_conf_h, last_br_h,
-                    rng, update_steps, lms_vertical, lms_horizontal
-                 ) = new_runner_state
+                    train_state_conf,
+                    train_state_br,
+                    last_env_state,
+                    last_obs,
+                    last_done,
+                    last_conf_h,
+                    last_br_h,
+                    rng,
+                    update_steps,
+                    lms_vertical,
+                    lms_horizontal,
+                ) = new_runner_state
 
                 # Decide if we store a checkpoint
                 # update steps is 1-indexed because it was incremented at the end of the update step
-                to_store = jnp.logical_or(jnp.equal(jnp.mod(update_steps-1, ckpt_and_eval_interval), 0),
-                                        jnp.equal(update_steps, config["NUM_UPDATES"]))
+                to_store = jnp.logical_or(
+                    jnp.equal(jnp.mod(update_steps - 1, ckpt_and_eval_interval), 0),
+                    jnp.equal(update_steps, config["NUM_UPDATES"]),
+                )
 
                 def store_and_eval_ckpt(args):
                     ckpt_arr_and_ep_infos, rng, cidx = args
                     ckpt_arr_conf, ckpt_arr_br, _ = ckpt_arr_and_ep_infos
                     new_ckpt_arr_conf = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_conf, train_state_conf.params
+                        ckpt_arr_conf,
+                        train_state_conf.params,
                     )
                     new_ckpt_arr_br = jax.tree.map(
                         lambda c_arr, p: c_arr.at[cidx].set(p),
-                        ckpt_arr_br, train_state_br.params
+                        ckpt_arr_br,
+                        train_state_br.params,
                     )
 
                     rng, eval_rng = jax.random.split(rng)
-                    ep_last_info = jax.tree.map(lambda x: x.mean(axis=(-2, -1)),
-                        run_all_episodes(eval_rng, train_state_conf, train_state_br))
+                    ep_last_info = jax.tree.map(
+                        lambda x: x.mean(axis=(-2, -1)),
+                        run_all_episodes(eval_rng, train_state_conf, train_state_br),
+                    )
 
-                    return ((new_ckpt_arr_conf, new_ckpt_arr_br, ep_last_info), rng, cidx + 1)
+                    return (
+                        (new_ckpt_arr_conf, new_ckpt_arr_br, ep_last_info),
+                        rng,
+                        cidx + 1,
+                    )
 
                 def skip_ckpt(args):
                     return args
@@ -860,17 +1223,37 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     to_store,
                     store_and_eval_ckpt,
                     skip_ckpt,
-                    ((checkpoint_array_conf, checkpoint_array_br, eval_info), rng, ckpt_idx)
+                    (
+                        (checkpoint_array_conf, checkpoint_array_br, eval_info),
+                        rng,
+                        ckpt_idx,
+                    ),
                 )
-                checkpoint_array_conf, checkpoint_array_br, eval_ep_last_info = checkpoint_array_and_infos
+                checkpoint_array_conf, checkpoint_array_br, eval_ep_last_info = (
+                    checkpoint_array_and_infos
+                )
 
-                metric["eval_ep_last_info"] = eval_ep_last_info # return of confederate
+                metric["eval_ep_last_info"] = eval_ep_last_info  # return of confederate
 
-                return ((train_state_conf, train_state_br,
-                         last_env_state, last_obs, last_done, last_conf_h, last_br_h,
-                         rng, update_steps, lms_vertical, lms_horizontal),
-                        checkpoint_array_conf, checkpoint_array_br, ckpt_idx,
-                        eval_ep_last_info), metric
+                return (
+                    (
+                        train_state_conf,
+                        train_state_br,
+                        last_env_state,
+                        last_obs,
+                        last_done,
+                        last_conf_h,
+                        last_br_h,
+                        rng,
+                        update_steps,
+                        lms_vertical,
+                        lms_horizontal,
+                    ),
+                    checkpoint_array_conf,
+                    checkpoint_array_br,
+                    ckpt_idx,
+                    eval_ep_last_info,
+                ), metric
 
             # Initialize checkpoint array
             checkpoint_array_conf = init_ckpt_array(all_conf_optims.params)
@@ -881,14 +1264,19 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
             update_steps = 0
 
             rng, rng_eval = jax.random.split(rng, 2)
-            eval_ep_last_info = jax.tree.map(lambda x: x.mean(axis=(-2, -1)),
-                run_all_episodes(rng_eval, all_conf_optims, all_br_optims))
+            eval_ep_last_info = jax.tree.map(
+                lambda x: x.mean(axis=(-2, -1)),
+                run_all_episodes(rng_eval, all_conf_optims, all_br_optims),
+            )
 
             # Initialize environment
             rng, reset_rng = jax.random.split(rng)
             reset_rngs = jax.random.split(reset_rng, config["NUM_ENVS"])
             init_obs, init_env_state = jax.vmap(env.reset, in_axes=(0,))(reset_rngs)
-            init_done = {k: jnp.zeros((config["NUM_ENVS"]), dtype=bool) for k in env.agents + ["__all__"]}
+            init_done = {
+                k: jnp.zeros((config["NUM_ENVS"]), dtype=bool)
+                for k in env.agents + ["__all__"]
+            }
 
             # Initialize conf and br hstates
             init_conf_h = conf_policy.init_hstate(config["NUM_CONF_ACTORS"])
@@ -907,15 +1295,25 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
             lagrange_multipliers_horizontal = 0.5 * jnp.eye(config["PARTNER_POP_SIZE"])
 
             update_runner_state = (
-                all_conf_optims, all_br_optims,
-                init_env_state, init_obs, init_done, init_conf_h, init_br_h,
-                rng, update_steps,
-                lagrange_multipliers_vertical, lagrange_multipliers_horizontal
+                all_conf_optims,
+                all_br_optims,
+                init_env_state,
+                init_obs,
+                init_done,
+                init_conf_h,
+                init_br_h,
+                rng,
+                update_steps,
+                lagrange_multipliers_vertical,
+                lagrange_multipliers_horizontal,
             )
 
             state_with_ckpt = (
-                update_runner_state, checkpoint_array_conf,
-                checkpoint_array_br, ckpt_idx, eval_ep_last_info
+                update_runner_state,
+                checkpoint_array_conf,
+                checkpoint_array_br,
+                ckpt_idx,
+                eval_ep_last_info,
             )
 
             # run training
@@ -923,12 +1321,15 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 _update_step_with_ckpt,
                 state_with_ckpt,
                 xs=None,
-                length=config["NUM_UPDATES"]
+                length=config["NUM_UPDATES"],
             )
 
             (
-                final_runner_state, checkpoint_array_conf, checkpoint_array_br,
-                final_ckpt_idx, all_ep_infos
+                final_runner_state,
+                checkpoint_array_conf,
+                checkpoint_array_br,
+                _final_ckpt_idx,
+                all_ep_infos,
             ) = state_with_ckpt
 
             out = {
@@ -936,12 +1337,13 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                 "final_params_br": final_runner_state[1].params,
                 "checkpoints_conf": checkpoint_array_conf,
                 "checkpoints_br": checkpoint_array_br,
-                "metrics": metrics, # metrics is from the perspective of the confederate agent (averaged over population)
-                "all_pair_returns": all_ep_infos
+                "metrics": metrics,  # metrics is from the perspective of the confederate agent (averaged over population)
+                "all_pair_returns": all_ep_infos,
             }
             return out
 
         return train
+
     # ------------------------------
     # Actually run the adversarial teammate training
     # ------------------------------
@@ -949,29 +1351,28 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
     out = train_fn(train_rng)
     return out
 
+
 def get_lbrdiv_population(config, out, env):
-    '''
+    """
     Get the partner params and partner population for ego training.
-    '''
+    """
     pop_size = config["algorithm"]["PARTNER_POP_SIZE"]
 
     # partner_params has shape (num_seeds, pop_size, ...)
-    partner_params = out['final_params_conf']
+    partner_params = out["final_params_conf"]
 
     partner_policy = ActorWithConditionalCriticPolicy(
         action_dim=env.action_space(env.agents[1]).n,
         obs_dim=env.observation_space(env.agents[1]).shape[0],
-        pop_size=pop_size, # used to create onehot agent id
-        activation=config["algorithm"].get("ACTIVATION", "tanh")
+        pop_size=pop_size,  # used to create onehot agent id
+        activation=config["algorithm"].get("ACTIVATION", "tanh"),
     )
 
     # Create partner population
-    partner_population = AgentPopulation(
-        pop_size=pop_size,
-        policy_cls=partner_policy
-    )
+    partner_population = AgentPopulation(pop_size=pop_size, policy_cls=partner_policy)
 
     return partner_params, partner_population
+
 
 def run_lbrdiv(config, wandb_logger):
     algorithm_config = dict(config["algorithm"])
@@ -1002,7 +1403,13 @@ def run_lbrdiv(config, wandb_logger):
     with jax.disable_jit(False):
         vmapped_train_fn = jax.jit(
             jax.vmap(
-                partial(train_lbrdiv_partners, env=env, config=algorithm_config, conf_policy=conf_policy, br_policy=br_policy)
+                partial(
+                    train_lbrdiv_partners,
+                    env=env,
+                    config=algorithm_config,
+                    conf_policy=conf_policy,
+                    br_policy=br_policy,
+                )
             )
         )
         out = vmapped_train_fn(rngs)
@@ -1021,7 +1428,9 @@ def run_lbrdiv(config, wandb_logger):
 def log_metrics(config, outs, logger, metric_names: tuple):
     metrics = outs["metrics"]
     # metrics now has shape (num_seeds, num_updates, pop_size)
-    num_seeds, num_updates, pop_size = metrics["pg_loss_conf_agent"].shape # number of trained pairs
+    _num_seeds, num_updates, pop_size = metrics[
+        "pg_loss_conf_agent"
+    ].shape  # number of trained pairs
 
     ### Log evaluation metrics
     # shape (num_seeds, num_updates, (pop_size)^2)  [pre-scalarized: mean over eval eps and agents taken inside scan]
@@ -1029,7 +1438,7 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     xs = list(range(num_updates))
 
     all_conf_ids, all_br_ids = _get_all_ids(pop_size)
-    sp_mask = (all_conf_ids == all_br_ids)
+    sp_mask = all_conf_ids == all_br_ids
     sp_returns = all_returns[:, :, sp_mask]
     xp_returns = all_returns[:, :, ~sp_mask]
 
@@ -1051,10 +1460,16 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     # shape (num_seeds, num_updates, update_epochs, num_minibatches, pop_size)
     # Average over seeds
     processed_losses = {
-        "ConfPGLoss": np.asarray(metrics["pg_loss_conf_agent"]).mean(axis=0).transpose(),
+        "ConfPGLoss": np.asarray(metrics["pg_loss_conf_agent"])
+        .mean(axis=0)
+        .transpose(),
         "BRPGLoss": np.asarray(metrics["pg_loss_br_agent"]).mean(axis=0).transpose(),
-        "ConfValLoss": np.asarray(metrics["value_loss_conf_agent"]).mean(axis=0).transpose(),
-        "BRValLoss": np.asarray(metrics["value_loss_br_agent"]).mean(axis=0).transpose(),
+        "ConfValLoss": np.asarray(metrics["value_loss_conf_agent"])
+        .mean(axis=0)
+        .transpose(),
+        "BRValLoss": np.asarray(metrics["value_loss_br_agent"])
+        .mean(axis=0)
+        .transpose(),
         "ConfEntropy": np.asarray(metrics["entropy_conf"]).mean(axis=0).transpose(),
         "BREntropy": np.asarray(metrics["entropy_br"]).mean(axis=0).transpose(),
     }
@@ -1064,9 +1479,11 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     for loss_name, loss_data in processed_losses.items():
         if np.isnan(loss_data).any():
             raise ValueError(f"Found nan in loss {loss_name}")
-        logger.log_item(f"Losses/{loss_name}",
-            wandb.plot.line_series(xs=xs, ys=loss_data, keys=keys,
-            title=loss_name, xname="train_step")
+        logger.log_item(
+            f"Losses/{loss_name}",
+            wandb.plot.line_series(
+                xs=xs, ys=loss_data, keys=keys, title=loss_name, xname="train_step"
+            ),
         )
 
     # Average over seeds for Lagrange multipliers
@@ -1074,8 +1491,10 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     lm_horizontal = np.asarray(metrics["lms_horizontal"]).mean(axis=0)
     lm_vertical = np.asarray(metrics["lms_vertical"]).mean(axis=0)
     lagrange_multipliers = {
-        "LMs_Horizontal": np.reshape(lm_horizontal, (lm_horizontal.shape[0], -1)).transpose(),
-        "LMs_Vertical": np.reshape(lm_vertical, (lm_vertical.shape[0], -1)).transpose()
+        "LMs_Horizontal": np.reshape(
+            lm_horizontal, (lm_horizontal.shape[0], -1)
+        ).transpose(),
+        "LMs_Vertical": np.reshape(lm_vertical, (lm_vertical.shape[0], -1)).transpose(),
     }
 
     for array_name, array_data in lagrange_multipliers.items():
@@ -1083,8 +1502,9 @@ def log_metrics(config, outs, logger, metric_names: tuple):
             raise ValueError(f"Found nan in loss {array_name}")
         logger.log_item(
             f"Losses/{array_name}",
-            wandb.plot.line_series(xs=xs, ys=array_data, keys=lm_keys,
-            title=array_name, xname="train_step")
+            wandb.plot.line_series(
+                xs=xs, ys=array_data, keys=lm_keys, title=array_name, xname="train_step"
+            ),
         )
     logger.commit()
 
@@ -1093,7 +1513,9 @@ def log_metrics(config, outs, logger, metric_names: tuple):
     # Save train run output and log to wandb as artifact
     out_savepath = save_train_run(outs, savedir, savename="saved_train_run")
     if config["logger"]["log_train_out"]:
-        logger.log_artifact(name="saved_train_run", path=out_savepath, type_name="train_run")
+        logger.log_artifact(
+            name="saved_train_run", path=out_savepath, type_name="train_run"
+        )
 
     # Cleanup locally logged out files
     if not config["local_logger"]["save_train_out"]:

--- a/teammate_generation/LBRDiv.py
+++ b/teammate_generation/LBRDiv.py
@@ -575,7 +575,7 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         _, value_xp_vary_conf, _, _ = br_policy.get_action_value_policy(
                             params=param,
                             obs=batch.obs,
-                            done=batch.done,
+                            done=batch.prev_done,
                             avail_actions=batch.avail_actions,
                             hstate=init_br_hstate,
                             rng=jax.random.PRNGKey(0),
@@ -623,7 +623,7 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         _, value_xp_vary_br, _, _ = br_policy.get_action_value_policy(
                             params=param,
                             obs=batch.obs,
-                            done=batch.done,
+                            done=batch.prev_done,
                             avail_actions=batch.avail_actions,
                             hstate=init_br_hstate,
                             rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here
@@ -701,7 +701,7 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     _, value_sp_pop_is_br, _, _ = br_policy.get_action_value_policy(
                         params=param_br_id,
                         obs=batch.obs,
-                        done=batch.done,
+                        done=batch.prev_done,
                         avail_actions=batch.avail_actions,
                         hstate=init_br_hstate,
                         rng=jax.random.PRNGKey(0),
@@ -712,7 +712,7 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     _, value_sp_pop_is_not_br, _, _ = br_policy.get_action_value_policy(
                         params=param_conf_id,
                         obs=batch.obs,
-                        done=batch.done,
+                        done=batch.prev_done,
                         avail_actions=batch.avail_actions,
                         hstate=init_br_hstate,
                         rng=jax.random.PRNGKey(0),

--- a/teammate_generation/LBRDiv.py
+++ b/teammate_generation/LBRDiv.py
@@ -226,7 +226,8 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     log_prob=logp_0,
                     obs=last_obs["agent_0"],
                     info=info_0,
-                    avail_actions=avail_actions_0
+                    avail_actions=avail_actions_0,
+                    prev_done=last_done["agent_0"]
                 )
 
                 transition_1 = XPTransition(
@@ -239,7 +240,8 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                     log_prob=logp_1,
                     obs=last_obs["agent_1"],
                     info=info_1,
-                    avail_actions=avail_actions_1
+                    avail_actions=avail_actions_1,
+                    prev_done=last_done["agent_1"]
                 )
                 new_runner_state = (all_train_state_conf, all_train_state_br, updated_conf_ids, updated_br_ids,
                                     env_state_next, obs_next, done, new_conf_h, new_br_h, rng)
@@ -301,7 +303,7 @@ def train_lbrdiv_partners(train_rng, env, config, conf_policy, br_policy):
                         _, value, pi, _ = agent_policy.get_action_value_policy(
                             params=squeezed_param,
                             obs=traj_batch.obs,
-                            done=traj_batch.done,
+                            done=traj_batch.prev_done,
                             avail_actions=traj_batch.avail_actions,
                             hstate=init_hstate,
                             rng=jax.random.PRNGKey(0), # only used for action sampling, which is not used here

--- a/tests/test_done_alignment.py
+++ b/tests/test_done_alignment.py
@@ -1,0 +1,87 @@
+"""Verify that replaying a trajectory with the stored pre-step done (prev_done)
+reproduces the stepwise rollout outputs exactly, and that replaying with the
+post-step done (the old behavior) does not.
+
+Rollouts step recurrent nets one step at a time with the done observed BEFORE
+the step (prev_done); the nets reset the carry before processing input t. The
+PPO replay must therefore also be fed prev_done, not the post-step done stored
+for GAE.
+"""
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")  # deterministic numerics for exact comparison
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from agents.rnn_actor_critic_agent import RNNActorCriticPolicy
+from agents.s5_actor_critic_agent import S5ActorCriticPolicy
+
+T, B, OBS, ACT = 8, 4, 6, 5
+# Episode boundary mid-trajectory: post-step done fires at t=3, so prev_done
+# fires at t=4.
+DONE_NEXT = jnp.zeros((T, B), dtype=bool).at[3].set(True)
+PREV_DONE = jnp.zeros((T, B), dtype=bool).at[4].set(True)
+
+
+def _make(policy_cls, **kwargs):
+    policy = policy_cls(action_dim=ACT, obs_dim=OBS, **kwargs)
+    params = policy.init_params(jax.random.PRNGKey(0))
+    return policy, params
+
+
+def _rollout_stepwise(policy, params, obs, prev_done, avail):
+    hstate = policy.init_hstate(B)
+    vals, logits = [], []
+    for t in range(T):
+        _, v, pi, hstate = policy.get_action_value_policy(
+            params=params,
+            obs=obs[t][None],
+            done=prev_done[t][None],
+            avail_actions=avail[t][None],
+            hstate=hstate,
+            rng=jax.random.PRNGKey(0),
+        )
+        vals.append(v.squeeze(0))
+        logits.append(pi.logits.squeeze(0))
+    return jnp.stack(vals), jnp.stack(logits)
+
+
+def _replay(policy, params, obs, done, avail):
+    _, v, pi, _ = policy.get_action_value_policy(
+        params=params,
+        obs=obs,
+        done=done,
+        avail_actions=avail,
+        hstate=policy.init_hstate(B),
+        rng=jax.random.PRNGKey(0),
+    )
+    return v, pi.logits
+
+
+@pytest.mark.parametrize("policy_cls,kwargs", [
+    (RNNActorCriticPolicy, {}),
+    (S5ActorCriticPolicy, {}),
+])
+def test_replay_with_prev_done_matches_rollout(policy_cls, kwargs):
+    policy, params = _make(policy_cls, **kwargs)
+    rng = jax.random.PRNGKey(1)
+    obs = jax.random.normal(rng, (T, B, OBS))
+    avail = jnp.ones((T, B, ACT))
+
+    roll_v, roll_logits = _rollout_stepwise(policy, params, obs, PREV_DONE, avail)
+    replay_v, replay_logits = _replay(policy, params, obs, PREV_DONE, avail)
+    good_diff = max(
+        float(jnp.abs(roll_v - replay_v).max()),
+        float(jnp.abs(roll_logits - replay_logits).max()),
+    )
+    assert good_diff < 1e-5, f"replay with prev_done diverges from rollout (max diff {good_diff})"
+
+    # The old behavior (replaying with post-step done) resets one step early
+    # and must diverge at/after the episode boundary.
+    _, bad_logits = _replay(policy, params, obs, DONE_NEXT, avail)
+    bad_diff = float(jnp.abs(roll_logits - bad_logits).max())
+    assert bad_diff > 100 * max(good_diff, 1e-7), (
+        "replay with post-step done unexpectedly matched rollout; test is not discriminating"
+    )

--- a/tests/test_done_alignment.py
+++ b/tests/test_done_alignment.py
@@ -7,9 +7,12 @@ the step (prev_done); the nets reset the carry before processing input t. The
 PPO replay must therefore also be fed prev_done, not the post-step done stored
 for GAE.
 """
+
 import os
 
-os.environ.setdefault("JAX_PLATFORMS", "cpu")  # deterministic numerics for exact comparison
+os.environ.setdefault(
+    "JAX_PLATFORMS", "cpu"
+)  # deterministic numerics for exact comparison
 
 import jax
 import jax.numpy as jnp
@@ -60,10 +63,13 @@ def _replay(policy, params, obs, done, avail):
     return v, pi.logits
 
 
-@pytest.mark.parametrize("policy_cls,kwargs", [
-    (RNNActorCriticPolicy, {}),
-    (S5ActorCriticPolicy, {}),
-])
+@pytest.mark.parametrize(
+    "policy_cls,kwargs",
+    [
+        (RNNActorCriticPolicy, {}),
+        (S5ActorCriticPolicy, {}),
+    ],
+)
 def test_replay_with_prev_done_matches_rollout(policy_cls, kwargs):
     policy, params = _make(policy_cls, **kwargs)
     rng = jax.random.PRNGKey(1)
@@ -76,7 +82,9 @@ def test_replay_with_prev_done_matches_rollout(policy_cls, kwargs):
         float(jnp.abs(roll_v - replay_v).max()),
         float(jnp.abs(roll_logits - replay_logits).max()),
     )
-    assert good_diff < 1e-5, f"replay with prev_done diverges from rollout (max diff {good_diff})"
+    assert good_diff < 1e-5, (
+        f"replay with prev_done diverges from rollout (max diff {good_diff})"
+    )
 
     # The old behavior (replaying with post-step done) resets one step early
     # and must diverge at/after the episode boundary.


### PR DESCRIPTION
Rollouts step recurrent nets with the pre-step done, but Transitions stored the post-step done and PPO/decoder loss replays used it as the RNN reset signal — since ScannedRNN/S5/LSTM reset the carry before processing input t, replayed hidden-state resets landed one step early at every episode boundary. This adds a `prev_done` field to the Transitions (post-step `done` is kept for GAE) and passes it to all recurrent replays, and fixes MeLIBA's done-based recon-window segmentation to match.

Verified with a unit test (`tests/test_done_alignment.py`: full-sequence replay with prev_done matches stepwise rollout for GRU and S5; post-step done diverges), short smoke train runs of all 11 touched trainers, and temporary instrumentation confirming the PPO ratio is ~1 (max |ratio−1| ≤ 2.4e-7) at update 1, epoch 1, minibatch 1, including episode-boundary steps.