### PR TITLE
Fix COLE metasolver sampling, Shapley padding, wandb steps, and update budgeting

### DIFF
--- a/open_ended_training/cole.py
+++ b/open_ended_training/cole.py
@@ -750,7 +750,9 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
 
                     mask = traj_batch_xp.info.get("returned_episode", jnp.ones_like(traj_batch_xp.reward))
                     metric = jax.tree.map(lambda x: mask_and_mean(x, mask), traj_batch_xp.info)
-                    metric["update_steps"] = update_steps
+                    # Global step across generations so wandb curves don't overlap:
+                    # num_prev_trained_agents is 1 for the first trained generation.
+                    metric["update_steps"] = (num_prev_trained_agents - 1) * config["NUM_UPDATES"] + update_steps
                     metric["value_loss_xp"] = value_loss_xp.mean()
                     metric["value_loss_sp"] = value_loss_sp.mean()
 
@@ -1173,16 +1175,18 @@ def log_final_metrics(config, outs, logger, metric_names: tuple):
 
     for num_add_policies in range(trained_pop_size):
         for update_step in eval_steps:
+            # Global step across generations so wandb curves don't overlap
+            global_step = num_add_policies * num_updates + update_step
             logger.log_item(
-                "Eval/AvgSPReturnCurve", 
-                sp_return_curve[num_add_policies, update_step], 
-                train_step=update_step
+                "Eval/AvgSPReturnCurve",
+                sp_return_curve[num_add_policies, update_step],
+                train_step=global_step
                 )
             mean_xp_returns = xp_return_curve[num_add_policies, :, :(num_add_policies+1)].mean(axis=-1)
             logger.log_item(
-                "Eval/AvgXPReturnCurve", 
-                mean_xp_returns[update_step], 
-                train_step=update_step
+                "Eval/AvgXPReturnCurve",
+                mean_xp_returns[update_step],
+                train_step=global_step
                 )
     logger.commit()
 

--- a/open_ended_training/cole.py
+++ b/open_ended_training/cole.py
@@ -67,20 +67,19 @@ def initialize_agent(actor_type, config, env, rng):
 
 def compute_total_updates(config):
     '''Compute the total number of updates and updates per iter.
+
+    TOTAL_TIMESTEPS_PER_ITERATION counts training rollout steps only
+    (evaluation episodes are not budgeted), matching the convention used
+    by the other open-ended trainers (e.g. rotate).
     '''
-    # XP matrix evaluation episodes: XP_EVAL_ROLLOUT_EPS per agent pair.
-    xp_eval_steps = (
-        config["XP_EVAL_ROLLOUT_EPS"] 
-        * config["ROLLOUT_LENGTH"] 
-        * config["PARTNER_POP_SIZE"] ** 2
-    )
     # Training rollouts (SP, XP) per update
     training_steps_per_update = 2 * config["ROLLOUT_LENGTH"] * config["NUM_ENVS"]
     num_updates_per_iter = int(
-        (config["TOTAL_TIMESTEPS_PER_ITERATION"] - xp_eval_steps) 
-        // training_steps_per_update
+        config["TOTAL_TIMESTEPS_PER_ITERATION"] // training_steps_per_update
     )
-    total_num_updates = num_updates_per_iter * config["PARTNER_POP_SIZE"]
+    # Slot 0 holds the seeded random agent, so only PARTNER_POP_SIZE - 1
+    # agents are trained.
+    total_num_updates = num_updates_per_iter * (config["PARTNER_POP_SIZE"] - 1)
     return num_updates_per_iter, total_num_updates
 
 def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=None):

--- a/open_ended_training/cole.py
+++ b/open_ended_training/cole.py
@@ -239,16 +239,20 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
 
                     if config["METASOLVE_MODE"] == "shapley":
                         # Min-max normalise the XP matrix locally so all edge weights
