### PR TITLE
Point plot_globals at the sept26 benchmark runs

### DIFF
--- a/evaluation/configs/heldout_ego_human_proxy.yaml
+++ b/evaluation/configs/heldout_ego_human_proxy.yaml
@@ -1,0 +1,47 @@
+# Standalone human-proxy heldout evaluation of a finished benchmark run's ego agent.
+# Used for older (neurips-era) teammate-generation runs whose heldout set predates
+# `human_proxy`; produces a wandb run shaped like the ego-method BC evals
+# (tag `bc_heldout_eval`, table + `heldout_eval_metrics` artifact) that
+# scripts/paper_vis merges in by partner name.
+defaults:
+  - task: lbf/lbf_7x7_nolevels
+  - global_heldout_settings
+  - hydra: hydra_simple
+  - _self_
+
+ENV_NAME: ${task.ENV_NAME}
+ENV_KWARGS: ${task.ENV_KWARGS}
+ROLLOUT_LENGTH: ${task.ROLLOUT_LENGTH}
+TASK_NAME: ${task.TASK_NAME}
+
+# Source benchmark run whose `ego_train_run` artifact is evaluated.
+source_run_id: ???
+source_entity: aht-project
+source_project: aht-benchmark
+# Heldout partners (keys of heldout_set[TASK_NAME]) to evaluate against.
+partners: [human_proxy]
+ego_test_mode: false
+
+label: bc_heldout
+# `method` is filled in from the source run's algorithm.ALG at runtime (the hydra
+# output dir is keyed by source_run_id instead, since it is resolved at launch).
+method: unknown
+name: ${TASK_NAME}/heldout_ego_bc/${source_run_id}/${label}
+
+logger:
+  project: aht-benchmark
+  entity: aht-project
+  tags:
+    - bc_heldout_eval
+    - ${TASK_NAME}
+    - ${method}
+    - ${method}_human_proxy
+    - source=${source_run_id}
+  mode: online
+  verbose: false
+  log_train_out: false
+  log_eval_out: true
+
+local_logger:
+  save_train_out: false
+  save_eval_out: true

--- a/evaluation/configs/heldout_ego_human_proxy.yaml
+++ b/evaluation/configs/heldout_ego_human_proxy.yaml
@@ -1,5 +1,5 @@
 # Standalone human-proxy heldout evaluation of a finished benchmark run's ego agent.
-# Used for older (neurips-era) teammate-generation runs whose heldout set predates
+# Used for older (may26-era) teammate-generation runs whose heldout set predates
 # `human_proxy`; produces a wandb run shaped like the ego-method BC evals
 # (tag `bc_heldout_eval`, table + `heldout_eval_metrics` artifact) that
 # scripts/paper_vis merges in by partner name.

--- a/evaluation/run_heldout_ego_human_proxy.py
+++ b/evaluation/run_heldout_ego_human_proxy.py
@@ -1,0 +1,116 @@
+"""Evaluate a finished benchmark run's ego agent against the human proxy teammate.
+
+Downloads the ``ego_train_run`` artifact of a teammate-generation benchmark run,
+rebuilds the ego policy from the run's own ``ego_train_algorithm`` config, and runs
+the standard heldout evaluation restricted to ``human_proxy`` (or any subset of
+partners). Results are logged to wandb exactly like a training run's heldout eval
+(``HeldoutEval/FinalEgoVsHeldout-*-CI`` table + ``heldout_eval_metrics`` artifact),
+so scripts/paper_vis can merge them by partner name.
+
+Run from repo root, e.g.:
+    PYTHONPATH=. python evaluation/run_heldout_ego_human_proxy.py \
+        task=overcooked-v1/cramped_room source_run_id=n1mplxeg
+"""
+
+import logging
+import os
+import tempfile
+
+import hydra
+import jax
+import wandb
+from omegaconf import OmegaConf, open_dict
+
+from common.plot_utils import get_metric_names
+from common.save_load_utils import load_train_run
+from common.wandb_visualizations import Logger
+from ego_agent_training.utils import initialize_ego_agent
+from envs import make_env
+from envs.log_wrapper import LogWrapper
+from evaluation.heldout_runner import log_heldout_metrics, run_heldout_evaluation
+
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def _download_ego_train_run(run, root):
+    for artifact in run.logged_artifacts():
+        if artifact.type == "train_run" and artifact.name.startswith("ego_train_run"):
+            log.info(f"Downloading {artifact.name} ({artifact.size / 1e6:.0f} MB)")
+            return artifact.download(root=root)
+    raise ValueError(f"Run {run.id} has no ego_train_run artifact.")
+
+
+@hydra.main(
+    version_base=None, config_path="configs", config_name="heldout_ego_human_proxy"
+)
+def main(cfg):
+    api = wandb.Api()
+    source = api.run(f"{cfg.source_entity}/{cfg.source_project}/{cfg.source_run_id}")
+    source_cfg = source.config
+    if source_cfg["TASK_NAME"] != cfg.TASK_NAME:
+        raise ValueError(
+            f"task={cfg.TASK_NAME} but source run {source.id} is {source_cfg['TASK_NAME']}"
+        )
+    ego_cfg = source_cfg["algorithm"]["ego_train_algorithm"]
+
+    with open_dict(cfg):
+        cfg.method = source_cfg["algorithm"]["ALG"]
+        cfg.name = f"{cfg.TASK_NAME}/heldout_ego_bc/{cfg.method}/{cfg.label}"
+        cfg.source_run_name = source.name
+        # log_heldout_metrics reads algorithm.ALG; keep the full source algorithm config
+        # for provenance.
+        cfg.algorithm = source_cfg["algorithm"]
+        cfg.heldout_set = {
+            cfg.TASK_NAME: {p: cfg.heldout_set[cfg.TASK_NAME][p] for p in cfg.partners}
+        }
+    print(OmegaConf.to_yaml(cfg, resolve=True))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        ckpt_dir = _download_ego_train_run(source, tmp)
+        out = load_train_run(os.path.abspath(ckpt_dir))
+    ego_params = out["final_params"]
+    num_seeds, num_ego_train_seeds = jax.tree.leaves(ego_params)[0].shape[:2]
+    log.info(f"Loaded ego params: {num_seeds} seeds x {num_ego_train_seeds} ego seeds")
+
+    # Older runs did not copy the env settings into the ego sub-config (and some
+    # have no ENV_KWARGS at all); fall back to the source run, then the task config.
+    env_name = ego_cfg.get("ENV_NAME") or source_cfg["ENV_NAME"]
+    env_kwargs = (
+        ego_cfg.get("ENV_KWARGS") or source_cfg.get("ENV_KWARGS") or cfg.ENV_KWARGS
+    )
+    env_kwargs = (
+        OmegaConf.to_container(env_kwargs, resolve=True)
+        if OmegaConf.is_config(env_kwargs)
+        else env_kwargs
+    )
+    log.info(f"Ego env: {env_name} {env_kwargs}")
+    env = LogWrapper(make_env(env_name, env_kwargs))
+    ego_policy, init_ego_params = initialize_ego_agent(
+        ego_cfg, env, jax.random.PRNGKey(0)
+    )
+
+    wandb_logger = Logger(cfg)
+    cfg = OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True)
+    eval_metrics, ego_names, heldout_names = run_heldout_evaluation(
+        cfg,
+        ego_policy,
+        ego_params,
+        init_ego_params,
+        ego_as_2d=False,
+        ego_test_mode=cfg["ego_test_mode"],
+    )
+    log_heldout_metrics(
+        cfg,
+        wandb_logger,
+        eval_metrics,
+        ego_names,
+        heldout_names,
+        get_metric_names(cfg["ENV_NAME"]),
+        ego_as_2d=False,
+    )
+    wandb_logger.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/experiments.sh
+++ b/scripts/benchmark/experiments.sh
@@ -193,7 +193,7 @@ for algo in "${algos[@]}"; do
             ego_seeds_arg="algorithm.ego_train_algorithm.NUM_EGO_TRAIN_SEEDS=1"
         fi
 
-        if XLA_FLAGS=--xla_disable_hlo_passes=fusion XLA_PYTHON_CLIENT_PREALLOCATE=false PYTHONPATH=. python "${entry_point}/run.py" \
+        if XLA_PYTHON_CLIENT_PREALLOCATE=false PYTHONPATH=. python "${entry_point}/run.py" \
             algorithm="${algo}/${task}" \
             task="${task}" \
             label="${label}" \

--- a/scripts/manage_configs/apply_best_hparams.py
+++ b/scripts/manage_configs/apply_best_hparams.py
@@ -13,15 +13,20 @@ import argparse
 import re
 from pathlib import Path
 
+import pandas as pd
+
 from scripts.manage_configs.helpers import format_value, resolve_algo_config
 from scripts.paper_vis.plot_globals import (
-    HYPERPARAM_SWEEPS, ENTITY, HYPERPARAM_PROJECT,
+    ENTITY,
+    HYPERPARAM_PROJECT,
+    HYPERPARAM_SWEEPS,
 )
 from scripts.utils import ALGO_TO_ENTRY_POINT
 from scripts.wandb_utils.wandb_cache import (
-    load_sweep_df, build_hparam_df, fetch_sweep_last_run_date,
+    build_hparam_df,
+    fetch_sweep_last_run_date,
+    load_sweep_df,
 )
