### PR TITLE
Improve paper_vis radar charts and sweep distribution layout

### DIFF
--- a/scripts/paper_vis/plot_by_agent_type.py
+++ b/scripts/paper_vis/plot_by_agent_type.py
@@ -33,6 +33,9 @@ from scripts.paper_vis.plot_globals import (
 
 HEURISTIC_KEY = "heuristic"
 
+# High-contrast styling so overlapping traces stay distinguishable.
+METHOD_MARKERS = ['o', 's', '^', 'D', 'v', 'P', 'X', '*']
+
 AGENT_TYPE_DISPLAY = {
     "comedi": "CoMeDi",
     "lbrdiv": "LBRDiv",
@@ -99,8 +102,8 @@ def draw_radar_on_ax(
         max_value = max(max_value, max(values))
         closed_values = values + values[:1]
 
-        ax.plot(angles, closed_values, 'o-', linewidth=2, color=colors[i], label=method_name)
-        ax.fill(angles, closed_values, alpha=0.15, color=colors[i])
+        ax.plot(angles, closed_values, linewidth=2, color=colors[i], label=method_name,
+                marker=METHOD_MARKERS[i % len(METHOD_MARKERS)], markersize=6, alpha=0.85)
 
     ax.plot(angles, [1.0] * len(angles), '--', color='dimgray', linewidth=1.5,
             label='_nolegend_')
@@ -175,7 +178,7 @@ def plot_tasks(
     n_tasks = len(task_data)
     ncols = n_tasks
     nrows = 1
-    colors = plt.cm.Set2(np.arange(len(all_method_names)) / 10)
+    colors = plt.cm.tab10(np.arange(len(all_method_names)) % 10)
 
     fig = plt.figure(figsize=(ncols * 6, 6))
 
@@ -195,7 +198,8 @@ def plot_tasks(
 
     if show_legend and all_method_names:
         handles = [
-            plt.Line2D([0], [0], color=colors[i], linewidth=2, marker='o', label=name)
+            plt.Line2D([0], [0], color=colors[i], linewidth=2,
+                       marker=METHOD_MARKERS[i % len(METHOD_MARKERS)], label=name)
             for i, name in enumerate(all_method_names)
         ]
         fig.legend(

--- a/scripts/paper_vis/plot_sweep_distribution.py
+++ b/scripts/paper_vis/plot_sweep_distribution.py
@@ -82,7 +82,7 @@ def plot_distribution(
 ) -> None:
     algos = list(scores_by_algo.keys())
     n = len(algos)
-    ncols = min(n, 3)
+    ncols = min(n, 4)
     nrows = (n + ncols - 1) // ncols
 
     fig, axes = plt.subplots(
@@ -146,7 +146,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Plot performance distribution across all hyperparameter settings."
     )
-    parser.add_argument("--algo-type", choices=["ego", "unified"], required=True,
+    parser.add_argument("--algo-type", choices=["ego", "teammate_gen", "unified"], required=True,
                         help="Which sweep family to visualize.")
     parser.add_argument("--task", required=True,
                         help="Task name (e.g. lbf/lbf_7x7_nolevels).")
@@ -162,10 +162,15 @@ if __name__ == "__main__":
     FORCE_RECOMPUTE = args.force_recompute
     MAX_NUM_TO_VISUALIZE = args.max_hparams
 
+    ALGO_TYPE_TO_ENTRY_POINT = {
+        "ego": "ego_agent_training",
+        "teammate_gen": "teammate_generation",
+        "unified": "open_ended_training",
+    }
     all_task_sweeps = HYPERPARAM_SWEEPS[TASK]
     task_sweeps = {
         algo: sid for algo, sid in all_task_sweeps.items()
-        if (ALGO_TO_ENTRY_POINT.get(algo) == "ego_agent_training") == (ALGO_TYPE == "ego")
+        if ALGO_TO_ENTRY_POINT.get(algo) == ALGO_TYPE_TO_ENTRY_POINT[ALGO_TYPE]
     }
 
     scores_by_algo: dict[str, np.ndarray] = {}

--- a/scripts/paper_vis/run_plot_sweep_distribution.sh
+++ b/scripts/paper_vis/run_plot_sweep_distribution.sh
@@ -9,7 +9,7 @@ TASKS=(
 )
 
 for task in "${TASKS[@]}"; do
-    for algo_type in ego unified; do
+    for algo_type in ego teammate_gen unified; do
         echo "=== task=${task}  algo-type=${algo_type} ==="
         PYTHONPATH=. python scripts/paper_vis/plot_sweep_distribution.py \
             --algo-type "${algo_type}" \


### PR DESCRIPTION
Two plotting tweaks that were sitting on `benchmark_expts`, moved onto `expts` so they aren't stranded.

- Radar charts use `tab10` with distinct per-method markers instead of `Set2` with fills, so overlapping traces stay readable.
- Sweep distribution plots widen to 4 columns and split into ego / teammate_gen / unified.