-                        # are in [0, 1] for PageRank
-                        xp_min = jnp.min(xp_matrix)
-                        xp_max = jnp.max(xp_matrix)
+                        # are in [0, 1] for PageRank. Restrict to the trained sub-matrix:
+                        # untrained slots hold junk returns (vs. random-init params) that
+                        # would otherwise skew the normalisation range.
+                        valid_2d = valid_mask[:, None] & valid_mask[None, :]
+                        xp_min = jnp.min(jnp.where(valid_2d, xp_matrix, jnp.inf))
+                        xp_max = jnp.max(jnp.where(valid_2d, xp_matrix, -jnp.inf))
                         xp_range = jnp.maximum(xp_max - xp_min, 1e-8)
-                        xp_norm = (xp_matrix - xp_min) / xp_range
+                        xp_norm = jnp.where(valid_2d, (xp_matrix - xp_min) / xp_range, 0.0)
 
                         N = config["POP_SIZE"]
                         phi = shapley_values(
                             rng, xp_norm,
                             N=N,
+                            valid_mask=valid_mask,
                             max_iter=config["SHAPLEY_MAX_ITER"],
                             damping=config["SHAPLEY_PAGERANK_DAMPING"],
                             pagerank_max_iter=config["SHAPLEY_PAGERANK_ITER"],
@@ -478,9 +482,12 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                         needs_resample_xp, sampled_indices_all, partner_indices_xp
                     )
 
-                    # Update sampling distribution using UCB logic
+                    # Update sampling distribution using UCB logic. Scores are logits,
+                    # so add the UCB bonus in log space: the sampled distribution is
+                    # proportional to p_i * exp(bonus_i), keeping the metasolver term
+                    # on a comparable scale instead of being swamped by the bonus.
                     sum_counts = partner_visit_counts.sum()
-                    ucb_scores = init_sampling_dist + config["C_UCT"] * jnp.sqrt(sum_counts / (1 + partner_visit_counts))
+                    ucb_scores = init_log_sampling_dist + config["C_UCT"] * jnp.sqrt(sum_counts / (1 + partner_visit_counts))
                     pop_buffer = partner_population.update_scores(
                         pop_buffer, jnp.arange(config["POP_SIZE"]), ucb_scores
                     )