-
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 
@@ -36,14 +41,24 @@ _EGO_ALGO_TO_CONFIG_NAME = {
 def _config_path(task: str, algorithm: str) -> Path:
     parts = task.split("/")
     if algorithm not in ALGO_TO_ENTRY_POINT:
-        raise ValueError(f"Unknown algorithm '{algorithm}'. Known: {list(ALGO_TO_ENTRY_POINT)}")
+        raise ValueError(
+            f"Unknown algorithm '{algorithm}'. Known: {list(ALGO_TO_ENTRY_POINT)}"
+        )
     root = ALGO_TO_ENTRY_POINT[algorithm]
     config_name = _EGO_ALGO_TO_CONFIG_NAME.get(algorithm, algorithm)
     if len(parts) == 1:
         return REPO_ROOT / root / "configs" / "algorithm" / config_name / f"{task}.yaml"
     task_family = "/".join(parts[:-1])
     task_name = parts[-1]
-    return REPO_ROOT / root / "configs" / "algorithm" / config_name / task_family / f"{task_name}.yaml"
+    return (
+        REPO_ROOT
+        / root
+        / "configs"
+        / "algorithm"
+        / config_name
+        / task_family
+        / f"{task_name}.yaml"
+    )
 
 
 # MeLIBA's KL loss is now summed over time and *averaged* over the batch. Sweeps that
@@ -58,14 +73,17 @@ _MELIBA_KL_FIX_DATE = "2026-08-30"
 _NON_HPARAM_KEYS = {"TOTAL_TIMESTEPS"}
 
 
-def _scale_meliba_kl_weight(task: str, best_hparams: dict, config_path: Path,
-                            sweep_id: str) -> None:
+def _scale_meliba_kl_weight(
+    task: str, best_hparams: dict, config_path: Path, sweep_id: str
+) -> None:
     """In-place: rescale MeLIBA's swept KL weight to the post-fix loss normalization.
 
     Only applied to sweeps whose most recent run predates _MELIBA_KL_FIX_DATE.
     """
     if _MELIBA_KL_KEY not in best_hparams:
-        print(f"  WARNING: {_MELIBA_KL_KEY} not in the sweep for {task}; no KL rescaling applied.")
+        print(
+            f"  WARNING: {_MELIBA_KL_KEY} not in the sweep for {task}; no KL rescaling applied."
+        )
         return
 
     last_run = fetch_sweep_last_run_date(sweep_id, ENTITY, HYPERPARAM_PROJECT)
@@ -73,8 +91,10 @@ def _scale_meliba_kl_weight(task: str, best_hparams: dict, config_path: Path,
         print(f"  WARNING: could not date sweep {sweep_id}; no KL rescaling applied.")
         return
     if last_run[:10] >= _MELIBA_KL_FIX_DATE:
-        print(f"  MeLIBA KL rescale skipped: sweep last ran {last_run[:10]}, "
-              f"on/after the {_MELIBA_KL_FIX_DATE} loss-normalization fix.")
+        print(
+            f"  MeLIBA KL rescale skipped: sweep last ran {last_run[:10]}, "
+            f"on/after the {_MELIBA_KL_FIX_DATE} loss-normalization fix."
+        )
         return
 
     algo_configs_root = config_path.parent
@@ -84,14 +104,18 @@ def _scale_meliba_kl_weight(task: str, best_hparams: dict, config_path: Path,
 
     # A swept value takes precedence over the config value.
     num_envs = float(best_hparams.get("NUM_ENVS", resolved["NUM_ENVS"]))
-    num_minibatches = float(best_hparams.get("NUM_MINIBATCHES", resolved["NUM_MINIBATCHES"]))
+    num_minibatches = float(
+        best_hparams.get("NUM_MINIBATCHES", resolved["NUM_MINIBATCHES"])
+    )
     scale = num_envs / num_minibatches
 
     raw = float(best_hparams[_MELIBA_KL_KEY])
     best_hparams[_MELIBA_KL_KEY] = raw * scale
-    print(f"  MeLIBA KL rescale: {_MELIBA_KL_KEY} {raw:g} * "
-          f"(NUM_ENVS {num_envs:g} / NUM_MINIBATCHES {num_minibatches:g} = {scale:g}) "
-          f"-> {raw * scale:g}")
+    print(
+        f"  MeLIBA KL rescale: {_MELIBA_KL_KEY} {raw:g} * "
+        f"(NUM_ENVS {num_envs:g} / NUM_MINIBATCHES {num_minibatches:g} = {scale:g}) "
+        f"-> {raw * scale:g}"
+    )
 
 
 def _set_top_level_key(content: str, key: str, new_val: str) -> str:
@@ -130,7 +154,9 @@ def _set_nested_key(content: str, parent: str, child: str, new_val: str) -> str:
     return "".join(new_lines)
 
 
-def update_config_file(config_path: Path, best_hparams: dict[str, str], dry_run: bool = False) -> None:
+def update_config_file(
+    config_path: Path, best_hparams: dict[str, str], dry_run: bool = False
+) -> None:
     content = config_path.read_text()
     changed_keys: list[str] = []
 
@@ -159,8 +185,21 @@ def update_config_file(config_path: Path, best_hparams: dict[str, str], dry_run:
         print(f"  Set {key}={best_hparams[key]}  →  {config_path}")
 
 
-def apply_algorithm(task: str, algorithm: str, force_recompute: bool, dry_run: bool,
-                    max_hparams: int | None = None, seed: int = 0) -> None:
+def select_hparam_settings(
+    task: str,
+    algorithm: str,
+    force_recompute: bool = False,
+    max_hparams: int | None = None,
+    seed: int = 0,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Return the hparam settings considered when picking the best config for task/algorithm.
+
+    Each row is one unique swept-hparam combination with its mean ``_score`` over seeds,
+    sorted best-first. With ``max_hparams`` set, a seeded random subset of that size is
+    drawn when the sweep ran more settings. This is the exact set the benchmark configs
+    were selected from (``--max-hparams 140 --seed 0``), so other tools (e.g. the sweep
+    distribution plots) should call this rather than re-deriving it.
+    """
     raw_df, bare_keys = load_sweep_df(task, algorithm, force_recompute)
     # Some sweep YAMLs pin the (reduced) sweep training budget under `parameters` rather
     # than in the `command` block, so it comes back as a single-valued "swept" key. It is
@@ -180,7 +219,23 @@ def apply_algorithm(task: str, algorithm: str, force_recompute: bool, dry_run: b
     )
     if max_hparams is not None and len(grouped) > max_hparams:
         print(f"Sampling {max_hparams} of {len(grouped)} hparam settings (seed={seed})")
-        grouped = grouped.sample(n=max_hparams, random_state=seed).sort_values("_score", ascending=False)
+        grouped = grouped.sample(n=max_hparams, random_state=seed).sort_values(
+            "_score", ascending=False
+        )
+    return grouped, bare_keys
+
+
+def apply_algorithm(
+    task: str,
+    algorithm: str,
+    force_recompute: bool,
+    dry_run: bool,
+    max_hparams: int | None = None,
+    seed: int = 0,
+) -> None:
+    grouped, bare_keys = select_hparam_settings(
+        task, algorithm, force_recompute, max_hparams=max_hparams, seed=seed
+    )
     best_row = grouped.iloc[0]
     raw_hparams = {key: best_row[key] for key in bare_keys}
 
@@ -189,8 +244,9 @@ def apply_algorithm(task: str, algorithm: str, force_recompute: bool, dry_run: b
         raise FileNotFoundError(f"Config file not found: {config_path}")
 
     if algorithm == "meliba":
-        _scale_meliba_kl_weight(task, raw_hparams, config_path,
-                                HYPERPARAM_SWEEPS[task][algorithm])
+        _scale_meliba_kl_weight(
+            task, raw_hparams, config_path, HYPERPARAM_SWEEPS[task][algorithm]
+        )
 
     best_hparams = {key: format_value(val) for key, val in raw_hparams.items()}
 
@@ -209,30 +265,59 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Apply the best sweep hyperparameters to the corresponding config file."
     )
-    parser.add_argument("--task", required=True, help="Task name (e.g. lbf/lbf_7x7_nolevels).")
-    parser.add_argument("--algorithm", default=None,
-                        help="Algorithm name (e.g. trajedi). Omit to run all algorithms for the task.")
-    parser.add_argument("--force-recompute", action="store_true",
-                        help="Re-fetch from wandb, ignoring the local cache.")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Print what would be written without modifying any files.")
-    parser.add_argument("--max-hparams", type=int, default=None,
-                        help="Maximum number of hparam settings to consider. If the sweep ran more, "
-                             "a random subset of this size is drawn (seeded, for reproducibility).")
-    parser.add_argument("--seed", type=int, default=0,
-                        help="Random seed used when subsampling hparam settings via --max-hparams.")
+    parser.add_argument(
+        "--task", required=True, help="Task name (e.g. lbf/lbf_7x7_nolevels)."
+    )
+    parser.add_argument(
+        "--algorithm",
+        default=None,
+        help="Algorithm name (e.g. trajedi). Omit to run all algorithms for the task.",
+    )
+    parser.add_argument(
+        "--force-recompute",
+        action="store_true",
+        help="Re-fetch from wandb, ignoring the local cache.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be written without modifying any files.",
+    )
+    parser.add_argument(
+        "--max-hparams",
+        type=int,
+        default=None,
+        help="Maximum number of hparam settings to consider. If the sweep ran more, "
+        "a random subset of this size is drawn (seeded, for reproducibility).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed used when subsampling hparam settings via --max-hparams.",
+    )
     args = parser.parse_args()
 
     if args.task not in HYPERPARAM_SWEEPS:
-        raise ValueError(f"Task '{args.task}' not found. Available: {list(HYPERPARAM_SWEEPS)}")
+        raise ValueError(
+            f"Task '{args.task}' not found. Available: {list(HYPERPARAM_SWEEPS)}"
+        )
 
-    algorithms = [args.algorithm] if args.algorithm else list(HYPERPARAM_SWEEPS[args.task])
+    algorithms = (
+        [args.algorithm] if args.algorithm else list(HYPERPARAM_SWEEPS[args.task])
+    )
 
     for algorithm in algorithms:
         if len(algorithms) > 1:
-            print(f"\n{'='*60}")
-        apply_algorithm(args.task, algorithm, args.force_recompute, args.dry_run,
-                        max_hparams=args.max_hparams, seed=args.seed)
+            print(f"\n{'=' * 60}")
+        apply_algorithm(
+            args.task,
+            algorithm,
+            args.force_recompute,
+            args.dry_run,
+            max_hparams=args.max_hparams,
+            seed=args.seed,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/paper_vis/README.md
+++ b/scripts/paper_vis/README.md
@@ -25,10 +25,6 @@ PYTHONPATH=. python scripts/paper_vis/benchmark_bar_charts.py --plot_type unifie
 PYTHONPATH=. python scripts/paper_vis/benchmark_bar_charts.py --plot_type ego --include_bc --filter_failed_seeds
 ```
 
-All figure scripts default to the benchmark tasks minus `PAPER_EXCLUDED_TASKS` in
-`plot_globals.py` (currently asymm_advantages, counter_circuit, forced_coord, held out of
-this paper revision to match the NeurIPS task set). Pass `--tasks ...` to override.
-
 **Key flags:**
 - `--use_best_returns_normalization` (default true) — renormalize by the best observed return per heldout agent instead of the original per-agent bounds
 - `--include_bc` (default false) — ensure the human proxy (BC) teammate is part of every method's heldout set. iclr26-era runs already evaluate against `human_proxy` as part of the heldout set; for older runs that lack it, the separate BC eval run listed in `BC_BENCHMARK_RUNS` is appended at plot time. The script prints a per-cell coverage report (`builtin` / `bc_merge` / `MISSING`) at the end

--- a/scripts/paper_vis/README.md
+++ b/scripts/paper_vis/README.md
@@ -8,15 +8,11 @@ conda activate bench311
 
 wandb run/sweep IDs for all plots are stored in [plot_globals.py](plot_globals.py).
 
-Downloaded wandb artifacts and computed stats are cached under `results/figures/cache/`
-(gitignored). From a worktree, symlink it to the main checkout's cache to avoid re-downloading.
+wandb downloads are cached in `results/figures/cache/` (gitignored; symlink it from worktrees).
 
-To regenerate all paper figures after changing run IDs in `plot_globals.py`, run in order:
-
-1. `recompute_best_returns.py --include_bc` (normalization bounds may shift)
-2. `benchmark_bar_charts.py` for `--plot_type unified` and `--plot_type ego` (see below)
-3. `plot_by_agent_type.py` (radar chart, `by_agent_type_br_norm.pdf`)
-4. `run_plot_sweep_distribution.sh`
+To regenerate all figures after changing run IDs, run in order:
+`recompute_best_returns.py --include_bc`, `benchmark_bar_charts.py` (unified and ego),
+`plot_by_agent_type.py` (radar), `run_plot_sweep_distribution.sh`.
 
 ---
 
@@ -37,25 +33,16 @@ PYTHONPATH=. python scripts/paper_vis/benchmark_bar_charts.py --plot_type ego --
 
 **Key flags:**
 - `--use_best_returns_normalization` (default true) — renormalize by the best observed return per heldout agent instead of the original per-agent bounds
-- `--include_bc` (default false) — ensure the human proxy (BC) teammate is part of every method's heldout set. sept26-era runs already evaluate against `human_proxy` as part of the heldout set; for older runs that lack it, the separate BC eval run listed in `BC_BENCHMARK_RUNS` is appended at plot time. The script prints a per-cell coverage report (`builtin` / `bc_merge` / `MISSING`) at the end
+- `--include_bc` (default false) — include the human proxy (BC) teammate in every cell, appending the separate BC eval from `BC_BENCHMARK_RUNS` for runs that lack it; prints a coverage report at the end
 - `--filter_failed_seeds` (default false) — filter out failed seeds
 - `--tasks lbf/lbf_7x7_nolevels overcooked-v1/cramped_room` — restrict to specific tasks
-- `--force_recompute` — re-download eval artifacts from wandb and recompute best returns and summary stats (normally unnecessary: caches are keyed by run IDs and invalidated automatically)
+- `--force_recompute` — re-download from wandb and recompute everything
 - `--save_dir PATH` — override output directory (default: `results/figures/`)
 
 Figures are saved as PDFs to `results/figures/`.
 
-### Heldout partner alignment
-
-Runs may differ in their heldout sets (e.g. 17 vs 18 partners when `human_proxy`
-was added), and the wandb run config does not preserve the heldout-set order, so
-partners are identified **by name** rather than by index. The partner order for
-each run is read from its logged `HeldoutEval/FinalEgoVsHeldout-*-CI` table
-(cached under `results/figures/cache/run_heldout_names/`), and per-partner
-bounds are looked up by name in the run config. See
-[heldout_partners.py](heldout_partners.py). Best returns, renormalization, and
-BC merging all operate on these named partners, so runs with different heldout
-sets can be compared as long as their common partners share names.
+Heldout partners are matched across runs by name, not index, so runs with
+different heldout sets can be compared (see [heldout_partners.py](heldout_partners.py)).
 
 ---
 
@@ -80,10 +67,9 @@ best-seen BR exceeds it.
 Performance bounds stored in `global_heldout_settings.yaml` are the original
 normalization maxima used at evaluation time. `compute_best_returns.py` scans
 all benchmark runs for each task and computes the highest return actually
-observed for each heldout agent (by name), caching results in
-`results/figures/cache/best_returns/<task>.json` together with a `_labels`
-list giving the partner order. Pass `--include_bc` to also scan the separate
-BC eval runs for methods whose heldout set lacks `human_proxy`.
+observed for each heldout agent, caching results in
+`results/figures/cache/best_returns/<task>.json`. Pass `--include_bc` to also
+scan the separate BC eval runs.
 
 To force recomputation from locally cached wandb artifacts (re-downloads from
 wandb only for runs not yet cached locally):
@@ -110,12 +96,8 @@ sweeps. Sweep IDs are stored in `plot_globals.py` under `HYPERPARAM_SWEEPS`.
 bash scripts/paper_vis/run_plot_sweep_distribution.sh
 ```
 
-Each point is one unique hyperparameter setting (mean score over its seeds). By
-default only the settings actually considered when the benchmark configs were
-chosen are shown: the seeded 140-setting subsample drawn by
-`scripts/manage_configs/apply_best_hparams.py --max-hparams 140 --seed 0`
-(`select_hparam_settings` there is the single source of truth; sweeps with at
-most 140 settings are shown in full). Use `--max-hparams 0` to plot every setting,
-or `--max-hparams N --seed S` to match a different selection.
+Each point is one hyperparameter setting (mean over seeds). By default only the
+140 settings sampled by `scripts/manage_configs/apply_best_hparams.py` (seed 0)
+are shown; use `--max-hparams 0` to plot all of them.
 
 Figures are saved to `results/figures/`.

--- a/scripts/paper_vis/README.md
+++ b/scripts/paper_vis/README.md
@@ -100,4 +100,12 @@ sweeps. Sweep IDs are stored in `plot_globals.py` under `HYPERPARAM_SWEEPS`.
 bash scripts/paper_vis/run_plot_sweep_distribution.sh
 ```
 
+Each point is one unique hyperparameter setting (mean score over its seeds). By
+default only the settings actually considered when the benchmark configs were
+chosen are shown: the seeded 140-setting subsample drawn by
+`scripts/manage_configs/apply_best_hparams.py --max-hparams 140 --seed 0`
+(`select_hparam_settings` there is the single source of truth; sweeps with at
+most 140 settings are shown in full). Use `--max-hparams 0` to plot every setting,
+or `--max-hparams N --seed S` to match a different selection.
+
 Figures are saved to `results/figures/`.

--- a/scripts/paper_vis/README.md
+++ b/scripts/paper_vis/README.md
@@ -27,13 +27,25 @@ PYTHONPATH=. python scripts/paper_vis/benchmark_bar_charts.py --plot_type ego --
 
 **Key flags:**
 - `--use_best_returns_normalization` (default true) — renormalize by the best observed return per heldout agent instead of the original per-agent bounds
-- `--include_bc` (default false) — include BC evaluation results (where available) in the benchmark
+- `--include_bc` (default false) — ensure the human proxy (BC) teammate is part of every method's heldout set. iclr26-era runs already evaluate against `human_proxy` as part of the heldout set; for older runs that lack it, the separate BC eval run listed in `BC_BENCHMARK_RUNS` is appended at plot time. The script prints a per-cell coverage report (`builtin` / `bc_merge` / `MISSING`) at the end
 - `--filter_failed_seeds` (default false) — filter out failed seeds
 - `--tasks lbf/lbf_7x7_nolevels overcooked-v1/cramped_room` — restrict to specific tasks
-- `--force_recompute` — recompute summary stats from cached wandb artifacts (does not re-download from wandb)
+- `--force_recompute` — re-download eval artifacts from wandb and recompute best returns and summary stats (normally unnecessary: caches are keyed by run IDs and invalidated automatically)
 - `--save_dir PATH` — override output directory (default: `results/figures/`)
 
 Figures are saved as PDFs to `results/figures/`.
+
+### Heldout partner alignment
+
+Runs may differ in their heldout sets (e.g. 17 vs 18 partners when `human_proxy`
+was added), and the wandb run config does not preserve the heldout-set order, so
+partners are identified **by name** rather than by index. The partner order for
+each run is read from its logged `HeldoutEval/FinalEgoVsHeldout-*-CI` table
+(cached under `results/figures/cache/run_heldout_names/`), and per-partner
+bounds are looked up by name in the run config. See
+[heldout_partners.py](heldout_partners.py). Best returns, renormalization, and
+BC merging all operate on these named partners, so runs with different heldout
+sets can be compared as long as their common partners share names.
 
 ---
 
@@ -58,8 +70,10 @@ best-seen BR exceeds it.
 Performance bounds stored in `global_heldout_settings.yaml` are the original
 normalization maxima used at evaluation time. `compute_best_returns.py` scans
 all benchmark runs for each task and computes the highest return actually
-observed for each heldout agent, caching results in
-`results/figures/cache/best_returns/<task>.json`.
+observed for each heldout agent (by name), caching results in
+`results/figures/cache/best_returns/<task>.json` together with a `_labels`
+list giving the partner order. Pass `--include_bc` to also scan the separate
+BC eval runs for methods whose heldout set lacks `human_proxy`.
 
 To force recomputation from locally cached wandb artifacts (re-downloads from
 wandb only for runs not yet cached locally):

--- a/scripts/paper_vis/README.md
+++ b/scripts/paper_vis/README.md
@@ -37,7 +37,7 @@ PYTHONPATH=. python scripts/paper_vis/benchmark_bar_charts.py --plot_type ego --
 
 **Key flags:**
 - `--use_best_returns_normalization` (default true) — renormalize by the best observed return per heldout agent instead of the original per-agent bounds
-- `--include_bc` (default false) — ensure the human proxy (BC) teammate is part of every method's heldout set. iclr26-era runs already evaluate against `human_proxy` as part of the heldout set; for older runs that lack it, the separate BC eval run listed in `BC_BENCHMARK_RUNS` is appended at plot time. The script prints a per-cell coverage report (`builtin` / `bc_merge` / `MISSING`) at the end
+- `--include_bc` (default false) — ensure the human proxy (BC) teammate is part of every method's heldout set. sept26-era runs already evaluate against `human_proxy` as part of the heldout set; for older runs that lack it, the separate BC eval run listed in `BC_BENCHMARK_RUNS` is appended at plot time. The script prints a per-cell coverage report (`builtin` / `bc_merge` / `MISSING`) at the end
 - `--filter_failed_seeds` (default false) — filter out failed seeds
 - `--tasks lbf/lbf_7x7_nolevels overcooked-v1/cramped_room` — restrict to specific tasks
 - `--force_recompute` — re-download eval artifacts from wandb and recompute best returns and summary stats (normally unnecessary: caches are keyed by run IDs and invalidated automatically)

--- a/scripts/paper_vis/README.md
+++ b/scripts/paper_vis/README.md
@@ -8,6 +8,16 @@ conda activate bench311
 
 wandb run/sweep IDs for all plots are stored in [plot_globals.py](plot_globals.py).
 
+Downloaded wandb artifacts and computed stats are cached under `results/figures/cache/`
+(gitignored). From a worktree, symlink it to the main checkout's cache to avoid re-downloading.
+
+To regenerate all paper figures after changing run IDs in `plot_globals.py`, run in order:
+
+1. `recompute_best_returns.py --include_bc` (normalization bounds may shift)
+2. `benchmark_bar_charts.py` for `--plot_type unified` and `--plot_type ego` (see below)
+3. `plot_by_agent_type.py` (radar chart, `by_agent_type_br_norm.pdf`)
+4. `run_plot_sweep_distribution.sh`
+
 ---
 
 ## Benchmark bar charts

--- a/scripts/paper_vis/README.md
+++ b/scripts/paper_vis/README.md
@@ -25,6 +25,10 @@ PYTHONPATH=. python scripts/paper_vis/benchmark_bar_charts.py --plot_type unifie
 PYTHONPATH=. python scripts/paper_vis/benchmark_bar_charts.py --plot_type ego --include_bc --filter_failed_seeds
 ```
 
+All figure scripts default to the benchmark tasks minus `PAPER_EXCLUDED_TASKS` in
+`plot_globals.py` (currently asymm_advantages, counter_circuit, forced_coord, held out of
+this paper revision to match the NeurIPS task set). Pass `--tasks ...` to override.
+
 **Key flags:**
 - `--use_best_returns_normalization` (default true) — renormalize by the best observed return per heldout agent instead of the original per-agent bounds
 - `--include_bc` (default false) — ensure the human proxy (BC) teammate is part of every method's heldout set. iclr26-era runs already evaluate against `human_proxy` as part of the heldout set; for older runs that lack it, the separate BC eval run listed in `BC_BENCHMARK_RUNS` is appended at plot time. The script prints a per-cell coverage report (`builtin` / `bc_merge` / `MISSING`) at the end

--- a/scripts/paper_vis/benchmark_bar_charts.py
+++ b/scripts/paper_vis/benchmark_bar_charts.py
@@ -445,7 +445,9 @@ if __name__ == "__main__":
         return entry or None
 
     all_task_results = {}
-    ego_run_info: list[tuple[str, str, str]] = []  # (display_name, base_name, hatch)
+    # (display_name, base_name, hatch, teammate_type); bars are grouped by
+    # teammate type (all FCP-trained runs first, then CoMeDi-trained).
+    ego_run_info: list[tuple[str, str, str, str]] = []
     ego_seen: set[str] = set()
 
     for task_name in task_list:
@@ -484,7 +486,9 @@ if __name__ == "__main__":
                     if display_name not in ego_seen:
                         ego_seen.add(display_name)
                         hatch = TEAMMATE_HATCH.get(teammate_type, "")
-                        ego_run_info.append((display_name, base_name, hatch))
+                        ego_run_info.append(
+                            (display_name, base_name, hatch, teammate_type)
+                        )
 
                     bc_run_id = (
                         _bc_run_id(task_name, method_name, teammate_type)
@@ -525,7 +529,13 @@ if __name__ == "__main__":
             savedir=args.save_dir,
             savename=f"all_tasks_{args.plot_type}_{norm_suffix}",
             show_plot=args.show_plots,
-            run_info=ego_run_info,
+            run_info=[
+                info[:3]
+                for info in sorted(
+                    ego_run_info,
+                    key=lambda info: list(TEAMMATE_HATCH).index(info[3]),
+                )
+            ],
         )
     elif len(all_task_results) == 1:
         task_name = next(iter(all_task_results))

--- a/scripts/paper_vis/benchmark_bar_charts.py
+++ b/scripts/paper_vis/benchmark_bar_charts.py
@@ -388,7 +388,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tasks",
         nargs="+",
-        help="Tasks to plot. Defaults to all tasks with benchmark runs except PAPER_EXCLUDED_TASKS.",
+        help="Tasks to plot. Defaults to PAPER_TASKS.",
     )
     parser.add_argument(
         "--force_recompute",
@@ -422,7 +422,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # Tasks with at least one benchmark run, minus this revision's excluded tasks
+    # This revision's paper tasks that have benchmark runs
     task_list = (
         args.tasks
         if args.tasks

--- a/scripts/paper_vis/benchmark_bar_charts.py
+++ b/scripts/paper_vis/benchmark_bar_charts.py
@@ -410,7 +410,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--include_bc",
         action="store_true",
-        help="Include the human proxy partner in every cell: iclr26-era runs already "
+        help="Include the human proxy partner in every cell: sept26-era runs already "
         "evaluate against it; for older runs the separate BC heldout-eval artifact "
         "(BC_BENCHMARK_RUNS) is appended along the partner axis. Cells with neither "
         "are reported at the end.",

--- a/scripts/paper_vis/benchmark_bar_charts.py
+++ b/scripts/paper_vis/benchmark_bar_charts.py
@@ -10,6 +10,7 @@ from scripts.paper_vis.plot_globals import (
     TASK_TO_AXIS_DISPLAY_NAME,
     TASK_TO_METRIC_NAME,
     TITLE_FONTSIZE,
+    paper_tasks,
 )
 from scripts.paper_vis.process_data import load_results_for_task
 
@@ -387,7 +388,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tasks",
         nargs="+",
-        help="Tasks to plot. Defaults to all tasks with benchmark runs.",
+        help="Tasks to plot. Defaults to all tasks with benchmark runs except PAPER_EXCLUDED_TASKS.",
     )
     parser.add_argument(
         "--force_recompute",
@@ -421,11 +422,12 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # Collect tasks that have at least one benchmark run defined
-    all_tasks = sorted(
-        set(EGO_BENCHMARK_RUNS.keys()) | set(UNIFIED_BENCHMARK_RUNS.keys())
+    # Tasks with at least one benchmark run, minus this revision's excluded tasks
+    task_list = (
+        args.tasks
+        if args.tasks
+        else paper_tasks(EGO_BENCHMARK_RUNS, UNIFIED_BENCHMARK_RUNS)
     )
-    task_list = args.tasks if args.tasks else all_tasks
 
     if args.include_bc:
         norm_suffix = "with_bc"

--- a/scripts/paper_vis/benchmark_bar_charts.py
+++ b/scripts/paper_vis/benchmark_bar_charts.py
@@ -1,20 +1,33 @@
-import os
-import numpy as np
-import matplotlib.pyplot as plt
 import argparse
+import os
 
-from scripts.paper_vis.process_data import load_results_for_task, load_results_for_task_merged
+import matplotlib.pyplot as plt
+import numpy as np
+
 from scripts.paper_vis.plot_globals import (
-    TITLE_FONTSIZE, AXIS_LABEL_FONTSIZE, LEGEND_FONTSIZE,
-    TASK_TO_AXIS_DISPLAY_NAME, TASK_TO_METRIC_NAME,
+    AXIS_LABEL_FONTSIZE,
+    LEGEND_FONTSIZE,
+    TASK_TO_AXIS_DISPLAY_NAME,
+    TASK_TO_METRIC_NAME,
+    TITLE_FONTSIZE,
 )
+from scripts.paper_vis.process_data import load_results_for_task
 
-plt.rcParams['xtick.labelsize'] = AXIS_LABEL_FONTSIZE
-plt.rcParams['ytick.labelsize'] = AXIS_LABEL_FONTSIZE
+plt.rcParams["xtick.labelsize"] = AXIS_LABEL_FONTSIZE
+plt.rcParams["ytick.labelsize"] = AXIS_LABEL_FONTSIZE
 
-def plot_single_bar_chart(results, metric_name: str, aggregate_stat_name: str,
-                          task_display_name: str, plot_title: str,
-                          save: bool, savedir: str, show_plot: bool, savename: str):
+
+def plot_single_bar_chart(
+    results,
+    metric_name: str,
+    aggregate_stat_name: str,
+    task_display_name: str,
+    plot_title: str,
+    save: bool,
+    savedir: str,
+    show_plot: bool,
+    savename: str,
+):
     """Bar chart for a single task.
 
     Each algorithm is a differently-colored bar. Algorithm names appear in a
@@ -24,7 +37,7 @@ def plot_single_bar_chart(results, metric_name: str, aggregate_stat_name: str,
     num_methods = len(method_display_names)
     bar_width = min(0.8 / num_methods, 0.25)
 
-    fig, ax = plt.subplots(figsize=(max(4, num_methods * bar_width * 2 + 4), 5))
+    _fig, ax = plt.subplots(figsize=(max(4, num_methods * bar_width * 2 + 4), 5))
     colors = plt.cm.tab10(np.arange(num_methods) / 10)
 
     star_positions = []
@@ -35,38 +48,71 @@ def plot_single_bar_chart(results, metric_name: str, aggregate_stat_name: str,
         upper_ci = results[display_name][metric_name]["overall_upper_ci"]
         yerr = [[point_estimate - lower_ci], [upper_ci - point_estimate]]
         x = (i - num_methods / 2 + 0.5) * bar_width
-        ax.bar([x], [point_estimate], width=bar_width, label=display_name,
-               yerr=yerr, alpha=0.7, color=colors[i], ecolor='black', capsize=5, zorder=10)
+        ax.bar(
+            [x],
+            [point_estimate],
+            width=bar_width,
+            label=display_name,
+            yerr=yerr,
+            alpha=0.7,
+            color=colors[i],
+            ecolor="black",
+            capsize=5,
+            zorder=10,
+        )
         if results[display_name].get("_filtered_seeds", False):
             star_positions.append((x, upper_ci))
 
     for x_s, y_s in star_positions:
-        ax.text(x_s, y_s, "*", ha="center", va="bottom", fontsize=LEGEND_FONTSIZE, zorder=11)
+        ax.text(
+            x_s, y_s, "*", ha="center", va="bottom", fontsize=LEGEND_FONTSIZE, zorder=11
+        )
 
     ax.set_xticks([0])
     ax.set_xticklabels([task_display_name], fontsize=AXIS_LABEL_FONTSIZE)
-    ax.set_xlim(-num_methods * bar_width / 2 - bar_width, num_methods * bar_width / 2 + bar_width)
-    ax.set_ylabel(f'{aggregate_stat_name.capitalize()} Normalized Return', fontsize=AXIS_LABEL_FONTSIZE)
+    ax.set_xlim(
+        -num_methods * bar_width / 2 - bar_width,
+        num_methods * bar_width / 2 + bar_width,
+    )
+    ax.set_ylabel(
+        f"{aggregate_stat_name.capitalize()} Normalized Return",
+        fontsize=AXIS_LABEL_FONTSIZE,
+    )
     if plot_title:
         ax.set_title(plot_title, fontsize=TITLE_FONTSIZE)
-    ax.legend(fontsize=LEGEND_FONTSIZE, loc='center left', bbox_to_anchor=(1.01, 0.5), framealpha=0.8)
-    ax.yaxis.grid(True, linestyle='--', alpha=0.7)
+    ax.legend(
+        fontsize=LEGEND_FONTSIZE,
+        loc="center left",
+        bbox_to_anchor=(1.01, 0.5),
+        framealpha=0.8,
+    )
+    ax.yaxis.grid(True, linestyle="--", alpha=0.7)
 
     plt.tight_layout()
     if save:
         if not os.path.exists(savedir):
             os.makedirs(savedir)
-        plt.savefig(os.path.join(savedir, f"{savename}.pdf"), bbox_inches='tight')
+        plt.savefig(os.path.join(savedir, f"{savename}.pdf"), bbox_inches="tight")
         print(f"Saved figure to {os.path.join(savedir, f'{savename}.pdf')}")
     if show_plot:
         plt.show()
 
-def plot_all_tasks_bar_chart(all_task_results, metric_name: str, aggregate_stat_name: str,
-                   plot_type: str, plot_title: str, save: bool, savedir: str, show_plot: bool, savename: str):
-    '''Plots a bar chart where all tasks are plotted as groups on the same bar chart.'''
+
+def plot_all_tasks_bar_chart(
+    all_task_results,
+    metric_name: str,
+    aggregate_stat_name: str,
+    plot_type: str,
+    plot_title: str,
+    save: bool,
+    savedir: str,
+    show_plot: bool,
+    savename: str,
+):
+    """Plots a bar chart where all tasks are plotted as groups on the same bar chart."""
     tasks = list(all_task_results.keys())
     num_tasks = len(tasks)
-    
+
     # Collect all method names from any task, order preserved (first task first)
     seen: set[str] = set()
     method_display_names: list[str] = []
@@ -76,15 +122,15 @@ def plot_all_tasks_bar_chart(all_task_results, metric_name: str, aggregate_stat_
                 method_display_names.append(m)
                 seen.add(m)
     num_methods = len(method_display_names)
-    
+
     # Width of each bar
     bar_width = min(0.8 / num_methods, 0.35)
-    
+
     # Set up the figure
     if num_methods > 2:
-        fig, ax = plt.subplots(figsize=(int(num_tasks * 1.8), 6))
+        _fig, ax = plt.subplots(figsize=(int(num_tasks * 1.8), 6))
     else:
-        fig, ax = plt.subplots(figsize=(num_tasks * 1.3, 6))
+        _fig, ax = plt.subplots(figsize=(num_tasks * 1.3, 6))
     # previously was int(num_tasks * 1.8) = 6*1.8 = 10.8
     # now is int(num_tasks * (num_methods+2) * bar_width) = 6* (6+3) * 0.2 = 10.8
     # previous for ablationsi was 6*1.8 = 10.8
@@ -92,10 +138,10 @@ def plot_all_tasks_bar_chart(all_task_results, metric_name: str, aggregate_stat_
 
     # Set up x positions for tasks and bars within each task group
     task_positions = np.arange(num_tasks)
-    
+
     # Colors for each method
     colors = plt.cm.tab10(np.arange(num_methods) / 10)
-    
+
     # Plot bars for each method across all tasks (skip tasks where method is absent)
     star_positions = []
     for i, method_name in enumerate(method_display_names):
@@ -107,7 +153,11 @@ def plot_all_tasks_bar_chart(all_task_results, metric_name: str, aggregate_stat_
             if method_name not in all_task_results[task]:
                 continue
             method_results = all_task_results[task][method_name]
-            task_metric_name = TASK_TO_METRIC_NAME.get(task, metric_name) if metric_name == "task_specific" else metric_name
+            task_metric_name = (
+                TASK_TO_METRIC_NAME.get(task, metric_name)
+                if metric_name == "task_specific"
+                else metric_name
+            )
 
             stat_key = f"overall_{aggregate_stat_name}"
             point_estimate = method_results[task_metric_name][stat_key]
@@ -125,30 +175,48 @@ def plot_all_tasks_bar_chart(all_task_results, metric_name: str, aggregate_stat_
             continue
 
         y_errors_transposed = np.array(y_errors).T
-        ax.bar(x_positions, y_values, width=bar_width, label=method_name,
-               yerr=y_errors_transposed, alpha=0.7, color=colors[i],
-               ecolor='black', capsize=5, zorder=10)
+        ax.bar(
+            x_positions,
+            y_values,
+            width=bar_width,
+            label=method_name,
+            yerr=y_errors_transposed,
+            alpha=0.7,
+            color=colors[i],
+            ecolor="black",
+            capsize=5,
+            zorder=10,
+        )
 
     for x_s, y_s in star_positions:
-        ax.text(x_s, y_s, "*", ha="center", va="bottom", fontsize=LEGEND_FONTSIZE, zorder=11)
-    
+        ax.text(
+            x_s, y_s, "*", ha="center", va="bottom", fontsize=LEGEND_FONTSIZE, zorder=11
+        )
+
     # Set x-axis tick labels to task names
     task_display_names = [TASK_TO_AXIS_DISPLAY_NAME[task] for task in tasks]
     ax.set_xticks(task_positions)
-    ax.set_xticklabels(task_display_names, rotation=0, ha="center", fontsize=AXIS_LABEL_FONTSIZE)
+    ax.set_xticklabels(
+        task_display_names, rotation=0, ha="center", fontsize=AXIS_LABEL_FONTSIZE
+    )
 
     # Set labels and title
-    ax.set_ylabel(f'{aggregate_stat_name.capitalize()} {metric_name.replace("_", " ").title() if metric_name != "task_specific" else "Normalized Return"}', 
-                  fontsize=AXIS_LABEL_FONTSIZE)
+    ax.set_ylabel(
+        f"{aggregate_stat_name.capitalize()} {metric_name.replace('_', ' ').title() if metric_name != 'task_specific' else 'Normalized Return'}",
+        fontsize=AXIS_LABEL_FONTSIZE,
+    )
     ax.set_title(plot_title, fontsize=TITLE_FONTSIZE)
-    
-    ax.legend(fontsize=LEGEND_FONTSIZE, loc='center', 
-              ncols=1 if plot_type != "core" else 2,
-              bbox_to_anchor=(0.73, 0.9), # legend loc if under plot: (0.5, -0.25)
-              framealpha=0.8)
-    ax.yaxis.grid(True, linestyle='--', alpha=0.7)
+
+    ax.legend(
+        fontsize=LEGEND_FONTSIZE,
+        loc="center",
+        ncols=1 if plot_type != "core" else 2,
+        bbox_to_anchor=(0.73, 0.9),  # legend loc if under plot: (0.5, -0.25)
+        framealpha=0.8,
+    )
+    ax.yaxis.grid(True, linestyle="--", alpha=0.7)
     plt.tight_layout()
-    
+
     if save:
         if not os.path.exists(savedir):
             os.makedirs(savedir)
@@ -169,8 +237,14 @@ TEAMMATE_TYPE_DISPLAY = {
 
 
 def plot_all_tasks_ego_bar_chart(
-    all_task_results, metric_name: str, aggregate_stat_name: str,
-    plot_title: str, save: bool, savedir: str, show_plot: bool, savename: str,
+    all_task_results,
+    metric_name: str,
+    aggregate_stat_name: str,
+    plot_title: str,
+    save: bool,
+    savedir: str,
+    show_plot: bool,
+    savename: str,
     run_info,
 ):
     """Bar chart for ego agents across all tasks with per-teammate hatching.
@@ -194,7 +268,9 @@ def plot_all_tasks_ego_bar_chart(
     num_bars = len(run_info)
     bar_width = min(0.8 / num_bars, 0.25)
 
-    fig, ax = plt.subplots(figsize=(max(4, num_tasks * (num_bars * bar_width * 2 + 1)), 6))
+    _fig, ax = plt.subplots(
+        figsize=(max(4, num_tasks * (num_bars * bar_width * 2 + 1)), 6)
+    )
     task_positions = np.arange(num_tasks)
 
     star_positions = []
@@ -226,31 +302,50 @@ def plot_all_tasks_ego_bar_chart(
         if not y_values:
             continue
 
-        ax.bar(x_positions, y_values, width=bar_width, label=display_name,
-               yerr=np.array(y_errors).T, alpha=0.7, color=color, hatch=hatch,
-               ecolor='black', capsize=5, zorder=10)
+        ax.bar(
+            x_positions,
+            y_values,
+            width=bar_width,
+            label=display_name,
+            yerr=np.array(y_errors).T,
+            alpha=0.7,
+            color=color,
+            hatch=hatch,
+            ecolor="black",
+            capsize=5,
+            zorder=10,
+        )
 
     for x_s, y_s in star_positions:
-        ax.text(x_s, y_s, "*", ha="center", va="bottom", fontsize=LEGEND_FONTSIZE, zorder=11)
+        ax.text(
+            x_s, y_s, "*", ha="center", va="bottom", fontsize=LEGEND_FONTSIZE, zorder=11
+        )
 
     task_display_names = [TASK_TO_AXIS_DISPLAY_NAME[task] for task in tasks]
     ax.set_xticks(task_positions)
-    ax.set_xticklabels(task_display_names, rotation=0, ha="center", fontsize=AXIS_LABEL_FONTSIZE)
+    ax.set_xticklabels(
+        task_display_names, rotation=0, ha="center", fontsize=AXIS_LABEL_FONTSIZE
+    )
     ax.set_ylabel(
-        f'{aggregate_stat_name.capitalize()} '
-        f'{"Normalized Return" if metric_name == "task_specific" else metric_name.replace("_", " ").title()}',
+        f"{aggregate_stat_name.capitalize()} "
+        f"{'Normalized Return' if metric_name == 'task_specific' else metric_name.replace('_', ' ').title()}",
         fontsize=AXIS_LABEL_FONTSIZE,
     )
     ax.set_title(plot_title, fontsize=TITLE_FONTSIZE)
-    ax.legend(fontsize=LEGEND_FONTSIZE, loc='center', ncols=num_base,
-              bbox_to_anchor=(0.5, -0.15), framealpha=0.8)
-    ax.yaxis.grid(True, linestyle='--', alpha=0.7)
+    ax.legend(
+        fontsize=LEGEND_FONTSIZE,
+        loc="center",
+        ncols=num_base,
+        bbox_to_anchor=(0.5, -0.15),
+        framealpha=0.8,
+    )
+    ax.yaxis.grid(True, linestyle="--", alpha=0.7)
     plt.tight_layout()
 
     if save:
         if not os.path.exists(savedir):
             os.makedirs(savedir)
-        plt.savefig(os.path.join(savedir, f"{savename}.pdf"), bbox_inches='tight')
+        plt.savefig(os.path.join(savedir, f"{savename}.pdf"), bbox_inches="tight")
         print(f"Saved figure to {os.path.join(savedir, f'{savename}.pdf')}")
     if show_plot:
         plt.show()
@@ -258,33 +353,72 @@ def plot_all_tasks_ego_bar_chart(
 
 if __name__ == "__main__":
     from scripts.paper_vis.plot_globals import (
-        GLOBAL_HELDOUT_CONFIG, SAVE_DIR,
-        EGO_BENCHMARK_RUNS, UNIFIED_BENCHMARK_RUNS, BC_BENCHMARK_RUNS,
-        METHOD_TO_DISPLAY_NAME, OEL_METHODS,
+        BC_BENCHMARK_RUNS,
+        EGO_BENCHMARK_RUNS,
+        GLOBAL_HELDOUT_CONFIG,
+        METHOD_TO_DISPLAY_NAME,
+        OEL_METHODS,
+        SAVE_DIR,
+        UNIFIED_BENCHMARK_RUNS,
     )
 
     parser = argparse.ArgumentParser(description="Generate benchmark bar charts")
-    parser.add_argument("--plot_type", type=str, default="unified",
-                        choices=["unified", "ego"],
-                        help="unified: teammate-generation methods; ego: ego-training methods")
-    parser.add_argument("--use_best_returns_normalization", action=argparse.BooleanOptionalAction,
-                        default=True, help="Renormalize using best observed returns across all methods")
-    parser.add_argument("--show_plots", action="store_true",
-                        help="Show plots in addition to saving them")
-    parser.add_argument("--save_dir", type=str, default=SAVE_DIR,
-                        help="Directory to save figures")
-    parser.add_argument("--tasks", nargs="+",
-                        help="Tasks to plot. Defaults to all tasks with benchmark runs.")
-    parser.add_argument("--force_recompute", action="store_true",
-                        help="Re-fetch artifacts and recompute summary stats")
-    parser.add_argument("--include_bc", action="store_true",
-                        help="Merge BC heldout-eval artifacts (BC_BENCHMARK_RUNS) onto the standard heldout pool along the partner axis before computing aggregate stats. Only applies to --plot_type=ego.")
-    parser.add_argument("--filter_failed_seeds", action="store_true",
-                        help="Exclude seeds with near-zero returns across most heldout agents")
-    parser.add_argument("--failed_seed_relative_threshold", type=float, default=0.10,
-                        help="Seed-vs-teammate mean below this fraction of best seed counts as failed (default: 0.10)")
-    parser.add_argument("--failed_seed_breadth_threshold", type=float, default=0.80,
-                        help="Fraction of heldout agents that must fail to flag a seed (default: 0.80)")
+    parser.add_argument(
+        "--plot_type",
+        type=str,
+        default="unified",
+        choices=["unified", "ego"],
+        help="unified: teammate-generation methods; ego: ego-training methods",
+    )
+    parser.add_argument(
+        "--use_best_returns_normalization",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Renormalize using best observed returns across all methods",
+    )
+    parser.add_argument(
+        "--show_plots",
+        action="store_true",
+        help="Show plots in addition to saving them",
+    )
+    parser.add_argument(
+        "--save_dir", type=str, default=SAVE_DIR, help="Directory to save figures"
+    )
+    parser.add_argument(
+        "--tasks",
+        nargs="+",
+        help="Tasks to plot. Defaults to all tasks with benchmark runs.",
+    )
+    parser.add_argument(
+        "--force_recompute",
+        action="store_true",
+        help="Re-fetch artifacts and recompute summary stats",
+    )
+    parser.add_argument(
+        "--include_bc",
+        action="store_true",
+        help="Include the human proxy partner in every cell: iclr26-era runs already "
+        "evaluate against it; for older runs the separate BC heldout-eval artifact "
+        "(BC_BENCHMARK_RUNS) is appended along the partner axis. Cells with neither "
+        "are reported at the end.",
+    )
+    parser.add_argument(
+        "--filter_failed_seeds",
+        action="store_true",
+        help="Exclude seeds with near-zero returns across most heldout agents",
+    )
+    parser.add_argument(
+        "--failed_seed_relative_threshold",
+        type=float,
+        default=0.10,
+        help="Seed-vs-teammate mean below this fraction of best seed counts as failed (default: 0.10)",
+    )
+    parser.add_argument(
+        "--failed_seed_breadth_threshold",
+        type=float,
+        default=0.80,
+        help="Fraction of heldout agents that must fail to flag a seed (default: 0.80)",
+    )
     args = parser.parse_args()
 
     # Collect tasks that have at least one benchmark run defined
@@ -296,7 +430,17 @@ if __name__ == "__main__":
     if args.include_bc:
         norm_suffix = "with_bc"
     else:
-        norm_suffix = "br_normalization" if args.use_best_returns_normalization else "original_normalization"
+        norm_suffix = (
+            "br_normalization"
+            if args.use_best_returns_normalization
+            else "original_normalization"
+        )
+
+    def _bc_run_id(task_name, method_name, teammate_type=None):
+        entry = BC_BENCHMARK_RUNS.get(task_name, {}).get(method_name)
+        if isinstance(entry, dict):
+            return entry.get(teammate_type)
+        return entry or None
 
     all_task_results = {}
     ego_run_info: list[tuple[str, str, str]] = []  # (display_name, base_name, hatch)
@@ -307,20 +451,31 @@ if __name__ == "__main__":
         bc_run_specs: list[tuple[str, str, bool]] = []
 
         if args.plot_type == "unified":
-            for method_name, run_id in UNIFIED_BENCHMARK_RUNS.get(task_name, {}).items():
+            for method_name, run_id in UNIFIED_BENCHMARK_RUNS.get(
+                task_name, {}
+            ).items():
                 if not run_id:
                     continue
                 display_name = METHOD_TO_DISPLAY_NAME.get(method_name, method_name)
                 is_oel = method_name in OEL_METHODS
                 run_specs.append((display_name, run_id, is_oel))
+                bc_run_id = (
+                    _bc_run_id(task_name, method_name) if args.include_bc else None
+                )
+                if bc_run_id:
+                    bc_run_specs.append((display_name, bc_run_id, is_oel))
 
         elif args.plot_type == "ego":
-            for method_name, teammate_runs in EGO_BENCHMARK_RUNS.get(task_name, {}).items():
+            for method_name, teammate_runs in EGO_BENCHMARK_RUNS.get(
+                task_name, {}
+            ).items():
                 for teammate_type, run_id in teammate_runs.items():
                     if not run_id:
                         continue
                     base_name = METHOD_TO_DISPLAY_NAME.get(method_name, method_name)
-                    teammate_display = TEAMMATE_TYPE_DISPLAY.get(teammate_type, teammate_type)
+                    teammate_display = TEAMMATE_TYPE_DISPLAY.get(
+                        teammate_type, teammate_type
+                    )
                     display_name = f"{base_name} ({teammate_display})"
                     is_oel = method_name in OEL_METHODS
                     run_specs.append((display_name, run_id, is_oel))
@@ -329,39 +484,28 @@ if __name__ == "__main__":
                         hatch = TEAMMATE_HATCH.get(teammate_type, "")
                         ego_run_info.append((display_name, base_name, hatch))
 
-                    if args.include_bc:
-                        bc_run_id = (
-                            BC_BENCHMARK_RUNS.get(task_name, {})
-                            .get(method_name, {})
-                            .get(teammate_type)
-                        )
-                        if bc_run_id:
-                            bc_run_specs.append((display_name, bc_run_id, is_oel))
+                    bc_run_id = (
+                        _bc_run_id(task_name, method_name, teammate_type)
+                        if args.include_bc
+                        else None
+                    )
+                    if bc_run_id:
+                        bc_run_specs.append((display_name, bc_run_id, is_oel))
 
         if not run_specs:
             print(f"No benchmark runs configured for {task_name}, skipping.")
             continue
 
-        if args.include_bc and args.plot_type == "ego":
-            all_task_results[task_name] = load_results_for_task_merged(
-                task_name,
-                run_specs,
-                bc_run_specs,
-                force_recompute=args.force_recompute,
-                filter_failed_seeds=args.filter_failed_seeds,
-                failed_seed_relative_threshold=args.failed_seed_relative_threshold,
-                failed_seed_breadth_threshold=args.failed_seed_breadth_threshold,
-            )
-        else:
-            all_task_results[task_name] = load_results_for_task(
-                task_name,
-                run_specs,
-                force_recompute=args.force_recompute,
-                renormalize_metrics=args.use_best_returns_normalization,
-                filter_failed_seeds=args.filter_failed_seeds,
-                failed_seed_relative_threshold=args.failed_seed_relative_threshold,
-                failed_seed_breadth_threshold=args.failed_seed_breadth_threshold,
-            )
+        all_task_results[task_name] = load_results_for_task(
+            task_name,
+            run_specs,
+            force_recompute=args.force_recompute,
+            renormalize_metrics=args.use_best_returns_normalization,
+            filter_failed_seeds=args.filter_failed_seeds,
+            failed_seed_relative_threshold=args.failed_seed_relative_threshold,
+            failed_seed_breadth_threshold=args.failed_seed_breadth_threshold,
+            bc_run_specs=bc_run_specs,
+        )
 
     if not all_task_results:
         print("No results to plot.")
@@ -385,6 +529,7 @@ if __name__ == "__main__":
         task_name = next(iter(all_task_results))
         metric_name = TASK_TO_METRIC_NAME.get(task_name, "returned_episode_returns")
         from scripts.paper_vis.plot_globals import TASK_TO_PLOT_TITLE
+
         safe_task = task_name.replace("/", "_").replace("-", "_")
         plot_single_bar_chart(
             all_task_results[task_name],
@@ -409,3 +554,20 @@ if __name__ == "__main__":
             plot_title="",
             show_plot=args.show_plots,
         )
+
+    # Human-proxy coverage report: which cells include the human proxy partner,
+    # and whether it came from the run itself or a merged BC eval.
+    print(
+        "\nHuman proxy partner coverage (builtin = in run's heldout set, "
+        "bc_merge = separate BC eval appended, MISSING = neither):"
+    )
+    missing = []
+    for task_name, results in all_task_results.items():
+        for display_name, summary in results.items():
+            src = summary.get("_human_proxy") or "MISSING"
+            n = len(summary.get("_partner_labels", []))
+            print(f"  {task_name:32s} {display_name:24s} {src:9s} ({n} partners)")
+            if src == "MISSING":
+                missing.append((task_name, display_name))
+    if missing:
+        print(f"\n{len(missing)} cell(s) have no human proxy partner: {missing}")

--- a/scripts/paper_vis/benchmark_bar_charts.py
+++ b/scripts/paper_vis/benchmark_bar_charts.py
@@ -333,7 +333,19 @@ def plot_all_tasks_ego_bar_chart(
         fontsize=AXIS_LABEL_FONTSIZE,
     )
     ax.set_title(plot_title, fontsize=TITLE_FONTSIZE)
+    # Matplotlib fills legend columns top-to-bottom; permute the entries so the
+    # legend reads row by row in the same order as the bars.
+    handles, labels = ax.get_legend_handles_labels()
+    n_rows = int(np.ceil(len(handles) / num_base))
+    order = [
+        i * num_base + j
+        for j in range(num_base)
+        for i in range(n_rows)
+        if i * num_base + j < len(handles)
+    ]
     ax.legend(
+        [handles[k] for k in order],
+        [labels[k] for k in order],
         fontsize=LEGEND_FONTSIZE,
         loc="center",
         ncols=num_base,

--- a/scripts/paper_vis/compute_best_returns.py
+++ b/scripts/paper_vis/compute_best_returns.py
@@ -216,7 +216,11 @@ def _run_specs_fingerprint(
         if rid
     )
     if bc_run_specs:
-        run_ids_str += "|bc:" + "|".join(rid for _, rid, _ in bc_run_specs if rid)
+        run_ids_str += "|bc:" + "|".join(
+            ("+".join(rid) if isinstance(rid, list) else rid)
+            for _, rid, _ in bc_run_specs
+            if rid
+        )
     return hashlib.md5(run_ids_str.encode()).hexdigest()[:8]
 
 

--- a/scripts/paper_vis/compute_best_returns.py
+++ b/scripts/paper_vis/compute_best_returns.py
@@ -9,86 +9,36 @@ Normalization pipeline:
      so that 1.0 corresponds to the best observed performance.
 
 Performance bounds are read from each run's wandb config (not from the live
-codebase) to ensure reproducibility across config changes.
+codebase) to ensure reproducibility across config changes. Partners are matched
+across runs *by name* (see ``heldout_partners``), so runs evaluated against
+different-sized heldout sets (e.g. with/without the human proxy) contribute to
+the same per-partner maxima. The cached JSON lists best returns in the live
+yaml's partner order (``_labels`` key) so that older consumers indexing by
+position keep working.
 """
+
 import json
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
-from scripts.paper_vis.plot_globals import BENCHMARK_PROJECT, ENTITY
-from scripts.wandb_utils.wandb_cache import (
-    DEFAULT_CACHE_DIR,
-    fetch_run_config_cached,
-    fetch_run_eval_metrics_cached,
+from scripts.paper_vis.heldout_partners import (
+    canonical_task_labels,
+    load_run_eval_metrics,
 )
-
-
-# ---------------------------------------------------------------------------
-# Performance-bounds helpers
-# ---------------------------------------------------------------------------
-
-def get_performance_bounds_from_run_config(run_config: dict, task_name: str) -> List[Optional[dict]]:
-    """Extract per-heldout-agent performance bounds from a wandb run config.
-
-    Iterates over the heldout set config in the same order that
-    ``load_heldout_set`` would, producing one bounds-dict per individual agent
-    (i.e. one entry per model checkpoint for RL agents, one entry for each
-    heuristic agent).
-
-    Returns:
-        List of dicts ``{metric_name: [lower, upper]}``, one per heldout agent,
-        in the same order as the heldout-agent dimension of the eval metrics.
-        Entries are ``None`` when no bounds are defined.
-    """
-    heldout_set_config = run_config.get("heldout_set", {}).get(task_name, {})
-    if not heldout_set_config:
-        raise ValueError(
-            f"No heldout_set config found for task '{task_name}' in run config. "
-            f"Available tasks: {list(run_config.get('heldout_set', {}).keys())}"
-        )
-
-    bounds_list = []
-    for agent_config in heldout_set_config.values():
-        performance_bounds = agent_config.get("performance_bounds", None)
-
-        if "path" in agent_config:
-            # RL agent — one entry per model checkpoint
-            idx_list = agent_config.get("idx_list", [])
-            n_models = len(idx_list)
-
-            if performance_bounds is None:
-                bounds_list.extend([None] * n_models)
-                continue
-
-            # Detect whether bounds are per-model (list-of-lists) or shared
-            first_val = next(iter(performance_bounds.values()))
-            per_model = isinstance(first_val[0], (list, tuple))
-
-            for i in range(n_models):
-                if per_model:
-                    bounds_list.append({k: v[i] for k, v in performance_bounds.items()})
-                else:
-                    bounds_list.append({k: v for k, v in performance_bounds.items()})
-        else:
-            # Heuristic agent — single entry
-            bounds_list.append(
-                {k: v for k, v in performance_bounds.items()} if performance_bounds else None
-            )
-
-    return bounds_list
-
+from scripts.paper_vis.plot_globals import BENCHMARK_PROJECT, ENTITY
+from scripts.wandb_utils.wandb_cache import DEFAULT_CACHE_DIR
 
 # ---------------------------------------------------------------------------
 # Per-run returns extraction
 # ---------------------------------------------------------------------------
 
+
 def extract_returns_for_run(
     eval_metrics: dict,
-    perf_bounds: List[Optional[dict]],
+    perf_bounds: list[dict | None],
     is_oel: bool,
-) -> Dict[str, Tuple[np.ndarray, np.ndarray, np.ndarray]]:
+) -> dict[str, tuple[np.ndarray, np.ndarray, np.ndarray]]:
     """Unnormalize eval metrics and compute the best mean return per heldout agent.
 
     Returns:
@@ -105,7 +55,9 @@ def extract_returns_for_run(
 
         if is_oel:
             if data.ndim != 5:
-                print(f"Warning: expected 5-D OEL data for {metric_name}, got {data.ndim}-D. Skipping.")
+                print(
+                    f"Warning: expected 5-D OEL data for {metric_name}, got {data.ndim}-D. Skipping."
+                )
                 continue
             num_heldout = data.shape[2]
 
@@ -152,7 +104,9 @@ def extract_returns_for_run(
                 mean_returns[h] = mean_over_eps[s, h]
                 best_seed_idx[h] = s
         else:
-            print(f"Warning: unexpected data shape {data.shape} for {metric_name}. Skipping.")
+            print(
+                f"Warning: unexpected data shape {data.shape} for {metric_name}. Skipping."
+            )
             continue
 
         results[metric_name] = (mean_returns, best_seed_idx, best_iter_idx)
@@ -164,118 +118,117 @@ def extract_returns_for_run(
 # Best-returns computation and caching
 # ---------------------------------------------------------------------------
 
+
 def compute_best_returns(
     task_name: str,
-    all_run_specs: List[Tuple[str, str, bool]],
+    all_run_specs: list[tuple[str, str, bool]],
     entity: str = ENTITY,
     project: str = BENCHMARK_PROJECT,
     cache_dir: Path = DEFAULT_CACHE_DIR,
+    bc_run_specs: list[tuple[str, str, bool]] | None = None,
 ) -> dict:
-    """Compute the best unnormalized return per heldout agent across all runs.
+    """Compute the best unnormalized return per heldout partner across all runs.
 
-    The best returns are guaranteed to be at least as high as each agent's
+    Partners are matched by name across runs, so a run that lacks the human
+    proxy simply contributes nothing to that partner's maximum. ``bc_run_specs``
+    (display_name -> BC eval run id) lets runs without a built-in human proxy
+    contribute their separate BC evaluation.
+
+    The best returns are guaranteed to be at least as high as each partner's
     original upper bound (so that re-normalization never makes results look
     worse than the original normalization).
 
     Returns:
-        Dict mapping metric_name -> list of best returns (one per heldout agent)
+        Dict mapping metric_name -> list of best returns, in the order given by
+        the ``_labels`` entry (the live yaml's canonical partner order).
     """
-    best_returns: Dict[str, np.ndarray] = {}
-    original_upper_bounds: Dict[str, List[float]] = {}
+    bc_by_name = {dn: rid for dn, rid, _ in (bc_run_specs or [])}
+    best: dict[str, dict[str, float]] = {}
+    original_upper: dict[str, dict[str, float]] = {}
 
     for display_name, run_id, is_oel in all_run_specs:
         if not run_id:
             continue
-
         run_ids = run_id if isinstance(run_id, list) else [run_id]
         print(f"\nProcessing {display_name} (run {'+'.join(run_ids)}) ...")
-        parts = [fetch_run_eval_metrics_cached(rid, entity, project, cache_dir) for rid in run_ids]
-        if len(parts) == 1:
-            eval_metrics = parts[0]
-        else:
-            eval_metrics = {
-                k: np.concatenate([p[k] for p in parts], axis=0)
-                for k in parts[0]
-            }
-        run_config = fetch_run_config_cached(run_ids[0], entity, project, cache_dir)
-        perf_bounds = get_performance_bounds_from_run_config(run_config, task_name)
+        eval_metrics, labels, perf_bounds, _ = load_run_eval_metrics(
+            task_name,
+            run_id,
+            is_oel,
+            cache_dir=cache_dir,
+            bc_run_id=bc_by_name.get(display_name),
+        )
 
-        # Record maximum upper bound per agent across all runs
-        for h, bounds in enumerate(perf_bounds):
-            if bounds:
-                for metric_name, (lo, hi) in bounds.items():
-                    if metric_name not in original_upper_bounds:
-                        original_upper_bounds[metric_name] = []
-                    if h >= len(original_upper_bounds[metric_name]):
-                        original_upper_bounds[metric_name].append(hi)
-                    else:
-                        original_upper_bounds[metric_name][h] = max(
-                            original_upper_bounds[metric_name][h], hi
-                        )
+        for label, bounds in zip(labels, perf_bounds):
+            if not bounds:
+                continue
+            for metric_name, (_lo, hi) in bounds.items():
+                cur = original_upper.setdefault(metric_name, {})
+                cur[label] = max(cur.get(label, hi), hi)
 
         returns_data = extract_returns_for_run(eval_metrics, perf_bounds, is_oel)
-
-        # Determine reference heldout count from the first metric of this run
-        if returns_data:
-            sample_metric = next(iter(returns_data))
-            run_n_heldout = len(returns_data[sample_metric][0])
-            if best_returns:
-                ref_n_heldout = len(next(iter(best_returns.values())))
-                if run_n_heldout != ref_n_heldout:
-                    print(
-                        f"  WARNING: skipping {display_name} — heldout agent count "
-                        f"{run_n_heldout} != expected {ref_n_heldout} "
-                        f"(run was evaluated against a different heldout set)"
-                    )
-                    continue
-
         for metric_name, (cur_returns, _, _) in returns_data.items():
-            if metric_name not in best_returns:
-                best_returns[metric_name] = cur_returns.copy()
-            else:
-                best_returns[metric_name] = np.maximum(best_returns[metric_name], cur_returns)
+            cur = best.setdefault(metric_name, {})
+            for label, value in zip(labels, cur_returns):
+                cur[label] = max(cur.get(label, -np.inf), float(value))
 
-    if not best_returns:
+    if not best:
         raise ValueError(f"No valid returns found for task '{task_name}'.")
 
     # Ensure best returns are at least as high as the original upper bounds
-    for metric_name, values in best_returns.items():
-        uppers = original_upper_bounds.get(metric_name, [])
-        for i in range(min(len(values), len(uppers))):
-            if values[i] < uppers[i]:
+    for metric_name, values in best.items():
+        for label, hi in original_upper.get(metric_name, {}).items():
+            if label in values and values[label] < hi:
                 print(
-                    f"Clamping best return for heldout agent {i}, {metric_name}: "
-                    f"{values[i]:.4f} → {uppers[i]:.4f}"
+                    f"Clamping best return for heldout agent {label}, {metric_name}: "
+                    f"{values[label]:.4f} -> {hi:.4f}"
                 )
-                values[i] = uppers[i]
+                values[label] = hi
 
-    return {k: v.tolist() for k, v in best_returns.items()}
+    canonical = canonical_task_labels(task_name)
+    extra = sorted({lbl for v in best.values() for lbl in v} - set(canonical))
+    if extra:
+        print(f"WARNING: partners not in live yaml for {task_name}: {extra}")
+    labels_out = canonical + extra
+    out = {
+        metric_name: [values.get(lbl) for lbl in labels_out]
+        for metric_name, values in best.items()
+    }
+    out["_labels"] = labels_out
+    return out
 
 
-def _run_specs_fingerprint(all_run_specs: List[Tuple[str, str, bool]]) -> str:
-    """Stable short hash over the run IDs in all_run_specs.
+def _run_specs_fingerprint(
+    all_run_specs: list[tuple[str, str, bool]],
+    bc_run_specs: list[tuple[str, str, bool]] | None = None,
+) -> str:
+    """Stable short hash over the run IDs in all_run_specs (and BC run IDs).
 
     Ego and unified plots pass different run_specs for the same task, so the
     best-returns cache must be keyed on run IDs as well as task name to avoid
     cross-contamination between plot types.
     """
     import hashlib
+
     run_ids_str = "|".join(
         ("+".join(rid) if isinstance(rid, list) else rid)
         for _, rid, _ in all_run_specs
         if rid
     )
+    if bc_run_specs:
+        run_ids_str += "|bc:" + "|".join(rid for _, rid, _ in bc_run_specs if rid)
     return hashlib.md5(run_ids_str.encode()).hexdigest()[:8]
 
 
 def load_best_returns(
     task_name: str,
-    all_run_specs: List[Tuple[str, str, bool]],
+    all_run_specs: list[tuple[str, str, bool]],
     entity: str = ENTITY,
     project: str = BENCHMARK_PROJECT,
     cache_dir: Path = DEFAULT_CACHE_DIR,
     force_recompute: bool = False,
-    cache_filename: Optional[str] = None,
+    cache_filename: str | None = None,
+    bc_run_specs: list[tuple[str, str, bool]] | None = None,
 ) -> dict:
     """Return cached best returns, computing and caching them if necessary.
 
@@ -287,15 +240,22 @@ def load_best_returns(
     if cache_filename:
         cache_path = Path(cache_dir) / "best_returns" / cache_filename
     else:
-        fingerprint = _run_specs_fingerprint(all_run_specs)
-        cache_path = Path(cache_dir) / "best_returns" / f"{safe_task}__{fingerprint}.json"
+        fingerprint = _run_specs_fingerprint(all_run_specs, bc_run_specs)
+        cache_path = (
+            Path(cache_dir) / "best_returns" / f"{safe_task}__{fingerprint}.json"
+        )
 
     if not force_recompute and cache_path.exists():
-        print(f"Loading best returns from cache: {cache_path}")
         with open(cache_path, "r") as f:
-            return json.load(f)
+            cached = json.load(f)
+        if "_labels" in cached:
+            print(f"Loading best returns from cache: {cache_path}")
+            return cached
+        print(f"Best-returns cache {cache_path} predates named partners; recomputing.")
 
-    best_returns = compute_best_returns(task_name, all_run_specs, entity, project, cache_dir)
+    best_returns = compute_best_returns(
+        task_name, all_run_specs, entity, project, cache_dir, bc_run_specs=bc_run_specs
+    )
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     with open(cache_path, "w") as f:
         json.dump(best_returns, f, indent=2)
@@ -308,7 +268,9 @@ def load_best_returns(
         for f in stale_files:
             f.unlink()
         if stale_files:
-            print(f"Deleted {len(stale_files)} stale renorm cache file(s) in {stale_dir}")
+            print(
+                f"Deleted {len(stale_files)} stale renorm cache file(s) in {stale_dir}"
+            )
 
     return best_returns
 
@@ -317,22 +279,26 @@ def load_best_returns(
 # Renormalization
 # ---------------------------------------------------------------------------
 
+
 def renormalize_eval_metrics(
     eval_metrics: dict,
-    perf_bounds: List[Optional[dict]],
+    perf_bounds: list[dict | None],
     best_returns: dict,
+    labels: list[str],
 ) -> dict:
     """Unnormalize eval metrics then renormalize by best observed returns.
 
     Args:
         eval_metrics: raw (already normalized) arrays from wandb artifact
-        perf_bounds: per-heldout-agent bounds from ``get_performance_bounds_from_run_config``
-        best_returns: dict metric_name -> list of best returns per agent
+        perf_bounds: per-partner bounds aligned with ``labels``
+        best_returns: output of ``compute_best_returns`` (has a ``_labels`` key)
+        labels: partner labels along the artifact's partner axis
 
     Returns:
         dict with the same keys as eval_metrics, values rescaled so that 1.0
-        corresponds to the best observed return for each heldout agent.
+        corresponds to the best observed return for each heldout partner.
     """
+    br_labels = best_returns["_labels"]
     renorm = {}
 
     for metric_name, data in eval_metrics.items():
@@ -340,13 +306,13 @@ def renormalize_eval_metrics(
         out = np.copy(data)
 
         if data.ndim == 5:
-            num_heldout = data.shape[2]
             heldout_dim = 2
         elif data.ndim == 4:
-            num_heldout = data.shape[1]
             heldout_dim = 1
         else:
-            print(f"Warning: unexpected shape {data.shape} for {metric_name}. Keeping original.")
+            print(
+                f"Warning: unexpected shape {data.shape} for {metric_name}. Keeping original."
+            )
             renorm[metric_name] = data
             continue
 
@@ -354,18 +320,23 @@ def renormalize_eval_metrics(
             renorm[metric_name] = data
             continue
 
-        br = best_returns[metric_name]
-        agents_to_process = min(num_heldout, len(perf_bounds), len(br))
+        br = dict(zip(br_labels, best_returns[metric_name]))
+        num_heldout = data.shape[heldout_dim]
+        if num_heldout != len(labels):
+            raise ValueError(
+                f"{metric_name}: {num_heldout} partners in data but {len(labels)} labels"
+            )
 
-        for h in range(agents_to_process):
-            bounds = perf_bounds[h]
+        for h, (label, bounds) in enumerate(zip(labels, perf_bounds)):
             if not bounds or metric_name not in bounds:
                 continue
-            lo, hi = bounds[metric_name]
-            best = br[h]
-            if best <= 0:
-                print(f"Warning: best_return={best} for {metric_name} agent {h}. Keeping original.")
+            best = br.get(label)
+            if best is None or best <= 0:
+                print(
+                    f"Warning: no usable best_return for {metric_name} partner '{label}'. Keeping original."
+                )
                 continue
+            lo, hi = bounds[metric_name]
 
             if heldout_dim == 2:
                 raw = data[:, :, h, :, :] * (hi - lo) + lo

--- a/scripts/paper_vis/heldout_partners.py
+++ b/scripts/paper_vis/heldout_partners.py
@@ -167,7 +167,7 @@ def load_run_eval_metrics(
     is_oel: bool,
     cache_dir: Path = DEFAULT_CACHE_DIR,
     force_recompute: bool = False,
-    bc_run_id: str | None = None,
+    bc_run_id: str | list[str] | None = None,
 ) -> tuple[dict, list[str], list[dict | None], HumanProxySource]:
     """Load a run's heldout eval metrics with named, bounds-aligned partners.
 
@@ -176,7 +176,9 @@ def load_run_eval_metrics(
 
     If the run's own heldout set contains no human proxy and ``bc_run_id`` is
     given, the canonical partner of that separate BC evaluation is appended to
-    the partner axis (labelled ``human_proxy``) with its own bounds.
+    the partner axis (labelled ``human_proxy``) with its own bounds. For pooled
+    ``run_id`` lists, ``bc_run_id`` must be a list of the same length (one BC
+    eval per source run, in the same order) so seeds line up.
 
     Returns:
         (eval_metrics, labels, bounds, human_proxy_source) where
@@ -218,10 +220,32 @@ def load_run_eval_metrics(
     if bc_run_id is None:
         return eval_metrics, labels, bounds, None
 
-    bc_metrics = fetch_run_eval_metrics_cached(
-        bc_run_id, ENTITY, BENCHMARK_PROJECT, cache_dir, force_recompute
+    bc_run_ids = bc_run_id if isinstance(bc_run_id, list) else [bc_run_id]
+    if len(bc_run_ids) != len(run_ids):
+        raise ValueError(
+            f"{'+'.join(run_ids)} ({task_name}): {len(run_ids)} pooled run(s) but "
+            f"{len(bc_run_ids)} BC eval run(s) given: {bc_run_ids}"
+        )
+    bc_parts = [
+        fetch_run_eval_metrics_cached(
+            rid, ENTITY, BENCHMARK_PROJECT, cache_dir, force_recompute
+        )
+        for rid in bc_run_ids
+    ]
+    bc_metrics = (
+        bc_parts[0]
+        if len(bc_parts) == 1
+        else {k: np.concatenate([p[k] for p in bc_parts], axis=0) for k in bc_parts[0]}
     )
-    bc_labels, bc_bounds = get_run_partners(bc_run_id, task_name, cache_dir)
+    bc_labels, bc_bounds = get_run_partners(bc_run_ids[0], task_name, cache_dir)
+    for rid in bc_run_ids[1:]:
+        other_labels, _ = get_run_partners(rid, task_name, cache_dir)
+        if other_labels != bc_labels:
+            raise ValueError(
+                f"Pooled BC evals {bc_run_ids[0]} and {rid} have different partners "
+                f"for {task_name}:\n  {bc_labels}\n  {other_labels}"
+            )
+    bc_run_id = "+".join(bc_run_ids)
     bc_idx = next(
         (i for i, lbl in enumerate(bc_labels) if lbl in BC_RUN_CANONICAL_KEYS), 0
     )

--- a/scripts/paper_vis/heldout_partners.py
+++ b/scripts/paper_vis/heldout_partners.py
@@ -1,0 +1,247 @@
+"""Per-run heldout partner bookkeeping for the paper plots.
+
+Every benchmark run logs a heldout-eval artifact whose partner axis follows the
+order in which ``load_heldout_set`` iterated the heldout config *at eval time*.
+Two things make that order hard to recover after the fact:
+
+* wandb stores nested config dicts with keys reordered, so the run config's
+  ``heldout_set`` cannot be iterated to recover the partner order;
+* the live yaml has been reordered since the neurips-era runs (e.g. the LBF 7x7
+  heuristics moved before the RL partners).
+
+The heldout runner also logs a table whose columns are the partner labels in
+artifact order, so we take the order from there and look bounds up *by name*
+in the run config.
+
+Human proxy partners: iclr26-era runs (and the neurips ROTATE runs) evaluate
+against a ``human_proxy`` partner as part of the standard heldout set. Older
+runs do not, and were instead evaluated against the BC proxy in a separate
+run (``BC_BENCHMARK_RUNS``). ``load_run_eval_metrics`` reconciles the two by
+appending the separate BC evaluation only for runs whose own heldout set has
+no human proxy, so every cell exposes the same partner set when a BC run is
+available.
+"""
+
+import re
+import warnings
+from pathlib import Path
+
+import numpy as np
+import omegaconf
+
+from scripts.paper_vis.plot_globals import (
+    BENCHMARK_PROJECT,
+    ENTITY,
+    GLOBAL_HELDOUT_CONFIG,
+    HUMAN_PROXY_AGENTS,
+)
+from scripts.wandb_utils.wandb_cache import (
+    DEFAULT_CACHE_DIR,
+    fetch_run_config_cached,
+    fetch_run_eval_metrics_cached,
+    fetch_run_heldout_names_cached,
+)
+
+HUMAN_PROXY_LABEL = "human_proxy"
+# Partner keys used by the separate BC heldout-eval runs; the first one found is
+# the canonical human proxy (bc_run_0 for overcooked, bc for LBF).
+BC_RUN_CANONICAL_KEYS = ("bc_run_0", "bc")
+
+HumanProxySource = str | None  # "builtin" | "bc_merge" | None
+
+
+def is_human_proxy(label: str) -> bool:
+    return any(p in label for p in HUMAN_PROXY_AGENTS)
+
+
+def _n_models(agent_cfg: dict) -> int:
+    """Number of partner-axis entries an agent config expands to."""
+    if "path" in agent_cfg and "idx_list" in agent_cfg:
+        return len(agent_cfg["idx_list"])
+    bounds = agent_cfg.get("performance_bounds") or {}
+    if bounds:
+        first = next(iter(bounds.values()))
+        if isinstance(first[0], (list, tuple)):
+            return len(first)
+    return 1
+
+
+def _label(base: str, i: int, n: int) -> str:
+    return base if n == 1 else f"{base}[{i}]"
+
+
+def expand_labels(heldout_cfg: dict, key_order: list[str]) -> list[str]:
+    """Expand agent keys into one canonical label per partner-axis entry."""
+    labels: list[str] = []
+    for key in key_order:
+        n = _n_models(heldout_cfg[key])
+        labels.extend(_label(key, i, n) for i in range(n))
+    return labels
+
+
+def canonical_task_labels(task_name: str) -> list[str]:
+    """Canonical partner labels for a task, in live-yaml order (human proxy last)."""
+    cfg = omegaconf.OmegaConf.to_container(
+        GLOBAL_HELDOUT_CONFIG["heldout_set"][task_name], resolve=True
+    )
+    cfg = {k: v for k, v in cfg.items() if v is not None}
+    return expand_labels(cfg, list(cfg.keys()))
+
+
+def labels_from_table(columns: list[str], heldout_cfg: dict) -> list[str]:
+    """Map logged table columns (``"comedi (1, 0)"``) to canonical labels."""
+    counts: dict[str, int] = {}
+    labels = []
+    for col in columns:
+        base = re.sub(r"\s*\(.*\)$", "", col)
+        i = counts.get(base, 0)
+        counts[base] = i + 1
+        n = _n_models(heldout_cfg[base]) if base in heldout_cfg else 1
+        labels.append(_label(base, i, n))
+    return labels
+
+
+def bounds_for_label(heldout_cfg: dict, label: str) -> dict | None:
+    """``{metric: [lo, hi]}`` for one partner label, or None if undefined."""
+    m = re.match(r"^(.*)\[(\d+)\]$", label)
+    base, i = (m.group(1), int(m.group(2))) if m else (label, 0)
+    bounds = (heldout_cfg.get(base) or {}).get("performance_bounds")
+    if not bounds:
+        return None
+    return {
+        metric: list(v[i]) if isinstance(v[0], (list, tuple)) else list(v)
+        for metric, v in bounds.items()
+    }
+
+
+def get_run_partners(
+    run_id: str,
+    task_name: str,
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+) -> tuple[list[str], list[dict | None]]:
+    """Return (labels, bounds) along the partner axis of a run's heldout artifact.
+
+    Bounds are read from the run's own wandb config (the bounds active at eval
+    time), looked up by partner name.
+    """
+    run_config = fetch_run_config_cached(run_id, ENTITY, BENCHMARK_PROJECT, cache_dir)
+    heldout_cfg = run_config.get("heldout_set", {}).get(task_name)
+    if not heldout_cfg:
+        raise ValueError(
+            f"No heldout_set config for task '{task_name}' in run {run_id}. "
+            f"Available: {list(run_config.get('heldout_set', {}).keys())}"
+        )
+    heldout_cfg = {k: v for k, v in heldout_cfg.items() if v is not None}
+
+    columns = fetch_run_heldout_names_cached(
+        run_id, ENTITY, BENCHMARK_PROJECT, cache_dir
+    )
+    if columns is not None:
+        labels = labels_from_table(columns, heldout_cfg)
+    else:
+        warnings.warn(
+            f"Run {run_id} has no logged heldout table; assuming live-yaml partner "
+            f"order for {task_name}.",
+            stacklevel=2,
+        )
+        yaml_keys = [
+            k
+            for k in GLOBAL_HELDOUT_CONFIG["heldout_set"][task_name]
+            if k in heldout_cfg
+        ]
+        yaml_keys += [k for k in heldout_cfg if k not in yaml_keys]
+        labels = expand_labels(heldout_cfg, yaml_keys)
+
+    bounds = [bounds_for_label(heldout_cfg, lbl) for lbl in labels]
+    return labels, bounds
+
+
+def _partner_axis(is_oel: bool) -> int:
+    # OEL artifacts are (seeds, oel_iter, partners, eps, agents); others drop oel_iter.
+    return 2 if is_oel else 1
+
+
+def load_run_eval_metrics(
+    task_name: str,
+    run_id,
+    is_oel: bool,
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+    force_recompute: bool = False,
+    bc_run_id: str | None = None,
+) -> tuple[dict, list[str], list[dict | None], HumanProxySource]:
+    """Load a run's heldout eval metrics with named, bounds-aligned partners.
+
+    ``run_id`` may be a list of run ids evaluated against the same heldout set;
+    their seeds are pooled along axis 0.
+
+    If the run's own heldout set contains no human proxy and ``bc_run_id`` is
+    given, the canonical partner of that separate BC evaluation is appended to
+    the partner axis (labelled ``human_proxy``) with its own bounds.
+
+    Returns:
+        (eval_metrics, labels, bounds, human_proxy_source) where
+        human_proxy_source is "builtin", "bc_merge", or None.
+    """
+    run_ids = run_id if isinstance(run_id, list) else [run_id]
+    parts = [
+        fetch_run_eval_metrics_cached(
+            rid, ENTITY, BENCHMARK_PROJECT, cache_dir, force_recompute
+        )
+        for rid in run_ids
+    ]
+    eval_metrics = (
+        parts[0]
+        if len(parts) == 1
+        else {k: np.concatenate([p[k] for p in parts], axis=0) for k in parts[0]}
+    )
+
+    labels, bounds = get_run_partners(run_ids[0], task_name, cache_dir)
+    for rid in run_ids[1:]:
+        other_labels, _ = get_run_partners(rid, task_name, cache_dir)
+        if other_labels != labels:
+            raise ValueError(
+                f"Pooled runs {run_ids[0]} and {rid} have different heldout partners "
+                f"for {task_name}:\n  {labels}\n  {other_labels}"
+            )
+
+    axis = _partner_axis(is_oel)
+    sample = next(iter(eval_metrics.values()))
+    if sample.shape[axis] != len(labels):
+        raise ValueError(
+            f"Run {run_ids[0]} ({task_name}): artifact has {sample.shape[axis]} partners "
+            f"but {len(labels)} labels were resolved: {labels}"
+        )
+
+    if any(is_human_proxy(lbl) for lbl in labels):
+        return eval_metrics, labels, bounds, "builtin"
+
+    if bc_run_id is None:
+        return eval_metrics, labels, bounds, None
+
+    bc_metrics = fetch_run_eval_metrics_cached(
+        bc_run_id, ENTITY, BENCHMARK_PROJECT, cache_dir, force_recompute
+    )
+    bc_labels, bc_bounds = get_run_partners(bc_run_id, task_name, cache_dir)
+    bc_idx = next(
+        (i for i, lbl in enumerate(bc_labels) if lbl in BC_RUN_CANONICAL_KEYS), 0
+    )
+    bc_axis = _partner_axis(False)
+    common = [k for k in eval_metrics if k in bc_metrics]
+    merged = {}
+    for k in common:
+        bc_slice = np.take(bc_metrics[k], indices=[bc_idx], axis=bc_axis)
+        if is_oel:
+            # Old-style OEL run without built-in human proxy: BC eval is only for the
+            # final iterate, so replicate it across the oel_iter axis.
+            bc_slice = np.broadcast_to(
+                bc_slice[:, None],
+                (bc_slice.shape[0], eval_metrics[k].shape[1]) + bc_slice.shape[1:],
+            )
+        merged[k] = np.concatenate([eval_metrics[k], bc_slice], axis=axis)
+    labels = labels + [HUMAN_PROXY_LABEL]
+    bounds = bounds + [bc_bounds[bc_idx]]
+    print(
+        f"  merged BC eval {bc_run_id} (partner '{bc_labels[bc_idx]}') into "
+        f"{'+'.join(run_ids)}: {sample.shape} -> {merged[common[0]].shape}"
+    )
+    return merged, labels, bounds, "bc_merge"

--- a/scripts/paper_vis/heldout_partners.py
+++ b/scripts/paper_vis/heldout_partners.py
@@ -6,14 +6,14 @@ Two things make that order hard to recover after the fact:
 
 * wandb stores nested config dicts with keys reordered, so the run config's
   ``heldout_set`` cannot be iterated to recover the partner order;
-* the live yaml has been reordered since the neurips-era runs (e.g. the LBF 7x7
+* the live yaml has been reordered since the may26-era runs (e.g. the LBF 7x7
   heuristics moved before the RL partners).
 
 The heldout runner also logs a table whose columns are the partner labels in
 artifact order, so we take the order from there and look bounds up *by name*
 in the run config.
 
-Human proxy partners: iclr26-era runs (and the neurips ROTATE runs) evaluate
+Human proxy partners: sept26-era runs (and the may26 ROTATE runs) evaluate
 against a ``human_proxy`` partner as part of the standard heldout set. Older
 runs do not, and were instead evaluated against the BC proxy in a separate
 run (``BC_BENCHMARK_RUNS``). ``load_run_eval_metrics`` reconciles the two by

--- a/scripts/paper_vis/heldout_partners.py
+++ b/scripts/paper_vis/heldout_partners.py
@@ -1,25 +1,10 @@
 """Per-run heldout partner bookkeeping for the paper plots.
 
-Every benchmark run logs a heldout-eval artifact whose partner axis follows the
-order in which ``load_heldout_set`` iterated the heldout config *at eval time*.
-Two things make that order hard to recover after the fact:
-
-* wandb stores nested config dicts with keys reordered, so the run config's
-  ``heldout_set`` cannot be iterated to recover the partner order;
-* the live yaml has been reordered since the may26-era runs (e.g. the LBF 7x7
-  heuristics moved before the RL partners).
-
-The heldout runner also logs a table whose columns are the partner labels in
-artifact order, so we take the order from there and look bounds up *by name*
-in the run config.
-
-Human proxy partners: sept26-era runs (and the may26 ROTATE runs) evaluate
-against a ``human_proxy`` partner as part of the standard heldout set. Older
-runs do not, and were instead evaluated against the BC proxy in a separate
-run (``BC_BENCHMARK_RUNS``). ``load_run_eval_metrics`` reconciles the two by
-appending the separate BC evaluation only for runs whose own heldout set has
-no human proxy, so every cell exposes the same partner set when a BC run is
-available.
+Heldout partners are identified by name rather than artifact index: wandb
+reorders config dict keys, so the partner order is read from the logged
+``HeldoutEval/FinalEgoVsHeldout`` table and bounds are looked up by name.
+For runs whose heldout set has no ``human_proxy``, ``load_run_eval_metrics``
+appends the separate BC eval run (``BC_BENCHMARK_RUNS``) along the partner axis.
 """
 
 import re

--- a/scripts/paper_vis/plot_by_agent_type.py
+++ b/scripts/paper_vis/plot_by_agent_type.py
@@ -1,64 +1,61 @@
 """Plot unified-method performance broken down by heldout agent type as radar charts.
 
 For each task, produces a radar chart where each axis is an agent type
-(CoMeDi, LBRDiv, IPPO, BRDiv, OBL, Heuristic) and each trace is a method.
-Values are the mean per-method performance over all heldout agents of that type.
+(CoMeDi, LBRDiv, IPPO, BRDiv, OBL, Heuristic, Human Proxy) and each trace is a
+method. Values are the mean per-method performance over all heldout agents of
+that type. Partners are grouped using each run's own partner labels
+(``_partner_labels`` in the summary), so runs with different heldout sets are
+handled correctly; a method with no partner of a given type is left as a gap.
 
 Run from repo root: python scripts/paper_vis/plot_by_agent_type.py
 """
+
 import argparse
 import os
 from collections import defaultdict
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
-import omegaconf
 
-from scripts.paper_vis.process_data import load_results_for_task
+from scripts.paper_vis.heldout_partners import is_human_proxy
 from scripts.paper_vis.plot_globals import (
+    AXIS_LABEL_FONTSIZE,
     GLOBAL_HELDOUT_CONFIG,
-    SAVE_DIR,
-    UNIFIED_BENCHMARK_RUNS,
+    LEGEND_FONTSIZE,
     METHOD_TO_DISPLAY_NAME,
     OEL_METHODS,
     RL_AGENTS,
-    TASK_TO_METRIC_NAME,
+    SAVE_DIR,
     TASK_TO_DISPLAY_NAME,
+    TASK_TO_METRIC_NAME,
     TITLE_FONTSIZE,
-    AXIS_LABEL_FONTSIZE,
-    LEGEND_FONTSIZE,
+    UNIFIED_BENCHMARK_RUNS,
 )
+from scripts.paper_vis.process_data import load_results_for_task
 
 HEURISTIC_KEY = "heuristic"
+HUMAN_PROXY_KEY = "human_proxy"
 
 # High-contrast styling so overlapping traces stay distinguishable.
-METHOD_MARKERS = ['o', 's', '^', 'D', 'v', 'P', 'X', '*']
+METHOD_MARKERS = ["o", "s", "^", "D", "v", "P", "X", "*"]
 
 AGENT_TYPE_DISPLAY = {
     "comedi": "CoMeDi",
     "lbrdiv": "LBRDiv",
-    "ippo":   "IPPO",
-    "brdiv":  "BRDiv",
-    "obl":    "OBL",
+    "ippo": "IPPO",
+    "brdiv": "BRDiv",
+    "obl": "OBL",
     HEURISTIC_KEY: "Heuristic",
+    HUMAN_PROXY_KEY: "Human Proxy",
 }
 
 
-def get_heldout_agent_labels(task_config: dict) -> list[str]:
-    labels = []
-    for teammate_name, agent_config in task_config.items():
-        if "path" in agent_config:
-            n = len(agent_config.get("idx_list", []))
-            for i in range(n):
-                labels.append(teammate_name if n == 1 else f"{teammate_name}[{i}]")
-        else:
-            labels.append(teammate_name)
-    return labels
-
-
 def classify_agent(label: str) -> str:
+    if is_human_proxy(label):
+        return HUMAN_PROXY_KEY
     for rl_type in RL_AGENTS:
         if rl_type in label:
             return rl_type
@@ -78,12 +75,14 @@ def draw_radar_on_ax(
     metric_name: str,
     agg_stat: str,
     type_order: list[str],
-    groups: dict[str, list[int]],
     colors,
     plot_title: str,
     show_title: bool,
 ):
-    """Draw a radar chart onto an existing polar axes. Returns the max value plotted."""
+    """Draw a radar chart onto an existing polar axes. Returns the max value plotted.
+
+    Partner indices are grouped per method from its own ``_partner_labels``.
+    """
     categories = [AGENT_TYPE_DISPLAY.get(t, t) for t in type_order]
     N = len(categories)
     angles = np.linspace(0, 2 * np.pi, N, endpoint=False).tolist()
@@ -93,27 +92,45 @@ def draw_radar_on_ax(
 
     for i, (method_name, method_results) in enumerate(results.items()):
         per_agent = np.array(method_results[metric_name][f"{agg_stat}_per_agent"])
+        labels = method_results["_partner_labels"]
+        assert len(labels) == len(per_agent), (
+            f"{method_name}: {len(labels)} partner labels vs {len(per_agent)} per-agent values"
+        )
+        groups = group_indices_by_type(labels)
         values = []
         for ag_type in type_order:
             indices = groups.get(ag_type, [])
-            valid = [k for k in indices if k < len(per_agent)]
-            values.append(float(np.mean(per_agent[valid])) if valid else 0.0)
+            values.append(float(np.mean(per_agent[indices])) if indices else np.nan)
 
-        max_value = max(max_value, max(values))
+        max_value = max(max_value, np.nanmax(values))
         closed_values = values + values[:1]
 
-        ax.plot(angles, closed_values, linewidth=2, color=colors[i], label=method_name,
-                marker=METHOD_MARKERS[i % len(METHOD_MARKERS)], markersize=6, alpha=0.85)
+        ax.plot(
+            angles,
+            closed_values,
+            linewidth=2,
+            color=colors[i],
+            label=method_name,
+            marker=METHOD_MARKERS[i % len(METHOD_MARKERS)],
+            markersize=6,
+            alpha=0.85,
+        )
 
-    ax.plot(angles, [1.0] * len(angles), '--', color='dimgray', linewidth=1.5,
-            label='_nolegend_')
+    ax.plot(
+        angles,
+        [1.0] * len(angles),
+        "--",
+        color="dimgray",
+        linewidth=1.5,
+        label="_nolegend_",
+    )
 
     ax.set_xticks(angles[:-1])
     ax.set_xticklabels(categories, fontsize=AXIS_LABEL_FONTSIZE)
     ax.set_ylim(0, max_value * 1.15)
     ax.yaxis.set_tick_params(labelsize=AXIS_LABEL_FONTSIZE - 4)
-    ax.grid(color='#EEEEEE', linewidth=1)
-    ax.spines['polar'].set_color('#CCCCCC')
+    ax.grid(color="#EEEEEE", linewidth=1)
+    ax.spines["polar"].set_color("#CCCCCC")
 
     if show_title:
         ax.set_title(plot_title, fontsize=TITLE_FONTSIZE, pad=20)
@@ -140,11 +157,13 @@ def plot_tasks(
         for method_name, run_id in UNIFIED_BENCHMARK_RUNS.get(task_name, {}).items():
             if not run_id:
                 continue
-            run_specs.append((
-                METHOD_TO_DISPLAY_NAME.get(method_name, method_name),
-                run_id,
-                method_name in OEL_METHODS,
-            ))
+            run_specs.append(
+                (
+                    METHOD_TO_DISPLAY_NAME.get(method_name, method_name),
+                    run_id,
+                    method_name in OEL_METHODS,
+                )
+            )
 
         if not run_specs:
             print(f"No runs found for task {task_name}, skipping.")
@@ -158,16 +177,26 @@ def plot_tasks(
         )
 
         metric_name = TASK_TO_METRIC_NAME.get(task_name, "returned_episode_returns")
-        heldout_cfg = omegaconf.OmegaConf.to_container(
-            GLOBAL_HELDOUT_CONFIG["heldout_set"][task_name], resolve=True
-        )
-        labels = get_heldout_agent_labels(heldout_cfg)
-        groups = group_indices_by_type(labels)
-        type_order = [t for t in RL_AGENTS if t in groups]
-        if HEURISTIC_KEY in groups:
-            type_order.append(HEURISTIC_KEY)
+        present_types = set()
+        for method_results in results.values():
+            present_types.update(
+                classify_agent(lb) for lb in method_results["_partner_labels"]
+            )
+        type_order = [
+            t
+            for t in RL_AGENTS + [HEURISTIC_KEY, HUMAN_PROXY_KEY]
+            if t in present_types
+        ]
+        for method_name, method_results in results.items():
+            missing = present_types - {
+                classify_agent(lb) for lb in method_results["_partner_labels"]
+            }
+            if missing:
+                print(
+                    f"  [{task_name}] {method_name} has no partner of type {sorted(missing)}; left as gap"
+                )
 
-        task_data.append((task_name, results, metric_name, groups, type_order))
+        task_data.append((task_name, results, metric_name, type_order))
         if all_method_names is None:
             all_method_names = list(results.keys())
 
@@ -182,15 +211,14 @@ def plot_tasks(
 
     fig = plt.figure(figsize=(ncols * 6, 6))
 
-    for idx, (task_name, results, metric_name, groups, type_order) in enumerate(task_data):
-        ax = fig.add_subplot(nrows, ncols, idx + 1, projection='polar')
+    for idx, (task_name, results, metric_name, type_order) in enumerate(task_data):
+        ax = fig.add_subplot(nrows, ncols, idx + 1, projection="polar")
         draw_radar_on_ax(
             ax=ax,
             results=results,
             metric_name=metric_name,
             agg_stat=agg_stat,
             type_order=type_order,
-            groups=groups,
             colors=colors,
             plot_title=TASK_TO_DISPLAY_NAME.get(task_name, task_name),
             show_title=True,
@@ -198,15 +226,21 @@ def plot_tasks(
 
     if show_legend and all_method_names:
         handles = [
-            plt.Line2D([0], [0], color=colors[i], linewidth=2,
-                       marker=METHOD_MARKERS[i % len(METHOD_MARKERS)], label=name)
+            plt.Line2D(
+                [0],
+                [0],
+                color=colors[i],
+                linewidth=2,
+                marker=METHOD_MARKERS[i % len(METHOD_MARKERS)],
+                label=name,
+            )
             for i, name in enumerate(all_method_names)
         ]
         fig.legend(
             handles=handles,
             title="Algorithms",
             title_fontsize=LEGEND_FONTSIZE,
-            loc='lower center',
+            loc="lower center",
             ncol=len(all_method_names),
             fontsize=LEGEND_FONTSIZE,
             framealpha=0.8,
@@ -218,7 +252,7 @@ def plot_tasks(
 
     os.makedirs(save_dir, exist_ok=True)
     save_path = os.path.join(save_dir, f"by_agent_type_{norm_suffix}.pdf")
-    plt.savefig(save_path, bbox_inches='tight')
+    plt.savefig(save_path, bbox_inches="tight")
     print(f"Saved combined radar chart to {save_path}")
 
     if show_plots:
@@ -232,23 +266,31 @@ if __name__ == "__main__":
         description="Plot unified-method performance grouped by heldout agent type (radar charts)"
     )
     parser.add_argument(
-        "--tasks", nargs="+",
+        "--tasks",
+        nargs="+",
         help="Tasks to plot (default: all tasks with unified benchmark runs)",
     )
     parser.add_argument(
-        "--use_best_returns_normalization", action=argparse.BooleanOptionalAction,
-        default=True, help="Renormalize using best observed returns",
+        "--use_best_returns_normalization",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Renormalize using best observed returns",
     )
     parser.add_argument(
-        "--force_recompute", action="store_true",
+        "--force_recompute",
+        action="store_true",
         help="Recompute summary stats from cached wandb artifacts",
     )
     parser.add_argument(
-        "--save_dir", type=str, default=SAVE_DIR,
+        "--save_dir",
+        type=str,
+        default=SAVE_DIR,
         help="Directory to save figures (default: %(default)s)",
     )
     parser.add_argument("--show_plots", action="store_true")
-    parser.add_argument("--show_legend", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--show_legend", action=argparse.BooleanOptionalAction, default=True
+    )
     args = parser.parse_args()
 
     task_list = args.tasks if args.tasks else sorted(UNIFIED_BENCHMARK_RUNS)

--- a/scripts/paper_vis/plot_by_agent_type.py
+++ b/scripts/paper_vis/plot_by_agent_type.py
@@ -23,6 +23,7 @@ import numpy as np
 from scripts.paper_vis.heldout_partners import is_human_proxy
 from scripts.paper_vis.plot_globals import (
     AXIS_LABEL_FONTSIZE,
+    BC_BENCHMARK_RUNS,
     GLOBAL_HELDOUT_CONFIG,
     LEGEND_FONTSIZE,
     METHOD_TO_DISPLAY_NAME,
@@ -155,16 +156,17 @@ def plot_tasks(
     all_method_names = None
     for task_name in task_list:
         run_specs = []
+        bc_run_specs = []
         for method_name, run_id in UNIFIED_BENCHMARK_RUNS.get(task_name, {}).items():
             if not run_id:
                 continue
-            run_specs.append(
-                (
-                    METHOD_TO_DISPLAY_NAME.get(method_name, method_name),
-                    run_id,
-                    method_name in OEL_METHODS,
-                )
-            )
+            display_name = METHOD_TO_DISPLAY_NAME.get(method_name, method_name)
+            is_oel = method_name in OEL_METHODS
+            run_specs.append((display_name, run_id, is_oel))
+            # Separate human-proxy eval for runs whose own heldout set lacks it
+            bc_run_id = BC_BENCHMARK_RUNS.get(task_name, {}).get(method_name)
+            if bc_run_id and not isinstance(bc_run_id, dict):
+                bc_run_specs.append((display_name, bc_run_id, is_oel))
 
         if not run_specs:
             print(f"No runs found for task {task_name}, skipping.")
@@ -175,6 +177,7 @@ def plot_tasks(
             run_specs,
             force_recompute=force_recompute,
             renormalize_metrics=use_best_returns_normalization,
+            bc_run_specs=bc_run_specs,
         )
 
         metric_name = TASK_TO_METRIC_NAME.get(task_name, "returned_episode_returns")

--- a/scripts/paper_vis/plot_by_agent_type.py
+++ b/scripts/paper_vis/plot_by_agent_type.py
@@ -33,6 +33,7 @@ from scripts.paper_vis.plot_globals import (
     TASK_TO_METRIC_NAME,
     TITLE_FONTSIZE,
     UNIFIED_BENCHMARK_RUNS,
+    paper_tasks,
 )
 from scripts.paper_vis.process_data import load_results_for_task
 
@@ -268,7 +269,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tasks",
         nargs="+",
-        help="Tasks to plot (default: all tasks with unified benchmark runs)",
+        help="Tasks to plot (default: unified-run tasks minus PAPER_EXCLUDED_TASKS)",
     )
     parser.add_argument(
         "--use_best_returns_normalization",
@@ -293,7 +294,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    task_list = args.tasks if args.tasks else sorted(UNIFIED_BENCHMARK_RUNS)
+    task_list = args.tasks if args.tasks else paper_tasks(UNIFIED_BENCHMARK_RUNS)
     plot_tasks(
         task_list=task_list,
         save_dir=args.save_dir,

--- a/scripts/paper_vis/plot_by_agent_type.py
+++ b/scripts/paper_vis/plot_by_agent_type.py
@@ -269,7 +269,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tasks",
         nargs="+",
-        help="Tasks to plot (default: unified-run tasks minus PAPER_EXCLUDED_TASKS)",
+        help="Tasks to plot (default: PAPER_TASKS)",
     )
     parser.add_argument(
         "--use_best_returns_normalization",

--- a/scripts/paper_vis/plot_globals.py
+++ b/scripts/paper_vis/plot_globals.py
@@ -35,120 +35,120 @@ BENCHMARK_PROJECT = "aht-benchmark"
 EGO_BENCHMARK_RUNS = {
     "lbf/lbf_7x7_nolevels": {
         "ppo_ego": {
-            "fcp_teammates": "lerlzvpv",  # iclr26, 5 seeds
-            "comedi_teammates": "i124n1hl",  # iclr26, 5 seeds
+            "fcp_teammates": "lerlzvpv",  # sept26, 5 seeds
+            "comedi_teammates": "i124n1hl",  # sept26, 5 seeds
         },
         "liam": {
-            "fcp_teammates": "3byp3td0",  # iclr26, 5 seeds
-            "comedi_teammates": "2opu8s3x",  # iclr26, 5 seeds
+            "fcp_teammates": "3byp3td0",  # sept26, 5 seeds
+            "comedi_teammates": "2opu8s3x",  # sept26, 5 seeds
         },
         "meliba": {
-            "fcp_teammates": ["ernydfeu", "isx6v5kf", "m04si2f5"],  # iclr26, 10 seeds
+            "fcp_teammates": ["ernydfeu", "isx6v5kf", "m04si2f5"],  # sept26, 10 seeds
             "comedi_teammates": [
                 "2gs98nrk",
                 "sadapb3o",
                 "pxsx1ahd",
-            ],  # iclr26, 10 seeds
+            ],  # sept26, 10 seeds
         },
     },
     "lbf/lbf_12x12": {
         "ppo_ego": {
-            "fcp_teammates": "otxy993u",  # neurips
-            "comedi_teammates": "jna0irje",  # neurips
+            "fcp_teammates": "otxy993u",  # may26
+            "comedi_teammates": "jna0irje",  # may26
         },
         "liam": {
-            "fcp_teammates": "j9adbki8",  # neurips
-            "comedi_teammates": "3h6fcrni",  # neurips
+            "fcp_teammates": "j9adbki8",  # may26
+            "comedi_teammates": "3h6fcrni",  # may26
         },
         "meliba": {
-            "fcp_teammates": ["t8v125ba", "2swcrf3y", "af08h0sw"],  # iclr26, 10 seeds
+            "fcp_teammates": ["t8v125ba", "2swcrf3y", "af08h0sw"],  # sept26, 10 seeds
             "comedi_teammates": [
                 "lw7cmntl",
                 "gxk4t9ee",
                 "xgi1oqro",
-            ],  # iclr26, 10 seeds
+            ],  # sept26, 10 seeds
         },
     },
     "overcooked-v1/cramped_room": {
         "ppo_ego": {
-            "fcp_teammates": "rm5bx4ui",  # neurips
-            "comedi_teammates": "7jhrdpxc",  # neurips
+            "fcp_teammates": "rm5bx4ui",  # may26
+            "comedi_teammates": "7jhrdpxc",  # may26
         },
         "liam": {
-            "fcp_teammates": "xuvmlpmi",  # neurips
-            "comedi_teammates": "8486vdnp",  # neurips
+            "fcp_teammates": "xuvmlpmi",  # may26
+            "comedi_teammates": "8486vdnp",  # may26
         },
         "meliba": {
-            "fcp_teammates": ["sjkmr2co", "9kvtltg8", "7gqbc2gd"],  # iclr26, 10 seeds
+            "fcp_teammates": ["sjkmr2co", "9kvtltg8", "7gqbc2gd"],  # sept26, 10 seeds
             "comedi_teammates": [
                 "ikbqpjaq",
                 "6hyan548",
                 "5mx43y3q",
-            ],  # iclr26, 10 seeds
+            ],  # sept26, 10 seeds
         },
     },
     "overcooked-v1/coord_ring": {
         "ppo_ego": {
-            "fcp_teammates": "we10tivv",  # iclr26, 5 seeds
-            "comedi_teammates": "1tq4878f",  # iclr26, 5 seeds
+            "fcp_teammates": "we10tivv",  # sept26, 5 seeds
+            "comedi_teammates": "1tq4878f",  # sept26, 5 seeds
         },
         "liam": {
-            "fcp_teammates": "a7usto7b",  # iclr26, 5 seeds
-            "comedi_teammates": "qsjbzty8",  # iclr26, 5 seeds
+            "fcp_teammates": "a7usto7b",  # sept26, 5 seeds
+            "comedi_teammates": "qsjbzty8",  # sept26, 5 seeds
         },
         "meliba": {
-            "fcp_teammates": ["vjvs7uug", "0b27ry3j", "8bpn86ss"],  # iclr26, 10 seeds
+            "fcp_teammates": ["vjvs7uug", "0b27ry3j", "8bpn86ss"],  # sept26, 10 seeds
             "comedi_teammates": [
                 "vt2edaa7",
                 "p0rv1ege",
                 "ins39ls1",
-            ],  # iclr26, 10 seeds
+            ],  # sept26, 10 seeds
         },
     },
     "overcooked-v1/asymm_advantages": {
         "ppo_ego": {
-            "fcp_teammates": "nydruntw",  # iclr26, 5 seeds
-            "comedi_teammates": "5z39jj4k",  # iclr26, 5 seeds
+            "fcp_teammates": "nydruntw",  # sept26, 5 seeds
+            "comedi_teammates": "5z39jj4k",  # sept26, 5 seeds
         },
         "liam": {
-            "fcp_teammates": "ryq0tsxe",  # iclr26, 5 seeds
-            "comedi_teammates": "iwu9233c",  # iclr26, 5 seeds
+            "fcp_teammates": "ryq0tsxe",  # sept26, 5 seeds
+            "comedi_teammates": "iwu9233c",  # sept26, 5 seeds
         },
         "meliba": {
-            "fcp_teammates": "4m8tmxj3",  # iclr26, 5 seeds
-            "comedi_teammates": "kekiners",  # iclr26, 5 seeds
+            "fcp_teammates": "4m8tmxj3",  # sept26, 5 seeds
+            "comedi_teammates": "kekiners",  # sept26, 5 seeds
         },
     },
     "overcooked-v1/forced_coord": {
         "ppo_ego": {
-            "fcp_teammates": "tf6xkzpu",  # iclr26, 5 seeds
-            "comedi_teammates": "5x1rtnii",  # iclr26, 5 seeds
+            "fcp_teammates": "tf6xkzpu",  # sept26, 5 seeds
+            "comedi_teammates": "5x1rtnii",  # sept26, 5 seeds
         },
         "liam": {
-            "fcp_teammates": "vuwcr5yh",  # iclr26, 5 seeds
-            "comedi_teammates": "seepwt80",  # iclr26, 5 seeds
+            "fcp_teammates": "vuwcr5yh",  # sept26, 5 seeds
+            "comedi_teammates": "seepwt80",  # sept26, 5 seeds
         },
         "meliba": {
-            "fcp_teammates": "1d2kx3tq",  # iclr26, 5 seeds
-            "comedi_teammates": "0cd2w1ec",  # iclr26, 5 seeds
+            "fcp_teammates": "1d2kx3tq",  # sept26, 5 seeds
+            "comedi_teammates": "0cd2w1ec",  # sept26, 5 seeds
         },
     },
     "overcooked-v1/counter_circuit": {
         "ppo_ego": {
-            "fcp_teammates": "9wekrbxo",  # iclr26, 5 seeds
-            "comedi_teammates": "udklgvdq",  # iclr26, 5 seeds
+            "fcp_teammates": "9wekrbxo",  # sept26, 5 seeds
+            "comedi_teammates": "udklgvdq",  # sept26, 5 seeds
         },
         "liam": {
-            "fcp_teammates": "4rwoutix",  # iclr26, 5 seeds
-            "comedi_teammates": "vyxn9dxp",  # iclr26, 5 seeds
+            "fcp_teammates": "4rwoutix",  # sept26, 5 seeds
+            "comedi_teammates": "vyxn9dxp",  # sept26, 5 seeds
         },
         "meliba": {
-            "fcp_teammates": ["obtdbm9y", "z7pmvhj7", "tv16ua4v"],  # iclr26, 10 seeds
+            "fcp_teammates": ["obtdbm9y", "z7pmvhj7", "tv16ua4v"],  # sept26, 10 seeds
             "comedi_teammates": [
                 "r5e8vlp7",
                 "giim6lb3",
                 "gnocl630",
-            ],  # iclr26, 10 seeds
+            ],  # sept26, 10 seeds
         },
     },
     "mini-hanabi": {
@@ -158,13 +158,13 @@ EGO_BENCHMARK_RUNS = {
                 "rflrtlzo",
                 "719okso0",
                 "6s91gqf5",
-            ],  # neurips, 5 seeds
+            ],  # may26, 5 seeds
             "comedi_teammates": [
                 "g61afu52",
                 "7rpmb6ie",
                 "70d2c8v2",
                 "38pn9msz",
-            ],  # neurips
+            ],  # may26
         },
         "liam": {
             "fcp_teammates": [
@@ -172,22 +172,22 @@ EGO_BENCHMARK_RUNS = {
                 "5ab05qxj",
                 "0hwgmfj3",
                 "lwpl8w6x",
-            ],  # neurips, 5 seeds
+            ],  # may26, 5 seeds
             "comedi_teammates": [
                 "x0ckfnlv",
                 "b2by5off",
                 "72at5w6x",
                 "tq4fcjh4",
                 "6sig81om",
-            ],  # neurips
+            ],  # may26
         },
         "meliba": {
-            "fcp_teammates": ["3pu1t8gw", "azrmgwkw", "es6t0hbh"],  # iclr26, 10 seeds
+            "fcp_teammates": ["3pu1t8gw", "azrmgwkw", "es6t0hbh"],  # sept26, 10 seeds
             "comedi_teammates": [
                 "lza9gtk4",
                 "mtx7yx4l",
                 "9vh5ul08",
-            ],  # iclr26, 10 seeds
+            ],  # sept26, 10 seeds
         },
     },
 }
@@ -201,7 +201,7 @@ EGO_BENCHMARK_RUNS = {
 # Ego-method cells (ppo_ego/liam/meliba, keyed by teammate type) were generated
 # 2026-05-06 via evaluation/run_heldout_ego_bc.py at NUM_EVAL_EPISODES=64.
 # Teammate-generation cells (fcp/brdiv/lbrdiv/comedi, plain ids) were generated
-# 2026-09-06 via evaluation/run_heldout_ego_human_proxy.py for the neurips-era
+# 2026-09-06 via evaluation/run_heldout_ego_human_proxy.py for the may26-era
 # UNIFIED_BENCHMARK_RUNS whose heldout set predates `human_proxy`; a list entry
 # pairs one eval per pooled source run, in the same order.
 BC_BENCHMARK_RUNS = {
@@ -241,97 +241,97 @@ BC_BENCHMARK_RUNS = {
 
 UNIFIED_BENCHMARK_RUNS = {
     "lbf/lbf_7x7_nolevels": {
-        "fcp": "1bhjc1ri",  # neurips
-        "brdiv": "nqbhn0x8",  # iclr26, 5 seeds
-        "lbrdiv": "jj2ycq8o",  # neurips
-        "comedi": "us4jl8ch",  # neurips
-        "rotate": "0vt39b0r",  # neurips
-        "cole": "k7uf5ndx",  # iclr26, 5 seeds
-        "trajedi": "733qoihr",  # iclr26, 5 seeds
+        "fcp": "1bhjc1ri",  # may26
+        "brdiv": "nqbhn0x8",  # sept26, 5 seeds
+        "lbrdiv": "jj2ycq8o",  # may26
+        "comedi": "us4jl8ch",  # may26
+        "rotate": "0vt39b0r",  # may26
+        "cole": "k7uf5ndx",  # sept26, 5 seeds
+        "trajedi": "733qoihr",  # sept26, 5 seeds
     },
     "lbf/lbf_12x12": {
         "fcp": [
             "1c0um2ls",
             "52wp5amm",
-        ],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
-        "brdiv": "b3xozodw",  # neurips
-        "lbrdiv": "dft2f0do",  # neurips
-        "comedi": "7qizaam5",  # neurips
-        "rotate": "9a280lft",  # neurips
-        "cole": "62dhrovw",  # iclr26, 5 seeds
-        "trajedi": "mbz2pbmy",  # iclr26, 5 seeds
+        ],  # may26; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
+        "brdiv": "b3xozodw",  # may26
+        "lbrdiv": "dft2f0do",  # may26
+        "comedi": "7qizaam5",  # may26
+        "rotate": "9a280lft",  # may26
+        "cole": "62dhrovw",  # sept26, 5 seeds
+        "trajedi": "mbz2pbmy",  # sept26, 5 seeds
     },
     "overcooked-v1/cramped_room": {
-        "fcp": "n1mplxeg",  # neurips
-        "brdiv": "u1hihvk2",  # iclr26, 5 seeds
-        "lbrdiv": "kfiwwxbu",  # neurips
+        "fcp": "n1mplxeg",  # may26
+        "brdiv": "u1hihvk2",  # sept26, 5 seeds
+        "lbrdiv": "kfiwwxbu",  # may26
         "comedi": [
             "8k97saxv",
             "fqw407x0",
-        ],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
-        "rotate": "egwn4951",  # neurips
-        "cole": "mj2zzmzq",  # iclr26, 5 seeds
-        "trajedi": "4ubrdpio",  # iclr26, 5 seeds
+        ],  # may26; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
+        "rotate": "egwn4951",  # may26
+        "cole": "mj2zzmzq",  # sept26, 5 seeds
+        "trajedi": "4ubrdpio",  # sept26, 5 seeds
     },
     "overcooked-v1/coord_ring": {
-        "fcp": "ikrlj1qe",  # neurips
-        "brdiv": "1yag7vj1",  # iclr26, 5 seeds
-        "lbrdiv": "x012q7qc",  # neurips
-        "comedi": "ont3iesc",  # iclr26, 5 seeds
-        "rotate": "x7cynboy",  # neurips
-        "cole": "zrc2agdk",  # iclr26, 5 seeds
-        "trajedi": ["r55lnqcb", "p8lnwq93"],  # iclr26, 5 seeds
+        "fcp": "ikrlj1qe",  # may26
+        "brdiv": "1yag7vj1",  # sept26, 5 seeds
+        "lbrdiv": "x012q7qc",  # may26
+        "comedi": "ont3iesc",  # sept26, 5 seeds
+        "rotate": "x7cynboy",  # may26
+        "cole": "zrc2agdk",  # sept26, 5 seeds
+        "trajedi": ["r55lnqcb", "p8lnwq93"],  # sept26, 5 seeds
     },
     "overcooked-v1/asymm_advantages": {
-        "fcp": "waolda91",  # iclr26, 5 seeds
-        "brdiv": "zmnouxfd",  # iclr26, 5 seeds
+        "fcp": "waolda91",  # sept26, 5 seeds
+        "brdiv": "zmnouxfd",  # sept26, 5 seeds
         "lbrdiv": [
             "e7ui3d6b",
             "ua0spahs",
             "95xkc9e3",
             "6q6ixj7x",
             "1pr9nuhi",
-        ],  # iclr26, 5 seeds
-        "comedi": "zeuzmm3p",  # iclr26, 5 seeds
-        "rotate": "l9q0kchn",  # iclr26, 5 seeds
-        "cole": "162sq4py",  # iclr26, 5 seeds
-        "trajedi": ["1v1ofunu", "p6uvw44b"],  # iclr26, 5 seeds
+        ],  # sept26, 5 seeds
+        "comedi": "zeuzmm3p",  # sept26, 5 seeds
+        "rotate": "l9q0kchn",  # sept26, 5 seeds
+        "cole": "162sq4py",  # sept26, 5 seeds
+        "trajedi": ["1v1ofunu", "p6uvw44b"],  # sept26, 5 seeds
     },
     "overcooked-v1/forced_coord": {
-        "fcp": "n57xsw4x",  # iclr26, 5 seeds
-        "brdiv": "1aj5wy5a",  # iclr26, 5 seeds
-        "lbrdiv": ["otb5ba9q", "4al8en97"],  # iclr26, 5 seeds
-        "comedi": "e6p1h9f5",  # iclr26, 5 seeds
-        "rotate": "ci72un83",  # iclr26, 5 seeds
-        "cole": "o9x9z9bb",  # iclr26, 5 seeds
-        "trajedi": ["awrppuvi", "qhszyk5x"],  # iclr26, 5 seeds
+        "fcp": "n57xsw4x",  # sept26, 5 seeds
+        "brdiv": "1aj5wy5a",  # sept26, 5 seeds
+        "lbrdiv": ["otb5ba9q", "4al8en97"],  # sept26, 5 seeds
+        "comedi": "e6p1h9f5",  # sept26, 5 seeds
+        "rotate": "ci72un83",  # sept26, 5 seeds
+        "cole": "o9x9z9bb",  # sept26, 5 seeds
+        "trajedi": ["awrppuvi", "qhszyk5x"],  # sept26, 5 seeds
     },
     "overcooked-v1/counter_circuit": {
-        "fcp": "5v7kd2ok",  # iclr26, 5 seeds
-        "brdiv": "f8tvok12",  # iclr26, 5 seeds
+        "fcp": "5v7kd2ok",  # sept26, 5 seeds
+        "brdiv": "f8tvok12",  # sept26, 5 seeds
         "lbrdiv": [
             "5iyo3iw6",
             "2r9gen4f",
             "jcg3b9c0",
             "ct5luwgo",
             "u021qxlz",
-        ],  # iclr26, 5 seeds
-        "comedi": "um47gdei",  # iclr26, 5 seeds
-        "rotate": "8nsgv1wk",  # iclr26, 5 seeds
-        "cole": "upb63g1n",  # iclr26, 5 seeds
-        "trajedi": ["pmecpq57", "8ritukil"],  # iclr26, 5 seeds
+        ],  # sept26, 5 seeds
+        "comedi": "um47gdei",  # sept26, 5 seeds
+        "rotate": "8nsgv1wk",  # sept26, 5 seeds
+        "cole": "upb63g1n",  # sept26, 5 seeds
+        "trajedi": ["pmecpq57", "8ritukil"],  # sept26, 5 seeds
     },
     "mini-hanabi": {
-        "fcp": "c5kukiyx",  # neurips
-        "brdiv": "0az0sa6t",  # neurips
+        "fcp": "c5kukiyx",  # may26
+        "brdiv": "0az0sa6t",  # may26
         "lbrdiv": [
             "wv7j92rh",
             "fig22cpk",
-        ],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
-        "comedi": "acp6wglt",  # neurips
-        "rotate": "mw1jdo7s",  # neurips
-        "cole": "ffb5g4tu",  # iclr26, 5 seeds
-        "trajedi": "qj2yxrp2",  # iclr26, 5 seeds
+        ],  # may26; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
+        "comedi": "acp6wglt",  # may26
+        "rotate": "mw1jdo7s",  # may26
+        "cole": "ffb5g4tu",  # sept26, 5 seeds
+        "trajedi": "qj2yxrp2",  # sept26, 5 seeds
     },
 }
 
@@ -443,7 +443,7 @@ HYPERPARAM_SWEEPS = {
 FILTERED_HYPERPARAMETER_KV = {"trajedi": {"TRAJEDI_COEF": [0.0]}}
 
 ####### PLOTTING SETTINGS #######
-# Tasks included in this paper revision's figures (the NeurIPS task set). Runs for other
+# Tasks included in this paper revision's figures (the may26 task set). Runs for other
 # tasks stay in the tables above; pass --tasks explicitly to plot them.
 PAPER_TASKS = [
     "lbf/lbf_12x12",

--- a/scripts/paper_vis/plot_globals.py
+++ b/scripts/paper_vis/plot_globals.py
@@ -355,21 +355,23 @@ FILTERED_HYPERPARAMETER_KV = {
 }
 
 ####### PLOTTING SETTINGS #######
-# Tasks held out of this paper revision's figures (kept in the run tables above so
-# they can be re-enabled later). Pass --tasks explicitly to plot them anyway.
-PAPER_EXCLUDED_TASKS = {
-    "overcooked-v1/asymm_advantages",
-    "overcooked-v1/counter_circuit",
-    "overcooked-v1/forced_coord",
-}
+# Tasks included in this paper revision's figures (the NeurIPS task set). Runs for other
+# tasks stay in the tables above; pass --tasks explicitly to plot them.
+PAPER_TASKS = [
+    "lbf/lbf_12x12",
+    "lbf/lbf_7x7_nolevels",
+    "mini-hanabi",
+    "overcooked-v1/coord_ring",
+    "overcooked-v1/cramped_room",
+]
 
 
 def paper_tasks(*run_tables):
-    """Sorted tasks present in any of the given run tables, minus PAPER_EXCLUDED_TASKS."""
-    tasks = set()
+    """PAPER_TASKS (in order) that appear in at least one of the given run tables."""
+    available = set()
     for table in run_tables:
-        tasks |= set(table)
-    return sorted(tasks - PAPER_EXCLUDED_TASKS)
+        available |= set(table)
+    return [t for t in PAPER_TASKS if t in available]
 
 
 TASK_TO_PLOT_TITLE = {

--- a/scripts/paper_vis/plot_globals.py
+++ b/scripts/paper_vis/plot_globals.py
@@ -355,6 +355,23 @@ FILTERED_HYPERPARAMETER_KV = {
 }
 
 ####### PLOTTING SETTINGS #######
+# Tasks held out of this paper revision's figures (kept in the run tables above so
+# they can be re-enabled later). Pass --tasks explicitly to plot them anyway.
+PAPER_EXCLUDED_TASKS = {
+    "overcooked-v1/asymm_advantages",
+    "overcooked-v1/counter_circuit",
+    "overcooked-v1/forced_coord",
+}
+
+
+def paper_tasks(*run_tables):
+    """Sorted tasks present in any of the given run tables, minus PAPER_EXCLUDED_TASKS."""
+    tasks = set()
+    for table in run_tables:
+        tasks |= set(table)
+    return sorted(tasks - PAPER_EXCLUDED_TASKS)
+
+
 TASK_TO_PLOT_TITLE = {
     "lbf/lbf_7x7_nolevels": "LBF 7x7",
     "lbf/lbf_12x12": "LBF 12x12",

--- a/scripts/paper_vis/plot_globals.py
+++ b/scripts/paper_vis/plot_globals.py
@@ -21,78 +21,123 @@ HUMAN_PROXY_AGENTS = [
 ]
 ####### BENCHMARK RUNS #######
 BENCHMARK_PROJECT = "aht-benchmark"
+# Run ids by campaign wandb tag (project aht-benchmark), refreshed 2026-09-06.
+# Seed counts are DISTINCT seeds: distinct (TRAIN_SEED, seed_index) pairs across
+# the listed runs. jax.random.split is prefix-stable, so chunks sharing a
+# TRAIN_SEED overlap and chunk sizes must not be summed.
 EGO_BENCHMARK_RUNS = {
     "lbf/lbf_7x7_nolevels": {
         "ppo_ego": {
-            "fcp_teammates": "d411alba",
-            "comedi_teammates": "2e5x3uko"
-        }, 
+            "fcp_teammates": "lerlzvpv",  # iclr26, 5 seeds
+            "comedi_teammates": "i124n1hl",  # iclr26, 5 seeds
+        },
         "liam": {
-            "fcp_teammates": "zq6yx6kf",
-            "comedi_teammates": "0kh751xl"
-        }, 
+            "fcp_teammates": "3byp3td0",  # iclr26, 5 seeds
+            "comedi_teammates": "2opu8s3x",  # iclr26, 5 seeds
+        },
         "meliba": {
-            "fcp_teammates": "47gw238c",
-            "comedi_teammates": "bc1legak"
-        }, 
+            "fcp_teammates": ["ernydfeu", "isx6v5kf", "m04si2f5"],  # iclr26, 10 seeds
+            "comedi_teammates": ["2gs98nrk", "sadapb3o", "pxsx1ahd"],  # iclr26, 10 seeds
+        },
     },
     "lbf/lbf_12x12": {
         "ppo_ego": {
-            "fcp_teammates": "otxy993u",
-            "comedi_teammates": "jna0irje"
-        }, 
+            "fcp_teammates": "otxy993u",  # neurips
+            "comedi_teammates": "jna0irje",  # neurips
+        },
         "liam": {
-            "fcp_teammates": "j9adbki8",
-            "comedi_teammates": "3h6fcrni"
-        }, 
+            "fcp_teammates": "j9adbki8",  # neurips
+            "comedi_teammates": "3h6fcrni",  # neurips
+        },
         "meliba": {
-            "fcp_teammates": "pifmvl5o",
-            "comedi_teammates": "pwvgckir"
-        }, 
+            "fcp_teammates": ["t8v125ba", "2swcrf3y", "af08h0sw"],  # iclr26, 10 seeds
+            "comedi_teammates": ["lw7cmntl", "gxk4t9ee", "xgi1oqro"],  # iclr26, 10 seeds
+        },
     },
     "overcooked-v1/cramped_room": {
         "ppo_ego": {
-            "fcp_teammates": "rm5bx4ui",
-            "comedi_teammates": "7jhrdpxc"
-        }, 
+            "fcp_teammates": "rm5bx4ui",  # neurips
+            "comedi_teammates": "7jhrdpxc",  # neurips
+        },
         "liam": {
-            "fcp_teammates": "xuvmlpmi",
-            "comedi_teammates": "8486vdnp"
-        }, 
+            "fcp_teammates": "xuvmlpmi",  # neurips
+            "comedi_teammates": "8486vdnp",  # neurips
+        },
         "meliba": {
-            "fcp_teammates": ["lghgomp3", "v5ey4lkt"],
-            "comedi_teammates": ["en1wbqt4", "3e6wffoi"]
-        }, 
+            "fcp_teammates": ["sjkmr2co", "9kvtltg8", "7gqbc2gd"],  # iclr26, 10 seeds
+            "comedi_teammates": ["ikbqpjaq", "6hyan548", "5mx43y3q"],  # iclr26, 10 seeds
+        },
     },
     "overcooked-v1/coord_ring": {
         "ppo_ego": {
-            "fcp_teammates": "0wzr6nbv",
-            "comedi_teammates": "5njknt2q"
-        }, 
+            "fcp_teammates": "we10tivv",  # iclr26, 5 seeds
+            "comedi_teammates": "1tq4878f",  # iclr26, 5 seeds
+        },
         "liam": {
-            "fcp_teammates": "e8y4gy49",
-            "comedi_teammates": "pmm9u33p"
-        }, 
+            "fcp_teammates": "a7usto7b",  # iclr26, 5 seeds
+            "comedi_teammates": "qsjbzty8",  # iclr26, 5 seeds
+        },
         "meliba": {
-            "fcp_teammates": "x6gmp9uc",
-            "comedi_teammates": ["7a19mtio", "bd6w70tr"]
+            "fcp_teammates": ["vjvs7uug", "0b27ry3j", "8bpn86ss"],  # iclr26, 10 seeds
+            "comedi_teammates": ["vt2edaa7", "p0rv1ege", "ins39ls1"],  # iclr26, 10 seeds
+        },
+    },
+    "overcooked-v1/asymm_advantages": {
+        "ppo_ego": {
+            "fcp_teammates": "nydruntw",  # iclr26, 5 seeds
+            "comedi_teammates": "5z39jj4k",  # iclr26, 5 seeds
+        },
+        "liam": {
+            "fcp_teammates": "ryq0tsxe",  # iclr26, 5 seeds
+            "comedi_teammates": "iwu9233c",  # iclr26, 5 seeds
+        },
+        "meliba": {
+            "fcp_teammates": "4m8tmxj3",  # iclr26, 5 seeds
+            "comedi_teammates": "kekiners",  # iclr26, 5 seeds
+        },
+    },
+    "overcooked-v1/forced_coord": {
+        "ppo_ego": {
+            "fcp_teammates": "tf6xkzpu",  # iclr26, 5 seeds
+            "comedi_teammates": "5x1rtnii",  # iclr26, 5 seeds
+        },
+        "liam": {
+            "fcp_teammates": "vuwcr5yh",  # iclr26, 5 seeds
+            "comedi_teammates": "seepwt80",  # iclr26, 5 seeds
+        },
+        "meliba": {
+            "fcp_teammates": "1d2kx3tq",  # iclr26, 5 seeds
+            "comedi_teammates": "0cd2w1ec",  # iclr26, 5 seeds
+        },
+    },
+    "overcooked-v1/counter_circuit": {
+        "ppo_ego": {
+            "fcp_teammates": "9wekrbxo",  # iclr26, 5 seeds
+            "comedi_teammates": "udklgvdq",  # iclr26, 5 seeds
+        },
+        "liam": {
+            "fcp_teammates": "4rwoutix",  # iclr26, 5 seeds
+            "comedi_teammates": "vyxn9dxp",  # iclr26, 5 seeds
+        },
+        "meliba": {
+            "fcp_teammates": ["obtdbm9y", "z7pmvhj7", "tv16ua4v"],  # iclr26, 10 seeds
+            "comedi_teammates": ["r5e8vlp7", "giim6lb3", "gnocl630"],  # iclr26, 10 seeds
         },
     },
     "mini-hanabi": {
         "ppo_ego": {
-            "fcp_teammates": ["hkoidsa0", "rflrtlzo", "719okso0"],
-            "comedi_teammates": ["g61afu52", "7rpmb6ie", "70d2c8v2", "38pn9msz"]
+            "fcp_teammates": ["hkoidsa0", "rflrtlzo", "719okso0", "6s91gqf5"],  # neurips, 5 seeds
+            "comedi_teammates": ["g61afu52", "7rpmb6ie", "70d2c8v2", "38pn9msz"],  # neurips
         },
         "liam": {
-            "fcp_teammates": ["gr03b106", "5ab05qxj", "0hwgmfj3"],
-            "comedi_teammates": ["x0ckfnlv", "b2by5off", "72at5w6x", "tq4fcjh4", "6sig81om"]
+            "fcp_teammates": ["gr03b106", "5ab05qxj", "0hwgmfj3", "lwpl8w6x"],  # neurips, 5 seeds
+            "comedi_teammates": ["x0ckfnlv", "b2by5off", "72at5w6x", "tq4fcjh4", "6sig81om"],  # neurips
         },
         "meliba": {
-            "fcp_teammates": ["canru355", "cob5rucj", "fdt0n0jq"],
-            "comedi_teammates": ["zppuzci6", "buj9lvwp", "usfsicq8", "gw2b4uz1", "8scr8vhv"]
+            "fcp_teammates": ["3pu1t8gw", "azrmgwkw", "es6t0hbh"],  # iclr26, 10 seeds
+            "comedi_teammates": ["lza9gtk4", "mtx7yx4l", "9vh5ul08"],  # iclr26, 10 seeds
         },
     },
-
 }
 
 # BC heldout-eval wandb runs (64-eps variant — eps count matches the training-time
@@ -127,50 +172,77 @@ BC_BENCHMARK_RUNS = {
 
 UNIFIED_BENCHMARK_RUNS = {
     "lbf/lbf_7x7_nolevels": {
-        "fcp": "1bhjc1ri", 
-        "brdiv": "3i68f80z", 
-        "lbrdiv": "jj2ycq8o",
-        "comedi": "us4jl8ch",
-        "rotate": "0vt39b0r",
-        "cole": "9mmd6r45",
-        "trajedi": "ilklfw2f",
+        "fcp": "1bhjc1ri",  # neurips
+        "brdiv": "nqbhn0x8",  # iclr26, 5 seeds
+        "lbrdiv": "jj2ycq8o",  # neurips
+        "comedi": "us4jl8ch",  # neurips
+        "rotate": "0vt39b0r",  # neurips
+        "cole": "k7uf5ndx",  # iclr26, 5 seeds
+        "trajedi": "733qoihr",  # iclr26, 5 seeds
     },
     "lbf/lbf_12x12": {
-        "fcp": ["1c0um2ls", "52wp5amm"],
-        "brdiv": "b3xozodw", 
-        "lbrdiv": "dft2f0do",
-        "comedi": "7qizaam5",
-        "rotate": "9a280lft",
-        "cole": "wom49daz",
-        "trajedi": "ipsuzp4z",
+        "fcp": ["1c0um2ls", "52wp5amm"],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
+        "brdiv": "b3xozodw",  # neurips
+        "lbrdiv": "dft2f0do",  # neurips
+        "comedi": "7qizaam5",  # neurips
+        "rotate": "9a280lft",  # neurips
+        "cole": "62dhrovw",  # iclr26, 5 seeds
+        "trajedi": "mbz2pbmy",  # iclr26, 5 seeds
     },
     "overcooked-v1/cramped_room": {
-        "fcp": "n1mplxeg", 
-        "brdiv": "0ruf65cb", 
-        "lbrdiv": "kfiwwxbu",
-        "comedi": ["8k97saxv", "fqw407x0"],
-        "rotate": "egwn4951",
-        "cole": "ga4gg8bs",
-        "trajedi": "2xtvi3x6",
+        "fcp": "n1mplxeg",  # neurips
+        "brdiv": "u1hihvk2",  # iclr26, 5 seeds
+        "lbrdiv": "kfiwwxbu",  # neurips
+        "comedi": ["8k97saxv", "fqw407x0"],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
+        "rotate": "egwn4951",  # neurips
+        "cole": "mj2zzmzq",  # iclr26, 5 seeds
+        "trajedi": "4ubrdpio",  # iclr26, 5 seeds
     },
     "overcooked-v1/coord_ring": {
-        "fcp": "ikrlj1qe", 
-        "brdiv": "r4a3ncl2", 
-        "lbrdiv": "x012q7qc",
-        "comedi": "ehz0njkk",
-        "rotate": "x7cynboy",
-        "cole": "zxwuozip",
-        "trajedi": "u7ssnuyi",
+        "fcp": "ikrlj1qe",  # neurips
+        "brdiv": "1yag7vj1",  # iclr26, 5 seeds
+        "lbrdiv": "x012q7qc",  # neurips
+        "comedi": "ont3iesc",  # iclr26, 5 seeds
+        "rotate": "x7cynboy",  # neurips
+        "cole": "zrc2agdk",  # iclr26, 5 seeds
+        "trajedi": ["r55lnqcb", "p8lnwq93"],  # iclr26, 5 seeds
+    },
+    "overcooked-v1/asymm_advantages": {
+        "fcp": "waolda91",  # iclr26, 5 seeds
+        "brdiv": "zmnouxfd",  # iclr26, 5 seeds
+        "lbrdiv": ["e7ui3d6b", "ua0spahs", "95xkc9e3", "6q6ixj7x", "1pr9nuhi"],  # iclr26, 5 seeds
+        "comedi": "zeuzmm3p",  # iclr26, 5 seeds
+        "rotate": "l9q0kchn",  # iclr26, 5 seeds
+        "cole": "162sq4py",  # iclr26, 5 seeds
+        "trajedi": ["1v1ofunu", "p6uvw44b"],  # iclr26, 5 seeds
+    },
+    "overcooked-v1/forced_coord": {
+        "fcp": "n57xsw4x",  # iclr26, 5 seeds
+        "brdiv": "1aj5wy5a",  # iclr26, 5 seeds
+        "lbrdiv": ["otb5ba9q", "4al8en97"],  # iclr26, 5 seeds
+        "comedi": "e6p1h9f5",  # iclr26, 5 seeds
+        "rotate": "ci72un83",  # iclr26, 5 seeds
+        "cole": "o9x9z9bb",  # iclr26, 5 seeds
+        "trajedi": ["awrppuvi", "qhszyk5x"],  # iclr26, 5 seeds
+    },
+    "overcooked-v1/counter_circuit": {
+        "fcp": "5v7kd2ok",  # iclr26, 5 seeds
+        "brdiv": "f8tvok12",  # iclr26, 5 seeds
+        "lbrdiv": ["5iyo3iw6", "2r9gen4f", "jcg3b9c0", "ct5luwgo", "u021qxlz"],  # iclr26, 5 seeds
+        "comedi": "um47gdei",  # iclr26, 5 seeds
+        "rotate": "8nsgv1wk",  # iclr26, 5 seeds
+        "cole": "upb63g1n",  # iclr26, 5 seeds
+        "trajedi": ["pmecpq57", "8ritukil"],  # iclr26, 5 seeds
     },
     "mini-hanabi": {
-        "fcp": "c5kukiyx", 
-        "brdiv": "0az0sa6t", 
-        "lbrdiv": ["wv7j92rh", "fig22cpk"],
-        "comedi": "acp6wglt",
-        "rotate": "mw1jdo7s",
-        "cole": "6zhwr6yb",
-        "trajedi": "2v2lw5k7",
-    }
+        "fcp": "c5kukiyx",  # neurips
+        "brdiv": "0az0sa6t",  # neurips
+        "lbrdiv": ["wv7j92rh", "fig22cpk"],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
+        "comedi": "acp6wglt",  # neurips
+        "rotate": "mw1jdo7s",  # neurips
+        "cole": "ffb5g4tu",  # iclr26, 5 seeds
+        "trajedi": "qj2yxrp2",  # iclr26, 5 seeds
+    },
 }
 
 ####### HYPERPARAMETER SWEEPS #######

--- a/scripts/paper_vis/plot_globals.py
+++ b/scripts/paper_vis/plot_globals.py
@@ -1,24 +1,31 @@
 """Stores hard-coded variables for paper plots."""
+
 import omegaconf
 
 SAVE_DIR = "results/figures"
 ENTITY = "aht-project"
-####### AGENT TYPE SUBSTRINGS #### 
+####### AGENT TYPE SUBSTRINGS ####
 HEURISTIC_AGENTS = [
     # LBF
-    "seq_agent*", "entitled_agent", "greedy_",
+    "seq_agent*",
+    "entitled_agent",
+    "greedy_",
     # Overcooked
-    "independent", "onion", "plate", 
+    "independent",
+    "onion",
+    "plate",
     # Hanabi
-    "iggi", "piers", "flawed", "outer", "van_den_bergh", 
-    "smartbot", "cautious", "internal"
+    "iggi",
+    "piers",
+    "flawed",
+    "outer",
+    "van_den_bergh",
+    "smartbot",
+    "cautious",
+    "internal",
 ]
-RL_AGENTS = [
-    "comedi", "lbrdiv", "ippo", "brdiv", "obl"
-]
-HUMAN_PROXY_AGENTS = [
-    "human_proxy"
-]
+RL_AGENTS = ["comedi", "lbrdiv", "ippo", "brdiv", "obl"]
+HUMAN_PROXY_AGENTS = ["human_proxy"]
 ####### BENCHMARK RUNS #######
 BENCHMARK_PROJECT = "aht-benchmark"
 # Run ids by campaign wandb tag (project aht-benchmark), refreshed 2026-09-06.
@@ -37,7 +44,11 @@ EGO_BENCHMARK_RUNS = {
         },
         "meliba": {
             "fcp_teammates": ["ernydfeu", "isx6v5kf", "m04si2f5"],  # iclr26, 10 seeds
-            "comedi_teammates": ["2gs98nrk", "sadapb3o", "pxsx1ahd"],  # iclr26, 10 seeds
+            "comedi_teammates": [
+                "2gs98nrk",
+                "sadapb3o",
+                "pxsx1ahd",
+            ],  # iclr26, 10 seeds
         },
     },
     "lbf/lbf_12x12": {
@@ -51,7 +62,11 @@ EGO_BENCHMARK_RUNS = {
         },
         "meliba": {
             "fcp_teammates": ["t8v125ba", "2swcrf3y", "af08h0sw"],  # iclr26, 10 seeds
-            "comedi_teammates": ["lw7cmntl", "gxk4t9ee", "xgi1oqro"],  # iclr26, 10 seeds
+            "comedi_teammates": [
+                "lw7cmntl",
+                "gxk4t9ee",
+                "xgi1oqro",
+            ],  # iclr26, 10 seeds
         },
     },
     "overcooked-v1/cramped_room": {
@@ -65,7 +80,11 @@ EGO_BENCHMARK_RUNS = {
         },
         "meliba": {
             "fcp_teammates": ["sjkmr2co", "9kvtltg8", "7gqbc2gd"],  # iclr26, 10 seeds
-            "comedi_teammates": ["ikbqpjaq", "6hyan548", "5mx43y3q"],  # iclr26, 10 seeds
+            "comedi_teammates": [
+                "ikbqpjaq",
+                "6hyan548",
+                "5mx43y3q",
+            ],  # iclr26, 10 seeds
         },
     },
     "overcooked-v1/coord_ring": {
@@ -79,7 +98,11 @@ EGO_BENCHMARK_RUNS = {
         },
         "meliba": {
             "fcp_teammates": ["vjvs7uug", "0b27ry3j", "8bpn86ss"],  # iclr26, 10 seeds
-            "comedi_teammates": ["vt2edaa7", "p0rv1ege", "ins39ls1"],  # iclr26, 10 seeds
+            "comedi_teammates": [
+                "vt2edaa7",
+                "p0rv1ege",
+                "ins39ls1",
+            ],  # iclr26, 10 seeds
         },
     },
     "overcooked-v1/asymm_advantages": {
@@ -121,21 +144,50 @@ EGO_BENCHMARK_RUNS = {
         },
         "meliba": {
             "fcp_teammates": ["obtdbm9y", "z7pmvhj7", "tv16ua4v"],  # iclr26, 10 seeds
-            "comedi_teammates": ["r5e8vlp7", "giim6lb3", "gnocl630"],  # iclr26, 10 seeds
+            "comedi_teammates": [
+                "r5e8vlp7",
+                "giim6lb3",
+                "gnocl630",
+            ],  # iclr26, 10 seeds
         },
     },
     "mini-hanabi": {
         "ppo_ego": {
-            "fcp_teammates": ["hkoidsa0", "rflrtlzo", "719okso0", "6s91gqf5"],  # neurips, 5 seeds
-            "comedi_teammates": ["g61afu52", "7rpmb6ie", "70d2c8v2", "38pn9msz"],  # neurips
+            "fcp_teammates": [
+                "hkoidsa0",
+                "rflrtlzo",
+                "719okso0",
+                "6s91gqf5",
+            ],  # neurips, 5 seeds
+            "comedi_teammates": [
+                "g61afu52",
+                "7rpmb6ie",
+                "70d2c8v2",
+                "38pn9msz",
+            ],  # neurips
         },
         "liam": {
-            "fcp_teammates": ["gr03b106", "5ab05qxj", "0hwgmfj3", "lwpl8w6x"],  # neurips, 5 seeds
-            "comedi_teammates": ["x0ckfnlv", "b2by5off", "72at5w6x", "tq4fcjh4", "6sig81om"],  # neurips
+            "fcp_teammates": [
+                "gr03b106",
+                "5ab05qxj",
+                "0hwgmfj3",
+                "lwpl8w6x",
+            ],  # neurips, 5 seeds
+            "comedi_teammates": [
+                "x0ckfnlv",
+                "b2by5off",
+                "72at5w6x",
+                "tq4fcjh4",
+                "6sig81om",
+            ],  # neurips
         },
         "meliba": {
             "fcp_teammates": ["3pu1t8gw", "azrmgwkw", "es6t0hbh"],  # iclr26, 10 seeds
-            "comedi_teammates": ["lza9gtk4", "mtx7yx4l", "9vh5ul08"],  # iclr26, 10 seeds
+            "comedi_teammates": [
+                "lza9gtk4",
+                "mtx7yx4l",
+                "9vh5ul08",
+            ],  # iclr26, 10 seeds
         },
     },
 }
@@ -146,27 +198,44 @@ EGO_BENCHMARK_RUNS = {
 # the BC partner(s) for its task: 5 BC partners (overcooked) or 1 (LBF).
 # When --include-bc is passed to benchmark_bar_charts.py, these artifacts are
 # merged with the standard heldout-eval ones before the reducer runs.
-# Generated 2026-05-06 via evaluation/run_heldout_ego_bc.py at NUM_EVAL_EPISODES=64.
+# Ego-method cells (ppo_ego/liam/meliba, keyed by teammate type) were generated
+# 2026-05-06 via evaluation/run_heldout_ego_bc.py at NUM_EVAL_EPISODES=64.
+# Teammate-generation cells (fcp/brdiv/lbrdiv/comedi, plain ids) were generated
+# 2026-09-06 via evaluation/run_heldout_ego_human_proxy.py for the neurips-era
+# UNIFIED_BENCHMARK_RUNS whose heldout set predates `human_proxy`; a list entry
+# pairs one eval per pooled source run, in the same order.
 BC_BENCHMARK_RUNS = {
     "lbf/lbf_7x7_nolevels": {
         "ppo_ego": {"fcp_teammates": "shov7vtt", "comedi_teammates": "5bzzvtvr"},
-        "liam":    {"fcp_teammates": "rodfedo5", "comedi_teammates": "kbmgv1qy"},
-        "meliba":  {"fcp_teammates": "yfqq4r7c", "comedi_teammates": "d66eh0tt"},
+        "liam": {"fcp_teammates": "rodfedo5", "comedi_teammates": "kbmgv1qy"},
+        "meliba": {"fcp_teammates": "yfqq4r7c", "comedi_teammates": "d66eh0tt"},
+        "fcp": "wfx1j0s9",  # human_proxy eval of 1bhjc1ri
+        "lbrdiv": "fakllgwc",  # human_proxy eval of jj2ycq8o
+        "comedi": "w9i929ds",  # human_proxy eval of us4jl8ch
     },
     "lbf/lbf_12x12": {
         "ppo_ego": {"fcp_teammates": "lgqum8kt", "comedi_teammates": "t7idtlm9"},
-        "liam":    {"fcp_teammates": "dhr9hjgo", "comedi_teammates": "pwuy5p46"},
-        "meliba":  {"fcp_teammates": "u5yu6xvn", "comedi_teammates": "ij48l33l"},
+        "liam": {"fcp_teammates": "dhr9hjgo", "comedi_teammates": "pwuy5p46"},
+        "meliba": {"fcp_teammates": "u5yu6xvn", "comedi_teammates": "ij48l33l"},
+        "fcp": ["nsf9pl09", "tg0pevb8"],  # human_proxy evals of 1c0um2ls, 52wp5amm
+        "brdiv": "qg089f9c",  # human_proxy eval of b3xozodw
+        "lbrdiv": "hnvvgr0g",  # human_proxy eval of dft2f0do
+        "comedi": "h0d82bxk",  # human_proxy eval of 7qizaam5
     },
     "overcooked-v1/coord_ring": {
         "ppo_ego": {"fcp_teammates": "v8x87epc", "comedi_teammates": "1k2kz0ge"},
-        "liam":    {"fcp_teammates": "4k8zkd5e", "comedi_teammates": "p3a0x1gb"},
-        "meliba":  {"fcp_teammates": "gna0budi", "comedi_teammates": "0eqejvkm"},
+        "liam": {"fcp_teammates": "4k8zkd5e", "comedi_teammates": "p3a0x1gb"},
+        "meliba": {"fcp_teammates": "gna0budi", "comedi_teammates": "0eqejvkm"},
+        "fcp": "3c8cwkhv",  # human_proxy eval of ikrlj1qe
+        "lbrdiv": "tuvmnert",  # human_proxy eval of x012q7qc
     },
     "overcooked-v1/cramped_room": {
         "ppo_ego": {"fcp_teammates": "durax862", "comedi_teammates": "86yovjo6"},
-        "liam":    {"fcp_teammates": "9ni4tvq3", "comedi_teammates": "tsfrosfr"},
-        "meliba":  {"fcp_teammates": "b612ne9c", "comedi_teammates": "kvygcmqc"},
+        "liam": {"fcp_teammates": "9ni4tvq3", "comedi_teammates": "tsfrosfr"},
+        "meliba": {"fcp_teammates": "b612ne9c", "comedi_teammates": "kvygcmqc"},
+        "fcp": "atgl2e6k",  # human_proxy eval of n1mplxeg
+        "lbrdiv": "93uq3pq7",  # human_proxy eval of kfiwwxbu
+        "comedi": ["ou97oaxs", "1jaobbqz"],  # human_proxy evals of 8k97saxv, fqw407x0
     },
 }
 
@@ -181,7 +250,10 @@ UNIFIED_BENCHMARK_RUNS = {
         "trajedi": "733qoihr",  # iclr26, 5 seeds
     },
     "lbf/lbf_12x12": {
-        "fcp": ["1c0um2ls", "52wp5amm"],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
+        "fcp": [
+            "1c0um2ls",
+            "52wp5amm",
+        ],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
         "brdiv": "b3xozodw",  # neurips
         "lbrdiv": "dft2f0do",  # neurips
         "comedi": "7qizaam5",  # neurips
@@ -193,7 +265,10 @@ UNIFIED_BENCHMARK_RUNS = {
         "fcp": "n1mplxeg",  # neurips
         "brdiv": "u1hihvk2",  # iclr26, 5 seeds
         "lbrdiv": "kfiwwxbu",  # neurips
-        "comedi": ["8k97saxv", "fqw407x0"],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
+        "comedi": [
+            "8k97saxv",
+            "fqw407x0",
+        ],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
         "rotate": "egwn4951",  # neurips
         "cole": "mj2zzmzq",  # iclr26, 5 seeds
         "trajedi": "4ubrdpio",  # iclr26, 5 seeds
@@ -210,7 +285,13 @@ UNIFIED_BENCHMARK_RUNS = {
     "overcooked-v1/asymm_advantages": {
         "fcp": "waolda91",  # iclr26, 5 seeds
         "brdiv": "zmnouxfd",  # iclr26, 5 seeds
-        "lbrdiv": ["e7ui3d6b", "ua0spahs", "95xkc9e3", "6q6ixj7x", "1pr9nuhi"],  # iclr26, 5 seeds
+        "lbrdiv": [
+            "e7ui3d6b",
+            "ua0spahs",
+            "95xkc9e3",
+            "6q6ixj7x",
+            "1pr9nuhi",
+        ],  # iclr26, 5 seeds
         "comedi": "zeuzmm3p",  # iclr26, 5 seeds
         "rotate": "l9q0kchn",  # iclr26, 5 seeds
         "cole": "162sq4py",  # iclr26, 5 seeds
@@ -228,7 +309,13 @@ UNIFIED_BENCHMARK_RUNS = {
     "overcooked-v1/counter_circuit": {
         "fcp": "5v7kd2ok",  # iclr26, 5 seeds
         "brdiv": "f8tvok12",  # iclr26, 5 seeds
-        "lbrdiv": ["5iyo3iw6", "2r9gen4f", "jcg3b9c0", "ct5luwgo", "u021qxlz"],  # iclr26, 5 seeds
+        "lbrdiv": [
+            "5iyo3iw6",
+            "2r9gen4f",
+            "jcg3b9c0",
+            "ct5luwgo",
+            "u021qxlz",
+        ],  # iclr26, 5 seeds
         "comedi": "um47gdei",  # iclr26, 5 seeds
         "rotate": "8nsgv1wk",  # iclr26, 5 seeds
         "cole": "upb63g1n",  # iclr26, 5 seeds
@@ -237,7 +324,10 @@ UNIFIED_BENCHMARK_RUNS = {
     "mini-hanabi": {
         "fcp": "c5kukiyx",  # neurips
         "brdiv": "0az0sa6t",  # neurips
-        "lbrdiv": ["wv7j92rh", "fig22cpk"],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
+        "lbrdiv": [
+            "wv7j92rh",
+            "fig22cpk",
+        ],  # neurips; 2+3 split at same TRAIN_SEED=20374 -> 3 seeds, not 5
         "comedi": "acp6wglt",  # neurips
         "rotate": "mw1jdo7s",  # neurips
         "cole": "ffb5g4tu",  # iclr26, 5 seeds
@@ -246,28 +336,30 @@ UNIFIED_BENCHMARK_RUNS = {
 }
 
 ####### HYPERPARAMETER SWEEPS #######
-HYPERPARAM_DEFAULT_METRIC = "HeldoutEval/FinalEgoVsHeldout/returned_episode_returns/mean"
+HYPERPARAM_DEFAULT_METRIC = (
+    "HeldoutEval/FinalEgoVsHeldout/returned_episode_returns/mean"
+)
 HYPERPARAM_PROJECT = "aht-parameter-sweep"
 
 HYPERPARAM_SWEEPS = {
     "lbf/lbf_7x7_nolevels": {
-        "ppo_ego": "yje7een6", 
-        "liam": "xqiaed80", 
+        "ppo_ego": "yje7een6",
+        "liam": "xqiaed80",
         "meliba": "y4ddadn8",
-        "fcp": "22cojezv", 
-        "brdiv": "d3e7c0fx", 
+        "fcp": "22cojezv",
+        "brdiv": "d3e7c0fx",
         "lbrdiv": "rni853js",
-        "comedi": "d1dt0arj", 
+        "comedi": "d1dt0arj",
         "rotate": "44c1kwu0",
         "cole": "pr0fwbdp",
         "trajedi": "13umuekr",
     },
     "lbf/lbf_12x12": {
-        "ppo_ego": "k2giuu4l", 
-        "liam": "yibcruuz", 
+        "ppo_ego": "k2giuu4l",
+        "liam": "yibcruuz",
         "meliba": "6jdo5rjv",
-        "fcp": "nivg4xvf", 
-        "brdiv": "fdg6dw1n", 
+        "fcp": "nivg4xvf",
+        "brdiv": "fdg6dw1n",
         "lbrdiv": "y23unh8y",
         "comedi": "7e9yf5zg",
         "rotate": "csg80xwm",
@@ -275,11 +367,11 @@ HYPERPARAM_SWEEPS = {
         "trajedi": "ik9juu5l",
     },
     "overcooked-v1/cramped_room": {
-        "ppo_ego": "vexvuss8", 
-        "liam": "zz9lkwdz", 
+        "ppo_ego": "vexvuss8",
+        "liam": "zz9lkwdz",
         "meliba": "dva0ffdq",
-        "fcp": "e23khyjt", 
-        "brdiv": "19gmzemf", 
+        "fcp": "e23khyjt",
+        "brdiv": "19gmzemf",
         "lbrdiv": "w8abf056",
         "comedi": "vt0xnwxc",
         "rotate": "aki2rypl",
@@ -287,13 +379,13 @@ HYPERPARAM_SWEEPS = {
         "trajedi": "okerlren",
     },
     "overcooked-v1/coord_ring": {
-        "ppo_ego": "qeafl8r7", 
-        "liam": "pbq863zp", 
+        "ppo_ego": "qeafl8r7",
+        "liam": "pbq863zp",
         "meliba": "i532vemb",
-        "fcp": "fubwmomo", 
-        "brdiv": "wgapxysb", 
+        "fcp": "fubwmomo",
+        "brdiv": "wgapxysb",
         "lbrdiv": "eu0g1orm",
-        "comedi": "xeikmue5", 
+        "comedi": "xeikmue5",
         "rotate": "df4m613k",
         "cole": "irstlaiv",
         "trajedi": "awdjju8b",
@@ -334,25 +426,21 @@ HYPERPARAM_SWEEPS = {
     },
     "mini-hanabi": {
         "ppo_ego": "y2w21bej",
-        "liam": "8t2so38u", 
+        "liam": "8t2so38u",
         "meliba": "q4z3szuh",
-        "fcp": "oku0yyg0", 
-        "brdiv": "wnnhav1m", 
+        "fcp": "oku0yyg0",
+        "brdiv": "wnnhav1m",
         "lbrdiv": "uvvpc05r",
         "comedi": "s745q3lg",
         "rotate": "ehxr5cyx",
         "cole": "158to6y5",
         "trajedi": "4uw6liu5",
-    }
+    },
 }
 
 # values that were mistakenly included in the
 # hyperparameter sweep that now need to be excluded
-FILTERED_HYPERPARAMETER_KV = {
-    "trajedi": {
-        "TRAJEDI_COEF": [0.0]
-    }
-}
+FILTERED_HYPERPARAMETER_KV = {"trajedi": {"TRAJEDI_COEF": [0.0]}}
 
 ####### PLOTTING SETTINGS #######
 # Tasks included in this paper revision's figures (the NeurIPS task set). Runs for other
@@ -394,7 +482,7 @@ TASK_TO_AXIS_DISPLAY_NAME = {
     "overcooked-v1/forced_coord": "FC",
     "overcooked-v1/counter_circuit": "CC",
     "overcooked-v1/coord_ring": "CoR",
-    "mini-hanabi": "Mini Hanabi"
+    "mini-hanabi": "Mini Hanabi",
 }
 
 METHOD_TO_DISPLAY_NAME = {
@@ -422,7 +510,7 @@ TASK_TO_DISPLAY_NAME = {
     "overcooked-v1/asymm_advantages": "Asymmetric Advantages (Overcooked)",
     "overcooked-v1/forced_coord": "Forced Coordination (Overcooked)",
     "overcooked-v1/counter_circuit": "Counter Circuit (Overcooked)",
-    "mini-hanabi": "Mini Hanabi"
+    "mini-hanabi": "Mini Hanabi",
 }
 
 TASK_TO_ENV_NAME = {
@@ -433,7 +521,7 @@ TASK_TO_ENV_NAME = {
     "overcooked-v1/forced_coord": "overcooked-v1",
     "overcooked-v1/counter_circuit": "overcooked-v1",
     "overcooked-v1/coord_ring": "overcooked-v1",
-    "mini-hanabi": "hanabi"
+    "mini-hanabi": "hanabi",
 }
 
 TASK_TO_METRIC_NAME = {
@@ -451,7 +539,9 @@ TASK_TO_METRIC_NAME = {
 # shape (num_seeds, num_oel_iter, num_heldout_agents, num_eval_episodes, num_agents_per_game)
 OEL_METHODS = ["rotate"]
 
-GLOBAL_HELDOUT_CONFIG = omegaconf.OmegaConf.load("evaluation/configs/global_heldout_settings.yaml")
+GLOBAL_HELDOUT_CONFIG = omegaconf.OmegaConf.load(
+    "evaluation/configs/global_heldout_settings.yaml"
+)
 CACHE_FILENAME = "cached_summary_metrics.pkl"
 HELDOUT_CURVES_CACHE_FILENAME = "cached_heldout_curves.pkl"
 TITLE_FONTSIZE = 20
@@ -459,13 +549,13 @@ AXIS_LABEL_FONTSIZE = 18
 LEGEND_FONTSIZE = 14
 
 # def get_heldout_agents(task_name, task_config_path):
-    # rng = jax.random.PRNGKey(0)
-    # heldout_cfg = GLOBAL_HELDOUT_CONFIG["heldout_set"][task_name]
-    # env_config = omegaconf.OmegaConf.load(task_config_path)
-    # env_name = env_config["ENV_NAME"]
-    # env_kwargs = env_config["ENV_KWARGS"]
+# rng = jax.random.PRNGKey(0)
+# heldout_cfg = GLOBAL_HELDOUT_CONFIG["heldout_set"][task_name]
+# env_config = omegaconf.OmegaConf.load(task_config_path)
+# env_name = env_config["ENV_NAME"]
+# env_kwargs = env_config["ENV_KWARGS"]
 
-    # env = make_env(env_name, env_kwargs)
-    # heldout_agents = load_heldout_set(heldout_cfg, env, task_name, env_kwargs, rng)
+# env = make_env(env_name, env_kwargs)
+# heldout_agents = load_heldout_set(heldout_cfg, env, task_name, env_kwargs, rng)
 
-    # return heldout_agents
+# return heldout_agents

--- a/scripts/paper_vis/plot_sweep_distribution.py
+++ b/scripts/paper_vis/plot_sweep_distribution.py
@@ -1,11 +1,16 @@
-"""Visualize the distribution of sweep performance across all hyperparameter settings.
+"""Visualize the distribution of sweep performance across hyperparameter settings.
 
-For a given task and algorithm type (ego or unified), generates a grid of subplots —
-one per algorithm — where each point is one sweep run. The y-axis shows performance;
-the x-axis is meaningless (points are spread with jitter for readability).
+For a given task and algorithm type (ego, teammate_gen or unified), generates a grid of
+subplots — one per algorithm — where each point is one unique hyperparameter setting
+(mean score over its seeds). The y-axis shows performance; the x-axis is meaningless
+(points are spread with jitter for readability).
 
-To run: edit the config block at the bottom of this file, then:
-    python scripts/paper_vis/plot_sweep_distribution.py
+The settings shown are exactly those considered when the benchmark configs were chosen:
+``scripts/manage_configs/apply_best_hparams.py --max-hparams 140 --seed 0`` (see
+``select_hparam_settings`` there). Pass ``--max-hparams 0`` to show every setting.
+
+To run:
+    python scripts/paper_vis/plot_sweep_distribution.py --algo-type ego --task lbf/lbf_12x12
 """
 
 from __future__ import annotations
@@ -15,64 +20,17 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from scipy.stats import gaussian_kde
 
+from scripts.manage_configs.apply_best_hparams import select_hparam_settings
 from scripts.paper_vis.plot_globals import (
-    SAVE_DIR,
-    ENTITY,
-    METHOD_TO_DISPLAY_NAME, TASK_TO_DISPLAY_NAME,
-    HYPERPARAM_PROJECT,
-    HYPERPARAM_DEFAULT_METRIC,
     HYPERPARAM_SWEEPS,
-    TASK_LEGACY_NAMES,
+    METHOD_TO_DISPLAY_NAME,
+    SAVE_DIR,
+    TASK_TO_DISPLAY_NAME,
 )
 from scripts.utils import ALGO_TO_ENTRY_POINT
-from scripts.wandb_utils.wandb_cache import fetch_sweep_cached, extract_metric
-
-
-def _get_hparam_cols(df: pd.DataFrame) -> list[str]:
-    """Return config columns that vary across runs and have hashable values.
-
-    Mirrors the logic in print_sweep_summary.py: skip columns where nunique()
-    raises TypeError (entirely unhashable, e.g. always-dict columns).
-    """
-    cols = []
-    for c in df.columns:
-        if c.startswith("_"):
-            continue
-        try:
-            if df[c].nunique() > 1:
-                cols.append(c)
-        except TypeError:
-            pass
-    return cols
-
-
-def deduplicate_and_sample(
-    df: pd.DataFrame,
-    max_num: int | None,
-    seed: int = 0,
-) -> pd.DataFrame:
-    """Aggregate duplicate hyperparam combinations and optionally subsample.
-
-    Rows with identical hyperparameter settings are collapsed by taking the
-    mean _score.  If more than *max_num* unique combinations remain, randomly
-    sample down to that limit.
-    """
-    hparam_cols = _get_hparam_cols(df)
-    if hparam_cols:
-        # Drop individual rows where a hyperparam value is unhashable (e.g. a
-        # dict nested inside an otherwise scalar column).
-        hashable_mask = df[hparam_cols].apply(
-            lambda col: col.map(lambda v: not isinstance(v, (dict, list)))
-        ).all(axis=1)
-        df = df[hashable_mask].copy()
-        df = df.groupby(hparam_cols, as_index=False, dropna=False).agg({"_score": "mean"})
-    if max_num is not None and len(df) > max_num:
-        df = df.sample(n=max_num, random_state=seed)
-    return df
 
 
 def plot_distribution(
@@ -86,7 +44,8 @@ def plot_distribution(
     nrows = (n + ncols - 1) // ncols
 
     fig, axes = plt.subplots(
-        nrows, ncols,
+        nrows,
+        ncols,
         figsize=(ncols * 3, nrows * 3.5),
         squeeze=False,
     )
@@ -101,8 +60,13 @@ def plot_distribution(
 
         ax.scatter(x, scores, alpha=0.5, s=18, color="steelblue")
         median = np.median(scores)
-        ax.axhline(median, color="crimson", linewidth=1.2, linestyle="--",
-                   label=f"median={median:.3f}")
+        ax.axhline(
+            median,
+            color="crimson",
+            linewidth=1.2,
+            linestyle="--",
+            label=f"median={median:.3f}",
+        )
 
         ax.set_title(METHOD_TO_DISPLAY_NAME[algo], fontsize=10)
         ax.set_ylabel("Mean Normalized Return", fontsize=8)
@@ -123,9 +87,15 @@ def plot_distribution(
         ax_kde.axhline(median, color="crimson", linewidth=1.2, linestyle="--")
         peak_y = y_vals[np.argmax(density)]
         peak_d = density.max()
-        ax_kde.annotate(f"{peak_y:.3f}", xy=(peak_d, peak_y),
-                        xytext=(-4, -10), textcoords="offset points",
-                        fontsize=7, va="center", color="steelblue")
+        ax_kde.annotate(
+            f"{peak_y:.3f}",
+            xy=(peak_d, peak_y),
+            xytext=(-4, -10),
+            textcoords="offset points",
+            fontsize=7,
+            va="center",
+            color="steelblue",
+        )
         ax_kde.set_ylim(0, y_max + 0.05)
         ax_kde.set_xticks([])
         ax_kde.set_yticks([])
@@ -146,21 +116,43 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Plot performance distribution across all hyperparameter settings."
     )
-    parser.add_argument("--algo-type", choices=["ego", "teammate_gen", "unified"], required=True,
-                        help="Which sweep family to visualize.")
-    parser.add_argument("--task", required=True,
-                        help="Task name (e.g. lbf/lbf_7x7_nolevels).")
-    parser.add_argument("--force-recompute", action="store_true",
-                        help="Re-fetch from wandb, ignoring the local cache.")
-    parser.add_argument("--max-hparams", type=int, default=200,
-                        help="Max unique hyperparam combinations to visualize per algorithm. "
-                             "If exceeded, randomly sample down to this limit.")
+    parser.add_argument(
+        "--algo-type",
+        choices=["ego", "teammate_gen", "unified"],
+        required=True,
+        help="Which sweep family to visualize.",
+    )
+    parser.add_argument(
+        "--task", required=True, help="Task name (e.g. lbf/lbf_7x7_nolevels)."
+    )
+    parser.add_argument(
+        "--force-recompute",
+        action="store_true",
+        help="Re-fetch from wandb, ignoring the local cache.",
+    )
+    parser.add_argument(
+        "--max-hparams",
+        type=int,
+        default=140,
+        help="Max unique hyperparam settings to visualize per algorithm. If the "
+        "sweep ran more, a seeded random subset is drawn — the same subset "
+        "apply_best_hparams.py used to pick the benchmark configs "
+        "(default: 140). Pass 0 to show every setting.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for the --max-hparams subsample (default: 0, matching "
+        "apply_best_hparams.py).",
+    )
     args = parser.parse_args()
 
     ALGO_TYPE = args.algo_type
     TASK = args.task
     FORCE_RECOMPUTE = args.force_recompute
-    MAX_NUM_TO_VISUALIZE = args.max_hparams
+    MAX_NUM_TO_VISUALIZE = args.max_hparams or None
+    SEED = args.seed
 
     ALGO_TYPE_TO_ENTRY_POINT = {
         "ego": "ego_agent_training",
@@ -169,21 +161,21 @@ if __name__ == "__main__":
     }
     all_task_sweeps = HYPERPARAM_SWEEPS[TASK]
     task_sweeps = {
-        algo: sid for algo, sid in all_task_sweeps.items()
+        algo: sid
+        for algo, sid in all_task_sweeps.items()
         if ALGO_TO_ENTRY_POINT.get(algo) == ALGO_TYPE_TO_ENTRY_POINT[ALGO_TYPE]
     }
 
     scores_by_algo: dict[str, np.ndarray] = {}
-    for algo, sweep_id in task_sweeps.items():
-        task_leaf = TASK_LEGACY_NAMES.get(TASK, TASK.split("/")[-1])
-        df = fetch_sweep_cached(sweep_id, ENTITY, HYPERPARAM_PROJECT,
-                                force_recompute=FORCE_RECOMPUTE,
-                                expected_name_parts=[algo, task_leaf])
-        df = extract_metric(df, HYPERPARAM_DEFAULT_METRIC)
-        df = deduplicate_and_sample(df, MAX_NUM_TO_VISUALIZE)
+    for algo in task_sweeps:
+        df, _ = select_hparam_settings(
+            TASK, algo, FORCE_RECOMPUTE, max_hparams=MAX_NUM_TO_VISUALIZE, seed=SEED
+        )
         scores_by_algo[algo] = df["_score"].values
-        print(f"  {algo}: {len(df)} unique hparam combos")
+        print(f"  {algo}: {len(df)} hparam settings")
 
-    out_path = Path(SAVE_DIR) / f"sweep_distribution_{ALGO_TYPE}_{TASK.replace('/', '_')}.pdf"
+    out_path = (
+        Path(SAVE_DIR) / f"sweep_distribution_{ALGO_TYPE}_{TASK.replace('/', '_')}.pdf"
+    )
     title = f"{TASK_TO_DISPLAY_NAME[TASK]}"
     plot_distribution(scores_by_algo, title, out_path)

--- a/scripts/paper_vis/process_data.py
+++ b/scripts/paper_vis/process_data.py
@@ -82,7 +82,7 @@ def load_results_for_task(
             run whose own heldout set has no human proxy, the matching BC
             heldout-eval artifact is appended along the partner axis before
             the reducer runs; runs that already include the human proxy
-            (iclr26-era) are used as-is. See ``heldout_partners``.
+            (sept26-era) are used as-is. See ``heldout_partners``.
 
     Returns:
         dict mapping display_name -> summary_data dict. Each summary carries

--- a/scripts/paper_vis/process_data.py
+++ b/scripts/paper_vis/process_data.py
@@ -1,17 +1,19 @@
 """Load and summarize heldout eval metrics pulled from wandb."""
+
 import pickle
 import warnings
 from pathlib import Path
-from typing import List, Tuple
 
 import numpy as np
 
 from common.plot_utils import get_metric_names
-from common.stat_utils import compute_aggregate_stat_and_ci_per_task, compute_aggregate_stat_and_ci
-from scripts.paper_vis.plot_globals import (
-    GLOBAL_HELDOUT_CONFIG, BENCHMARK_PROJECT, ENTITY, TASK_TO_ENV_NAME,
+from common.stat_utils import (
+    compute_aggregate_stat_and_ci,
+    compute_aggregate_stat_and_ci_per_task,
 )
-from scripts.wandb_utils.wandb_cache import fetch_run_eval_metrics_cached, DEFAULT_CACHE_DIR
+from scripts.paper_vis.heldout_partners import load_run_eval_metrics
+from scripts.paper_vis.plot_globals import GLOBAL_HELDOUT_CONFIG, TASK_TO_ENV_NAME
+from scripts.wandb_utils.wandb_cache import DEFAULT_CACHE_DIR
 
 
 def detect_failed_seeds(
@@ -33,7 +35,9 @@ def detect_failed_seeds(
     """
     data = eval_metrics[metric_name]
     if oel_method and data.ndim == 5:
-        data = data[:, -1]  # (num_seeds, num_heldout_agents, num_eval_eps, num_agents_per_game)
+        data = data[
+            :, -1
+        ]  # (num_seeds, num_heldout_agents, num_eval_eps, num_agents_per_game)
 
     # Mean over eval_eps and agents_per_game -> (num_seeds, num_heldout_agents)
     seed_teammate_means = data.mean(axis=(-1, -2))
@@ -43,19 +47,22 @@ def detect_failed_seeds(
     if not valid.any():
         return np.zeros(seed_teammate_means.shape[0], dtype=bool)
 
-    below = seed_teammate_means[:, valid] < relative_threshold * best_per_teammate[valid]
+    below = (
+        seed_teammate_means[:, valid] < relative_threshold * best_per_teammate[valid]
+    )
     return below.mean(axis=-1) > breadth_threshold
 
 
 def load_results_for_task(
     task_name: str,
-    run_specs: List[Tuple[str, str, bool]],
+    run_specs: list[tuple[str, str, bool]],
     force_recompute: bool = False,
     renormalize_metrics: bool = False,
     cache_dir: Path = DEFAULT_CACHE_DIR,
     filter_failed_seeds: bool = False,
     failed_seed_relative_threshold: float = 0.10,
     failed_seed_breadth_threshold: float = 0.80,
+    bc_run_specs: list[tuple[str, str, bool]] | None = None,
 ) -> dict:
     """Fetch wandb eval-metric artifacts and compute summary stats for each method.
 
@@ -71,66 +78,91 @@ def load_results_for_task(
             this fraction of the best seed's mean to count as failed
         failed_seed_breadth_threshold: fraction of heldout agents that must
             be below the relative threshold to flag a seed as failed
+        bc_run_specs: optional (display_name, bc_run_id, is_oel) tuples. For a
+            run whose own heldout set has no human proxy, the matching BC
+            heldout-eval artifact is appended along the partner axis before
+            the reducer runs; runs that already include the human proxy
+            (iclr26-era) are used as-is. See ``heldout_partners``.
 
     Returns:
-        dict mapping display_name -> summary_data dict
+        dict mapping display_name -> summary_data dict. Each summary carries
+        ``_partner_labels`` (partner names along the artifact axis) and
+        ``_human_proxy`` ("builtin", "bc_merge", or None).
     """
     cache_dir = Path(cache_dir)
     env_name = TASK_TO_ENV_NAME[task_name]
     metric_names = get_metric_names(env_name)
+    bc_by_name = {dn: rid for dn, rid, _ in (bc_run_specs or [])}
 
     best_returns = None
     if renormalize_metrics:
         from scripts.paper_vis.compute_best_returns import load_best_returns
-        best_returns = load_best_returns(task_name, run_specs, cache_dir=cache_dir,
-                                         force_recompute=force_recompute)
+
+        best_returns = load_best_returns(
+            task_name,
+            run_specs,
+            cache_dir=cache_dir,
+            force_recompute=force_recompute,
+            bc_run_specs=bc_run_specs,
+        )
         print(f"Loaded best returns for {task_name}: {best_returns}")
 
     results = {}
     for display_name, run_id, is_oel in run_specs:
         run_ids = run_id if isinstance(run_id, list) else [run_id]
         run_id_str = "+".join(run_ids)
+        bc_id = bc_by_name.get(display_name)
 
         safe_name = display_name.replace("/", "_").replace(" ", "_")
-        suffix = "_renorm" if renormalize_metrics else ""
+        suffix = f"__bc_{bc_id}" if bc_id else ""
+        suffix += "_renorm" if renormalize_metrics else ""
         if filter_failed_seeds:
             suffix += f"_filtered{failed_seed_relative_threshold}x{failed_seed_breadth_threshold}"
         summary_cache = (
-            cache_dir / "summary_stats" / task_name / f"{safe_name}__{run_id_str}{suffix}.pkl"
+            cache_dir
+            / "summary_stats"
+            / task_name
+            / f"{safe_name}__{run_id_str}{suffix}.pkl"
         )
 
         if not force_recompute and summary_cache.exists():
             with open(summary_cache, "rb") as f:
-                results[display_name] = pickle.load(f)
-            print(f"Loaded cached summary for {display_name}")
-            continue
+                cached = pickle.load(f)
+            if "_partner_labels" in cached:
+                results[display_name] = cached
+                print(f"Loaded cached summary for {display_name}")
+                continue
+            print(
+                f"Summary cache for {display_name} predates named partners; recomputing."
+            )
 
-        parts = [
-            fetch_run_eval_metrics_cached(rid, ENTITY, BENCHMARK_PROJECT, cache_dir, force_recompute)
-            for rid in run_ids
-        ]
-        if len(parts) == 1:
-            eval_metrics = parts[0]
-        else:
-            eval_metrics = {
-                k: np.concatenate([p[k] for p in parts], axis=0)
-                for k in parts[0]
-            }
+        eval_metrics, labels, perf_bounds, hp_source = load_run_eval_metrics(
+            task_name,
+            run_id,
+            is_oel,
+            cache_dir=cache_dir,
+            force_recompute=force_recompute,
+            bc_run_id=bc_id,
+        )
+        if hp_source is None:
+            warnings.warn(
+                f"[{task_name}] {display_name} ({run_id_str}) has no human proxy partner "
+                f"and no BC eval run is registered for it.",
+                stacklevel=2,
+            )
 
         if renormalize_metrics and best_returns is not None:
-            from scripts.paper_vis.compute_best_returns import (
-                renormalize_eval_metrics,
-                get_performance_bounds_from_run_config,
+            from scripts.paper_vis.compute_best_returns import renormalize_eval_metrics
+
+            eval_metrics = renormalize_eval_metrics(
+                eval_metrics, perf_bounds, best_returns, labels
             )
-            from scripts.wandb_utils.wandb_cache import fetch_run_config_cached
-            run_config = fetch_run_config_cached(run_ids[0], ENTITY, BENCHMARK_PROJECT, cache_dir)
-            perf_bounds = get_performance_bounds_from_run_config(run_config, task_name)
-            eval_metrics = renormalize_eval_metrics(eval_metrics, perf_bounds, best_returns)
 
         had_filtered_seeds = False
         if filter_failed_seeds:
             failed_mask = detect_failed_seeds(
-                eval_metrics, metric_names[0],
+                eval_metrics,
+                metric_names[0],
                 relative_threshold=failed_seed_relative_threshold,
                 breadth_threshold=failed_seed_breadth_threshold,
                 oel_method=is_oel,
@@ -152,6 +184,8 @@ def load_results_for_task(
             GLOBAL_HELDOUT_CONFIG, eval_metrics, metric_names, oel_method=is_oel
         )
         summary_data["_filtered_seeds"] = had_filtered_seeds
+        summary_data["_partner_labels"] = labels
+        summary_data["_human_proxy"] = hp_source
 
         summary_cache.parent.mkdir(parents=True, exist_ok=True)
         with open(summary_cache, "wb") as f:
@@ -163,120 +197,9 @@ def load_results_for_task(
     return results
 
 
-def load_results_for_task_merged(
-    task_name: str,
-    run_specs: List[Tuple[str, str, bool]],
-    bc_run_specs: List[Tuple[str, str, bool]],
-    force_recompute: bool = False,
-    cache_dir: Path = DEFAULT_CACHE_DIR,
-    filter_failed_seeds: bool = False,
-    failed_seed_relative_threshold: float = 0.10,
-    failed_seed_breadth_threshold: float = 0.80,
-) -> dict:
-    """Like `load_results_for_task` but merges each ego's training-time heldout
-    artifact with its BC heldout-eval artifact along the partner axis BEFORE
-    running the reducer. Both source artifacts are already per-partner
-    normalized by their `performance_bounds`, so the concat is comparable.
-
-    `bc_run_specs` indexes by display_name; cells without a matching BC entry
-    fall back to the standard pool only. Failed-seed filtering uses the same
-    `detect_failed_seeds` heuristic and threshold defaults as `load_results_for_task`.
-    """
-    cache_dir = Path(cache_dir)
-    env_name = TASK_TO_ENV_NAME[task_name]
-    metric_names = get_metric_names(env_name)
-
-    bc_by_name = {dn: rid for dn, rid, _ in bc_run_specs}
-
-    results = {}
-    for display_name, run_id, is_oel in run_specs:
-        run_ids = run_id if isinstance(run_id, list) else [run_id]
-        run_id_str = "+".join(run_ids)
-
-        bc_id = bc_by_name.get(display_name)
-        bc_id_str = bc_id if bc_id else "none"
-
-        safe_name = display_name.replace("/", "_").replace(" ", "_")
-        suffix = ""
-        if filter_failed_seeds:
-            suffix += f"_filtered{failed_seed_relative_threshold}x{failed_seed_breadth_threshold}"
-        summary_cache = (
-            cache_dir / "summary_stats_merged" / task_name
-            / f"{safe_name}__{run_id_str}__bc_{bc_id_str}{suffix}.pkl"
-        )
-
-        if not force_recompute and summary_cache.exists():
-            with open(summary_cache, "rb") as f:
-                results[display_name] = pickle.load(f)
-            print(f"Loaded cached merged summary for {display_name}")
-            continue
-
-        # Pull the standard heldout-eval artifact(s) (handles list-pooling).
-        old_parts = [
-            fetch_run_eval_metrics_cached(rid, ENTITY, BENCHMARK_PROJECT, cache_dir, force_recompute)
-            for rid in run_ids
-        ]
-        old_metrics = old_parts[0] if len(old_parts) == 1 else {
-            k: np.concatenate([p[k] for p in old_parts], axis=0) for k in old_parts[0]
-        }
-
-        if bc_id is None:
-            print(f"  no BC run registered for {display_name}; using old artifact only.")
-            eval_metrics = old_metrics
-        else:
-            bc_metrics = fetch_run_eval_metrics_cached(
-                bc_id, ENTITY, BENCHMARK_PROJECT, cache_dir, force_recompute
-            )
-            partner_axis = 2 if is_oel else 1   # OEL is 5D with seeds×iter prefix; partner axis shifts by 1
-            # Restrict to bc_run_0 only for overcooked (5 BC partners → 1); LBF already has 1.
-            if "overcooked" in task_name:
-                bc_metrics = {k: v.take(indices=[0], axis=partner_axis) for k, v in bc_metrics.items()}
-            common = sorted(set(old_metrics) & set(bc_metrics))
-            eval_metrics = {
-                k: np.concatenate([old_metrics[k], bc_metrics[k]], axis=partner_axis)
-                for k in common
-            }
-            print(f"  merged {display_name}: old shape "
-                  f"{old_metrics[common[0]].shape} + BC shape "
-                  f"{bc_metrics[common[0]].shape} → {eval_metrics[common[0]].shape}")
-
-        had_filtered_seeds = False
-        if filter_failed_seeds:
-            failed_mask = detect_failed_seeds(
-                eval_metrics, metric_names[0],
-                relative_threshold=failed_seed_relative_threshold,
-                breadth_threshold=failed_seed_breadth_threshold,
-                oel_method=is_oel,
-            )
-            if failed_mask.any():
-                had_filtered_seeds = True
-                seed_means = eval_metrics[metric_names[0]].mean(
-                    axis=tuple(range(1, eval_metrics[metric_names[0]].ndim))
-                )
-                warnings.warn(
-                    f"[{display_name}] Filtering {failed_mask.sum()} failed seed(s) "
-                    f"at index {np.where(failed_mask)[0].tolist()} "
-                    f"(per-seed means: {seed_means.round(4).tolist()})",
-                    stacklevel=2,
-                )
-                eval_metrics = {k: v[~failed_mask] for k, v in eval_metrics.items()}
-
-        summary_data = heldout_metrics_per_agent(
-            GLOBAL_HELDOUT_CONFIG, eval_metrics, metric_names, oel_method=is_oel
-        )
-        summary_data["_filtered_seeds"] = had_filtered_seeds
-
-        summary_cache.parent.mkdir(parents=True, exist_ok=True)
-        with open(summary_cache, "wb") as f:
-            pickle.dump(summary_data, f)
-        print(f"Saved merged summary for {display_name} → {summary_cache}")
-
-        results[display_name] = summary_data
-
-    return results
-
-
-def heldout_metrics_per_agent(config, eval_metrics, metric_names: tuple, oel_method: bool):
+def heldout_metrics_per_agent(
+    config, eval_metrics, metric_names: tuple, oel_method: bool
+):
     """Compute aggregate stat and CI over heldout agents.
 
     For OEL methods (5D arrays), uses the last iteration.
@@ -309,8 +232,10 @@ def heldout_metrics_per_agent(config, eval_metrics, metric_names: tuple, oel_met
 
         data = np.array(data)
 
-        point_est_per_task, interval_ests_per_task = compute_aggregate_stat_and_ci_per_task(
-            data, aggregate_stat, return_interval_est=True
+        point_est_per_task, interval_ests_per_task = (
+            compute_aggregate_stat_and_ci_per_task(
+                data, aggregate_stat, return_interval_est=True
+            )
         )
         lower_ci_per_task = interval_ests_per_task[:, 0]
         upper_ci_per_task = interval_ests_per_task[:, 1]

--- a/scripts/paper_vis/process_data.py
+++ b/scripts/paper_vis/process_data.py
@@ -114,7 +114,8 @@ def load_results_for_task(
         bc_id = bc_by_name.get(display_name)
 
         safe_name = display_name.replace("/", "_").replace(" ", "_")
-        suffix = f"__bc_{bc_id}" if bc_id else ""
+        bc_id_str = "+".join(bc_id) if isinstance(bc_id, list) else bc_id
+        suffix = f"__bc_{bc_id_str}" if bc_id else ""
         suffix += "_renorm" if renormalize_metrics else ""
         if filter_failed_seeds:
             suffix += f"_filtered{failed_seed_relative_threshold}x{failed_seed_breadth_threshold}"

--- a/scripts/paper_vis/process_data.py
+++ b/scripts/paper_vis/process_data.py
@@ -210,26 +210,18 @@ def heldout_metrics_per_agent(
         OEL:      (num_seeds, num_oel_iter, num_heldout_agents, num_eval_eps, num_agents_per_game)
         Standard: (num_seeds, num_heldout_agents, num_eval_eps, num_agents_per_game)
     """
-    num_heldout_agents = eval_metrics[metric_names[0]].shape[-3]
 
     summary_data = {}
     aggregate_stat = config["global_heldout_settings"]["AGGREGATE_STAT"]
 
     for metric_name in metric_names:
+        # Average out the episode and agents-per-game dims so that seeds are the
+        # bootstrap replication unit and heldout agents are the tasks (matches
+        # evaluation/heldout_runner.py). Final shape: (num_seeds, num_heldout_agents).
         if oel_method:
-            data = (
-                eval_metrics[metric_name][:, -1]
-                .mean(axis=-1)
-                .transpose(0, 2, 1)
-                .reshape(-1, num_heldout_agents)
-            )
+            data = eval_metrics[metric_name][:, -1].mean(axis=(-1, -2))
         else:
-            data = (
-                eval_metrics[metric_name]
-                .mean(axis=-1)
-                .transpose(0, 2, 1)
-                .reshape(-1, num_heldout_agents)
-            )
+            data = eval_metrics[metric_name].mean(axis=(-1, -2))
 
         data = np.array(data)
 

--- a/scripts/paper_vis/recompute_best_returns.py
+++ b/scripts/paper_vis/recompute_best_returns.py
@@ -3,75 +3,86 @@
 Uses locally cached wandb artifact pickles (eval metrics + run configs) when
 available; only downloads from wandb for runs that have not been cached yet.
 
+Best returns are matched across runs by partner name, so runs with and without
+the human proxy partner are combined in one file (see ``heldout_partners``).
+
 Run from repo root: python scripts/paper_vis/recompute_best_returns.py [--tasks ...]
 """
-import argparse
-import json
-from pathlib import Path
 
-from scripts.paper_vis.compute_best_returns import compute_best_returns, load_best_returns
+import argparse
+
+from scripts.paper_vis.compute_best_returns import load_best_returns
 from scripts.paper_vis.plot_globals import (
-    ENTITY, BENCHMARK_PROJECT,
-    EGO_BENCHMARK_RUNS, UNIFIED_BENCHMARK_RUNS, BC_BENCHMARK_RUNS,
-    METHOD_TO_DISPLAY_NAME, OEL_METHODS,
+    BC_BENCHMARK_RUNS,
+    BENCHMARK_PROJECT,
+    EGO_BENCHMARK_RUNS,
+    ENTITY,
+    METHOD_TO_DISPLAY_NAME,
+    OEL_METHODS,
+    UNIFIED_BENCHMARK_RUNS,
 )
 from scripts.wandb_utils.wandb_cache import DEFAULT_CACHE_DIR
+
+
+def _display_name(method_name: str, teammate_type: str | None = None) -> str:
+    name = METHOD_TO_DISPLAY_NAME.get(method_name, method_name)
+    return f"{name} ({teammate_type})" if teammate_type else name
 
 
 def build_run_specs(task_name: str) -> list[tuple[str, str | list[str], bool]]:
     """Collect all (display_name, run_id, is_oel) tuples for a task.
 
     Combines unified-benchmark and ego-benchmark runs so that best returns
-    are computed across every available method.  Runs evaluated against a
-    different-sized heldout set are skipped with a warning inside
-    compute_best_returns.
+    are computed across every available method.
     """
     specs: list[tuple] = []
     seen_run_ids: set[str] = set()
 
-    def _add(method_name: str, run_id):
+    def _add(method_name: str, run_id, teammate_type: str | None = None):
         if not run_id:
             return
         key = "+".join(run_id if isinstance(run_id, list) else [run_id])
         if key in seen_run_ids:
             return
         seen_run_ids.add(key)
-        specs.append((
-            METHOD_TO_DISPLAY_NAME.get(method_name, method_name),
-            run_id,
-            method_name in OEL_METHODS,
-        ))
+        specs.append(
+            (
+                _display_name(method_name, teammate_type),
+                run_id,
+                method_name in OEL_METHODS,
+            )
+        )
 
     for method_name, run_id in UNIFIED_BENCHMARK_RUNS.get(task_name, {}).items():
         _add(method_name, run_id)
 
     for method_name, teammate_runs in EGO_BENCHMARK_RUNS.get(task_name, {}).items():
-        for run_id in teammate_runs.values():
-            _add(method_name, run_id)
+        for teammate_type, run_id in teammate_runs.items():
+            _add(method_name, run_id, teammate_type)
 
     return specs
 
 
 def build_bc_run_specs(task_name: str) -> list[tuple[str, str, bool]]:
-    """Collect (display_name, run_id, is_oel) tuples from BC_BENCHMARK_RUNS for a task.
+    """Collect (display_name, bc_run_id, is_oel) tuples from BC_BENCHMARK_RUNS.
 
-    Each cell evaluates one ego against the BC partner(s) for that task. All
-    cells share the same heldout-set (the bc_proxy entry), so their eval-metric
-    artifacts have the same partner axis and can be aggregated by the standard
-    compute_best_returns pipeline.
+    Display names must match those produced by ``build_run_specs`` so the
+    loader can pair each benchmark run with its separate BC evaluation. Only
+    runs whose own heldout set lacks the human proxy actually use them.
     """
     specs: list[tuple] = []
-    seen: set[str] = set()
-    for method_name, teammate_runs in BC_BENCHMARK_RUNS.get(task_name, {}).items():
-        for run_id in teammate_runs.values():
-            if not run_id or run_id in seen:
+    for method_name, entry in BC_BENCHMARK_RUNS.get(task_name, {}).items():
+        items = entry.items() if isinstance(entry, dict) else [(None, entry)]
+        for teammate_type, run_id in items:
+            if not run_id:
                 continue
-            seen.add(run_id)
-            specs.append((
-                METHOD_TO_DISPLAY_NAME.get(method_name, method_name),
-                run_id,
-                method_name in OEL_METHODS,
-            ))
+            specs.append(
+                (
+                    _display_name(method_name, teammate_type),
+                    run_id,
+                    method_name in OEL_METHODS,
+                )
+            )
     return specs
 
 
@@ -80,15 +91,16 @@ def main():
         description="Recompute best-returns cache from local wandb artifact pickles"
     )
     parser.add_argument(
-        "--tasks", nargs="+",
+        "--tasks",
+        nargs="+",
         help="Tasks to recompute (default: all tasks with benchmark runs)",
     )
     parser.add_argument(
-        "--include_bc", action="store_true",
-        help="In default mode, also compute best_returns from BC_BENCHMARK_RUNS "
-             "and append them to the per-metric arrays so the bounds-gap plot "
-             "shows BC partners at the end of each task panel (matching the "
-             "live yaml's bc_proxy entry order).",
+        "--include_bc",
+        action="store_true",
+        help="Also merge the separate BC heldout evals (BC_BENCHMARK_RUNS) into runs "
+        "whose own heldout set lacks the human proxy, so the human_proxy entry "
+        "of the best returns covers every method.",
     )
     args = parser.parse_args()
 
@@ -100,11 +112,14 @@ def main():
         if not run_specs:
             print(f"No benchmark runs configured for '{task_name}', skipping.")
             continue
-        print(f"\n{'='*60}")
+        bc_specs = build_bc_run_specs(task_name) if args.include_bc else None
+        print(f"\n{'=' * 60}")
         print(f"Recomputing best returns for: {task_name}")
         print(f"  {len(run_specs)} run spec(s): {[s[0] for s in run_specs]}")
+        if bc_specs:
+            print(f"  {len(bc_specs)} BC eval run(s) available for merging")
         safe = task_name.replace("/", "__")
-        old_br = load_best_returns(
+        best_returns = load_best_returns(
             task_name,
             run_specs,
             entity=ENTITY,
@@ -112,32 +127,16 @@ def main():
             cache_dir=DEFAULT_CACHE_DIR,
             force_recompute=True,
             cache_filename=f"{safe}.json",
+            bc_run_specs=bc_specs,
         )
-
-        if args.include_bc:
-            bc_specs = build_bc_run_specs(task_name)
-            if not bc_specs:
-                print(f"  --include_bc: no BC runs registered for '{task_name}', leaving as-is.")
+        labels = best_returns["_labels"]
+        for metric, values in best_returns.items():
+            if metric.startswith("_"):
                 continue
-            print(f"  --include_bc: appending BC best_returns from {len(bc_specs)} run(s)")
-            bc_br = compute_best_returns(
-                task_name, bc_specs, entity=ENTITY,
-                project=BENCHMARK_PROJECT, cache_dir=DEFAULT_CACHE_DIR,
-            )
-            # Restrict to bc_run_0 only for overcooked (5 BC partners → 1).
-            if "overcooked" in task_name:
-                bc_br = {k: v[:1] for k, v in bc_br.items()}
-            merged = {}
-            for metric in set(old_br) | set(bc_br):
-                old_vals = list(old_br.get(metric, []))
-                bc_vals = list(bc_br.get(metric, []))
-                merged[metric] = old_vals + bc_vals
-            merged_path = Path(DEFAULT_CACHE_DIR) / "best_returns" / f"{safe}.json"
-            with open(merged_path, "w") as f:
-                json.dump(merged, f, indent=2)
-            lens = {m: len(v) for m, v in merged.items()}
-            print(f"  wrote merged (old+BC) best returns -> {merged_path}  "
-                  f"(per-metric lengths: {lens})")
+            missing = [lbl for lbl, v in zip(labels, values) if v is None]
+            if missing:
+                print(f"  WARNING: no best return for {metric} partners {missing}")
+        print(f"  {len(labels)} partners: {labels}")
 
 
 if __name__ == "__main__":

--- a/scripts/paper_vis/recompute_best_returns.py
+++ b/scripts/paper_vis/recompute_best_returns.py
@@ -94,7 +94,7 @@ def main():
     parser.add_argument(
         "--tasks",
         nargs="+",
-        help="Tasks to recompute (default: benchmark tasks minus PAPER_EXCLUDED_TASKS)",
+        help="Tasks to recompute (default: PAPER_TASKS)",
     )
     parser.add_argument(
         "--include_bc",

--- a/scripts/paper_vis/recompute_best_returns.py
+++ b/scripts/paper_vis/recompute_best_returns.py
@@ -3,9 +3,6 @@
 Uses locally cached wandb artifact pickles (eval metrics + run configs) when
 available; only downloads from wandb for runs that have not been cached yet.
 
-Best returns are matched across runs by partner name, so runs with and without
-the human proxy partner are combined in one file (see ``heldout_partners``).
-
 Run from repo root: python scripts/paper_vis/recompute_best_returns.py [--tasks ...]
 """
 

--- a/scripts/paper_vis/recompute_best_returns.py
+++ b/scripts/paper_vis/recompute_best_returns.py
@@ -20,6 +20,7 @@ from scripts.paper_vis.plot_globals import (
     METHOD_TO_DISPLAY_NAME,
     OEL_METHODS,
     UNIFIED_BENCHMARK_RUNS,
+    paper_tasks,
 )
 from scripts.wandb_utils.wandb_cache import DEFAULT_CACHE_DIR
 
@@ -93,7 +94,7 @@ def main():
     parser.add_argument(
         "--tasks",
         nargs="+",
-        help="Tasks to recompute (default: all tasks with benchmark runs)",
+        help="Tasks to recompute (default: benchmark tasks minus PAPER_EXCLUDED_TASKS)",
     )
     parser.add_argument(
         "--include_bc",
@@ -104,8 +105,11 @@ def main():
     )
     args = parser.parse_args()
 
-    all_tasks = sorted(set(UNIFIED_BENCHMARK_RUNS) | set(EGO_BENCHMARK_RUNS))
-    task_list = args.tasks if args.tasks else all_tasks
+    task_list = (
+        args.tasks
+        if args.tasks
+        else paper_tasks(UNIFIED_BENCHMARK_RUNS, EGO_BENCHMARK_RUNS)
+    )
 
     for task_name in task_list:
         run_specs = build_run_specs(task_name)

--- a/scripts/wandb_utils/wandb_cache.py
+++ b/scripts/wandb_utils/wandb_cache.py
@@ -19,7 +19,6 @@ import numpy as np
 import pandas as pd
 import wandb
 
-
 DEFAULT_CACHE_DIR = Path("results/figures/cache")
 
 
@@ -123,7 +122,7 @@ def fetch_sweep_bare_keys(sweep_id: str, entity: str, project: str) -> list[str]
     """Return swept parameter names from the wandb sweep config, with 'algorithm.' prefix stripped."""
     api = wandb.Api()
     sweep = api.sweep(f"{entity}/{project}/{sweep_id}")
-    return [k.removeprefix("algorithm.") for k in sweep.config.get("parameters", {}).keys()]
+    return [k.removeprefix("algorithm.") for k in sweep.config.get("parameters", {})]
 
 
 def fetch_sweep_last_run_date(sweep_id: str, entity: str, project: str) -> str | None:
@@ -156,11 +155,17 @@ def load_sweep_df(
     Swept keys come from the wandb sweep config, not the local param_sweep YAML.
     """
     from scripts.paper_vis.plot_globals import (
-        ENTITY, HYPERPARAM_PROJECT, HYPERPARAM_DEFAULT_METRIC,
-        HYPERPARAM_SWEEPS, TASK_LEGACY_NAMES,
+        ENTITY,
+        HYPERPARAM_DEFAULT_METRIC,
+        HYPERPARAM_PROJECT,
+        HYPERPARAM_SWEEPS,
+        TASK_LEGACY_NAMES,
     )
+
     if task not in HYPERPARAM_SWEEPS:
-        raise ValueError(f"Task '{task}' not found. Available: {list(HYPERPARAM_SWEEPS)}")
+        raise ValueError(
+            f"Task '{task}' not found. Available: {list(HYPERPARAM_SWEEPS)}"
+        )
     if algorithm not in HYPERPARAM_SWEEPS[task]:
         raise ValueError(
             f"Algorithm '{algorithm}' not found for task '{task}'. "
@@ -172,7 +177,9 @@ def load_sweep_df(
     task_name_for_check = TASK_LEGACY_NAMES.get(task, task.split("/")[-1])
     bare_keys = fetch_sweep_bare_keys(sweep_id, ENTITY, HYPERPARAM_PROJECT)
     df = fetch_sweep_cached(
-        sweep_id, ENTITY, HYPERPARAM_PROJECT,
+        sweep_id,
+        ENTITY,
+        HYPERPARAM_PROJECT,
         force_recompute=force_recompute,
         expected_name_parts=[algorithm, task_name_for_check],
     )
@@ -232,7 +239,9 @@ def fetch_run_eval_metrics_cached(
         with open(cache_path, "rb") as f:
             return pickle.load(f)
 
-    print(f"Fetching heldout_eval_metrics artifact for run {entity}/{project}/{run_id} ...")
+    print(
+        f"Fetching heldout_eval_metrics artifact for run {entity}/{project}/{run_id} ..."
+    )
     api = wandb.Api()
     run = api.run(f"{entity}/{project}/{run_id}")
 
@@ -247,8 +256,10 @@ def fetch_run_eval_metrics_cached(
 
     with tempfile.TemporaryDirectory() as tmp:
         artifact_dir = heldout_artifact.download(root=tmp)
-        from common.save_load_utils import load_train_run
         import jax
+
+        from common.save_load_utils import load_train_run
+
         eval_metrics = load_train_run(artifact_dir)
 
     # Convert all leaves to plain numpy arrays for pickling
@@ -292,8 +303,57 @@ def extract_metric(df: pd.DataFrame, metric: str) -> pd.DataFrame:
     """Add a '_score' column from a summary metric, dropping rows where it is missing."""
     col = f"_summary.{metric}"
     if col not in df.columns:
-        available = [c.removeprefix("_summary.") for c in df.columns if c.startswith("_summary.")]
-        raise ValueError(f"Metric '{metric}' not found. Available summary metrics: {available}")
+        available = [
+            c.removeprefix("_summary.") for c in df.columns if c.startswith("_summary.")
+        ]
+        raise ValueError(
+            f"Metric '{metric}' not found. Available summary metrics: {available}"
+        )
     result = df.dropna(subset=[col]).copy()
     result["_score"] = result[col].astype(float)
     return result
+
+
+def fetch_run_heldout_names_cached(
+    run_id: str,
+    entity: str,
+    project: str,
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+) -> list[str] | None:
+    """Return the heldout partner names, in artifact order, logged by a run.
+
+    The heldout runner logs a ``HeldoutEval/FinalEgoVsHeldout-*-CI`` table whose
+    columns after the first three (Algorithm, Metric, aggregate) are the partner
+    labels in the same order as the partner axis of the eval-metrics artifact.
+    This is the only reliable source of that order: the wandb run config
+    reorders nested dict keys, so it cannot be used for per-partner alignment.
+
+    Returns None (and caches that) when the run has no such table.
+    """
+    cache_path = (
+        Path(cache_dir) / "run_heldout_names" / f"{entity}__{project}__{run_id}.json"
+    )
+    if cache_path.exists():
+        with open(cache_path, "r") as f:
+            return json.load(f)
+
+    print(f"Fetching heldout partner names for run {entity}/{project}/{run_id} ...")
+    api = wandb.Api()
+    run = api.run(f"{entity}/{project}/{run_id}")
+    table_files = [
+        f
+        for f in run.files()
+        if "FinalEgoVsHeldout" in f.name and f.name.endswith(".table.json")
+    ]
+    names = None
+    if table_files:
+        with tempfile.TemporaryDirectory() as tmp:
+            table_files[0].download(root=tmp, replace=True)
+            with open(Path(tmp) / table_files[0].name, "r") as f:
+                table = json.load(f)
+        names = list(table["columns"][3:])
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(cache_path, "w") as f:
+        json.dump(names, f)
+    return names


### PR DESCRIPTION
Update EGO_BENCHMARK_RUNS and UNIFIED_BENCHMARK_RUNS with the 108 wandb runs from the sept26 benchmark round in aht-project/aht-benchmark.

Seed counts are distinct (TRAIN_SEED, seed_index) pairs across the runs listed in each cell, not the sum of chunk sizes: jax.random.split is prefix-stable, so chunked runs sharing a TRAIN_SEED overlap. Every cell has >= 5 distinct seeds.

Cells for algo/task combos that were deliberately not rerun keep their may26 run ids and are marked "carried over".

Plotting changes:
- Heldout partners are aligned by name (`heldout_partners.py`), so runs with 17- and 18-partner heldout sets can be compared and the human proxy can be merged in from separate BC evals.
- New `evaluation/run_heldout_ego_human_proxy.py` re-evaluates a finished ego run against the human proxy only; the 14 carried-over unified runs lacking a built-in human proxy now have such evals (tag `bc_heldout_eval`) registered in `BC_BENCHMARK_RUNS`.
- Fix the paper CI bootstrap: episodes were folded into the resampling axis, so CIs were far too narrow. Now seeds are resampled within each heldout-partner stratum, as in `heldout_runner.py`.
- `PAPER_TASKS` inclusion list (may26 task set) used by all figure scripts; sweep distribution plots restricted to the 140 seeded hparam settings from `apply_best_hparams.py`.
- Ego bar chart grouped by teammate type with a matching legend order.
