### PR TITLE
Add install verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ pip install -e .
 
 On macOS, the platform-specific dependency path automatically installs CPU JAX instead of the CUDA build.
 
+Verify the install with:
+```bash
+python scripts/verify_install.py
+```
+
 Evaluating trained agents against the heldout evaluation set requires downloading the evaluation agents.
 We also provide the best returns achieved against each evaluation agent in our experiments.
 Directories containing both data can be obtained by running the provided data download script:

--- a/docs/install_instructions.md
+++ b/docs/install_instructions.md
@@ -26,16 +26,24 @@ pip install -e .
 
 This installs the default cross-platform dependency set from `pyproject.toml` and sets up the package for development.
 
-4. Verify that JAX is available by running `import jax; jax.devices()` in the Python interpreter.
-On Linux machines with NVIDIA GPUs and CUDA 12, the default install should show something like:
-```
-[CudaDevice(id=0)]
+4. Verify the installation:
+```bash
+python scripts/verify_install.py
 ```
 
-On macOS, the platform-specific dependency path installs CPU JAX automatically, so you should see:
+This reports the devices JAX can see and runs the array operations the training
+code relies on. On Linux with an NVIDIA GPU, the output should end with
+`All checks passed.` and look like:
 ```
-[CpuDevice(id=0)]
+jax 0.5.3, backend gpu, [CudaDevice(id=0)]
+[ok] devices
+[ok] matmul (cuBLAS)
+[ok] QR decomposition (cuSolver)
+[ok] orthogonal init (as used by agents/)
+All checks passed.
 ```
+Machines with several GPUs list one `CudaDevice` per GPU. On macOS, CPU JAX is
+installed automatically, so the backend is `cpu` and the device is `[CpuDevice(id=0)]`.
 
 5. Download evaluation data to get the evaluation agents:
 ```bash
@@ -96,10 +104,13 @@ python -m pip install "setuptools<81" --force-reinstall
 python -m pip install -e .
 ```
 
-## If the installed CUDA library is not found
+## CUDA library conflicts
 
-You may have a CUDA library installed elsewhere, check with `echo $LD_LIBRARY_PATH`. 
-If the output is not empty, use:
+`pip install -e .` installs its own CUDA 12 libraries. If a system CUDA toolkit is
+also on the library search path, the two can be mixed at runtime, which causes
+segfaults or cuBLAS/cuSolver errors *after* `jax.devices()` already reports a GPU.
+
+Check with `echo $LD_LIBRARY_PATH`. If the output is not empty, use:
 ```bash
 export LD_LIBRARY_PATH="" #so that it defaults to the pip-installed CUDA.
 conda env config vars set LD_LIBRARY_PATH= #so that it unsets the LD_LIBRARY_PATH when the conda environment is activated.

--- a/scripts/verify_install.py
+++ b/scripts/verify_install.py
@@ -1,0 +1,62 @@
+"""Check that the installation can actually run GPU training.
+
+Usage: python scripts/verify_install.py
+"""
+
+import sys
+import traceback
+
+import jax
+import jax.numpy as jnp
+import flax.linen as nn
+from flax.linen.initializers import orthogonal
+
+
+def devices():
+    print(f"jax {jax.__version__}, backend {jax.default_backend()}, {jax.devices()}")
+
+
+def matmul():
+    a = jnp.ones((512, 512), dtype=jnp.float32)
+    (a @ a).block_until_ready()
+
+
+def qr():
+    jax.block_until_ready(jnp.linalg.qr(jnp.eye(8, dtype=jnp.float32)))
+
+
+def orthogonal_init():
+    layer = nn.Dense(64, kernel_init=orthogonal(jnp.sqrt(2)))
+    jax.block_until_ready(layer.init(jax.random.PRNGKey(0), jnp.zeros((1, 32))))
+
+
+CHECKS = [
+    ("devices", devices),
+    ("matmul (cuBLAS)", matmul),
+    ("QR decomposition (cuSolver)", qr),
+    ("orthogonal init (as used by agents/)", orthogonal_init),
+]
+
+HINT = """
+A segfault or a cuSolver/cuBLAS error here usually means a system CUDA toolkit on
+LD_LIBRARY_PATH is being mixed with the pip-installed CUDA libraries. See the
+troubleshooting section of docs/install_instructions.md.
+"""
+
+
+def main():
+    for name, fn in CHECKS:
+        try:
+            fn()
+        except Exception:
+            traceback.print_exc()
+            print(f"[FAIL] {name}")
+            print(HINT)
+            return 1
+        print(f"[ok] {name}")
+    print("All checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A user hit a CUDA failure on their cluster that passed the `jax.devices()` check in our install instructions and then failed once training actually started. Every network in `agents/` initializes with `orthogonal`, which goes through `jnp.linalg.qr` and therefore cuSolver, so that path runs on every training job but wasn't covered by the documented check.

Adds `scripts/verify_install.py`, which reports devices and runs a matmul, a QR decomposition, and an orthogonal `nn.Dense` init, stopping at the first failure. Install step 4 now runs it instead of `import jax; jax.devices()`. The existing CUDA troubleshooting section is retitled "CUDA library conflicts" and lists segfaults and cuBLAS/cuSolver errors as symptoms, so the `LD_LIBRARY_PATH` advice that was already there is findable from those symptoms.