@@ -786,8 +793,12 @@ def train_cole_partners(train_rng, wandb_logger, env, config, progress_callback=
                 init_sampling_dist = metasolve_game_graph(
                     xp_matrix, num_existing_agents, metasolve_rng
                 )
+                # The buffer's softmax sampling strategy treats scores as logits, so
+                # store log-probabilities: softmax(log p) = p recovers the metasolver
+                # distribution exactly (temp=1).
+                init_log_sampling_dist = jnp.log(init_sampling_dist + 1e-8)
                 pop_buffer = partner_population.update_scores(
-                    pop_buffer, jnp.arange(config["POP_SIZE"]), init_sampling_dist
+                    pop_buffer, jnp.arange(config["POP_SIZE"]), init_log_sampling_dist
                 )
 
                 update_steps = 0

--- a/open_ended_training/shapley_utils.py
+++ b/open_ended_training/shapley_utils.py
@@ -182,6 +182,7 @@ def shapley_values(
     pagerank_max_iter: int = 100,
     tol: float = 1e-6,
     sigma_temperature: float = 10.0,
+    valid_mask: jnp.ndarray = None,
 ) -> jnp.ndarray:
     """Monte-Carlo Shapley value estimator over a population, given XP matrix.
 
@@ -216,10 +217,20 @@ def shapley_values(
         pagerank_max_iter: Maximum PageRank power iterations.
         tol:               PageRank convergence tolerance.
         sigma_temperature: Temperature for the difficulty-weight softmax.
+        valid_mask:        (N,) boolean — True for players that are part of the
+                           game. Invalid players are excluded from every sampled
+                           coalition and the Shapley weights use the number of
+                           valid players as the effective game size; their phi
+                           is returned as 0. None means all N players are valid.
 
     Returns:
         phi: (N,) float — Shapley value estimate for each player.
     """
+    if valid_mask is None:
+        valid_mask = jnp.ones(N, dtype=bool)
+    # Effective game size: coalitions are drawn from the valid players only.
+    n_valid = jnp.sum(valid_mask).astype(jnp.float32)
+
     # Split one key per player so each player's samples are independent.
     player_keys = jax.random.split(key, N)    # (N, 2)
 
@@ -230,8 +241,8 @@ def shapley_values(
         sample_keys = jax.random.split(player_key, max_iter)   # (max_iter, 2)
 
         def one_sample(sample_key):
-            # Sample S ⊆ players \ {i} via Bernoulli(0.5)
-            base_mask = jax.random.bernoulli(sample_key, p=0.5, shape=(N,))
+            # Sample S ⊆ valid players \ {i} via Bernoulli(0.5)
+            base_mask = jax.random.bernoulli(sample_key, p=0.5, shape=(N,)) & valid_mask
             s_mask = base_mask.at[i].set(False)   # S excludes player i
             s_with_i = s_mask.at[i].set(True)     # S ∪ {i}
 
@@ -253,14 +264,15 @@ def shapley_values(
 
             marginal = v_s_with_i - v_s
 
-            # ── Shapley weight w(|S|) = |S|! · (N−|S|−1)! / N! ─────────────
-            # Computed in log-space to handle large N without overflow.
+            # ── Shapley weight w(|S|) = |S|! · (n−|S|−1)! / n! over the n
+            # valid players. Computed in log-space to handle large n without
+            # overflow.
             s_size = jnp.sum(s_mask).astype(jnp.float32)   # |S|
             log_weight = (
-                (N - 1) * jnp.log(2.0)                      # log(2^{N-1}) to correct for uniform subset sampling
+                (n_valid - 1) * jnp.log(2.0)                # log(2^{n-1}) to correct for uniform subset sampling
                 + jsp.special.gammaln(s_size + 1)           # log(|S|!)
-                + jsp.special.gammaln(N - s_size)           # log((N−|S|−1)!)
-                - jsp.special.gammaln(N + 1)                # log(N!)
+                + jsp.special.gammaln(n_valid - s_size)     # log((n−|S|−1)!)
+                - jsp.special.gammaln(n_valid + 1)          # log(n!)
             )
             weight = jnp.exp(log_weight)
 
@@ -271,7 +283,7 @@ def shapley_values(
 
         return jnp.mean(samples)
 
-    # Vectorise over all N players simultaneously.
+    # Vectorise over all N players simultaneously; invalid players get phi = 0.
     players = jnp.arange(N)
     phi = jax.vmap(phi_for_player)(players, player_keys)
-    return phi
+    return jnp.where(valid_mask, phi, 0.0)


### PR DESCRIPTION
Fixes four bugs in the COLE implementation found by multi-agent review:

1. **Metasolver distribution flattened**: the Shapley/returns sampling distribution was stored as raw probabilities in `pop_buffer.scores`, but the buffer's softmax sampler treats scores as logits, capping any partner ratio at ~e and letting the unbounded UCB bonus dominate. Scores are now log-probabilities, so `softmax` recovers the metasolver distribution exactly and UCB acts as a bounded multiplicative bonus.
2. **Shapley over padded slots**: Shapley values were computed over the full `POP_SIZE` matrix including untrained slots (which hold junk returns vs. random-init params). `shapley_values` now takes a `valid_mask`: coalitions are sampled from trained agents only, weights use the effective game size, and XP normalization is restricted to the trained submatrix. Verified the masked estimator matches the ground-truth reduced game exactly.
3. **wandb step collision**: per-generation `update_steps` restarted at 0, overlaying all generations' curves. Steps are now global across generations (matching rotate.py).
4. **Update budgeting**: `compute_total_updates` deducted a wrong eval-step estimate and counted `PARTNER_POP_SIZE` generations though only `POP_SIZE-1` agents are trained. It now budgets training rollout steps only (rotate's convention).

Validation performance at the hqdudasd-best hparams (forced_coord, 3 seeds each): fixed 0.525 vs old 0.583 mean normalized return — within seed noise (old code alone spans 0.463–0.647; paired p≈0.33), so no significant degradation. Note the swept hparams were tuned under the buggy sampler (`C_UCT` changed meaning with log-scale scores), so a re-sweep may favor the fixed code. Also note `scripts/manage_configs/helpers.py` on expts computes COLE totals as `POP_SIZE × per_iter`; with the fixed semantics it should be `(POP_SIZE−1) × per_iter`.