### PR TITLE
Post-hoc Overcooked feature pipeline and convention clustering

### DIFF
--- a/scripts/convention_analysis/README.md
+++ b/scripts/convention_analysis/README.md
@@ -1,0 +1,80 @@
+# Convention clustering of Overcooked teammates
+
+Clusters a population of Overcooked teammates (e.g. the eval teammate set of a layout)
+by the convention they play, from behavioral statistics of BR-paired episodes.
+
+## Reproduce
+
+```bash
+export PYTHONPATH=$PWD
+# 1. rollouts -> features.csv + cell_support.csv per population (GPU; two lanes)
+scripts/convention_analysis/extract_features.sh results/conv results/traj_cache <br_root> 0 1
+# 2. derive, screen, cluster (CPU)
+python scripts/convention_analysis/run_pipeline.py --pd-root results/conv --out results/conv/eval
+# 3. optional figure per population
+python scripts/convention_analysis/plot_convention_clusters.py \
+    --features results/conv/pd_coord_ring/overcooked-coord_ring/features_derived.csv \
+    --clusters results/conv/eval/coord_ring__split/clusters.csv --out coord_ring.png
+```
+
+## Pipeline
+
+1. **Feature extraction** (`scripts/population_diversity/compute_population_diversity.py
+   --full-heldout --br-paired --br-root <br_root> --batched --deterministic-reset`, driver
+   `extract_features.sh`): 128 episodes per teammate with its BR, vmapped rollouts
+   (~36 s per teammate), trajectory cache so feature recompute is CPU-only.
+2. **Feature vocabulary** (`feature_groups.py`, `pd_events.py`, `pd_rollouts.py`): ~60
+   layout-independent columns in groups role, counter_use, counter_identity, movement,
+   partner_coupling, contention, throughput. Counter usage is expressed as
+   activity-conditioned fractions (`derive()`), station choice as modal pot / onion-pile /
+   plate-pile / goal coordinates plus a sharing rate, movement as region shares and
+   circulation direction, coupling as MI between the agents' routes.
+3. **Screening** (`screen_features.py`, using the `cell_support.csv` the extraction writes
+   next to `features.csv`): per-task removal of structurally dead columns
+   only; no single-task hacks. Four rules: exactly-constant columns, counter-cell
+   columns without support, derived ratios whose numerator event averages fewer
+   than `MIN_EVENT_SUPPORT` (0.01) occurrences per episode (e.g. `soup_via_counter` on
+   forced_coord), and, when the two agents start in different connected components of
+   the layout, the contention group plus the proximity-conditioned coupling columns
+   (`PROXIMITY_CONDITIONED`). Raw counts consumed by `derive()` (`DERIVE_INPUTS`) are never
+   clustered.
+4. **Clustering** (`cluster_conventions.py`, driver `run_pipeline.py`): z-score ->
+   `--groups split` (each column scaled by 1/sqrt(group size) so every group carries equal
+   expected squared distance; a group that screening reduced to a single column on a
+   task is dropped rather than given a full group's weight) -> cosine -> average
+   linkage. `--exclude-groups throughput`.
+   k = largest k within `--k-tolerance 0.05` of the best silhouette with
+   `--min-cluster-size 2`; if every k in that band isolates a singleton, the band is
+   re-taken over the cuts that satisfy the floor. `labels_by_k.csv` keeps every cut
+   k=2..8. Medoids are real teammates and are the objects to watch.
+
+## Findings
+
+- **Delivery counts are the tracked agent's, not the team's** (r=0.10 with team score).
+  The "throughput" axis of early versions was the onion-side vs plate-side role axis,
+  written into the distance ~10 times through correlated counts. Deduplicating it and
+  excluding throughput from the distance is what moved every task off k=2. Competence is
+  checked only afterwards via eta^2 against team score.
+- **Feature rollouts must start from the layout's canonical state.** With the env
+  default `random_reset=True`, disconnected layouts (forced_coord, asymm_advantages)
+  place the tracked agent on a random side each episode, so one feature vector averaged
+  two roles. `--deterministic-reset` fixes this. Never compare features across that
+  boundary.
+- **Cell-identity and role features carry the convention structure**: which counter cell
+  onions vs plates go through, which pot / pile is used, handoff vs dead-drop fractions,
+  region shares, circulation direction (separates clockwise from counter-clockwise runners
+  on coord_ring and loop carriers from shuttlers on counter_circuit).
+- **What did not help**: ICC reliability weighting (no change to partitions), corridor
+  contention features (too rare per episode), per-step length normalization (no-op, all
+  episodes are 400 steps).
+- **Frame of reference is the ceiling.** Against hand labels on coord_ring the best
+  agreement is 9/10 pairs; the missed pair differs only in joint arrangement with their
+  respective BRs. Fixed probe partners would remove this; BR partners were kept by choice.
+
+## Open issues
+
+- Positional-mode features (e.g. `dish_counter_x/y`) default to 0 when the item is never
+  handled, which encodes "role absent" as a location.
+- Still-frame vision reviews cannot judge temporal features (MI, contention, idle,
+  circulation); use them to validate cell-identity / role features and cluster
+  distinctness only.

--- a/scripts/convention_analysis/cluster_conventions.py
+++ b/scripts/convention_analysis/cluster_conventions.py
@@ -1,0 +1,453 @@
+"""Cluster teammates by their behavioral-feature vectors; writes clusters.csv, labels_by_k.csv, cluster_summary.md.
+
+    python scripts/convention_analysis/cluster_conventions.py \
+        --features results/conv_v12/pd_coord_ring/overcooked-coord_ring/features_derived.csv \
+        --set-labels coord_ring --groups split --exclude-groups throughput \
+        --k-tolerance 0.05 --min-cluster-size 2 --output-dir results/tmp/coord_ring
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from scipy.cluster.hierarchy import cut_tree, leaves_list, linkage
+from scipy.spatial.distance import pdist, squareform
+
+from scripts.convention_analysis import feature_groups
+
+log = logging.getLogger("cluster_conventions")
+
+# Metadata / outcome columns, never features.
+NON_FEATURE_COLS = {"agent", "env", "num_episodes", "mean_final_score", "mean_episode_length"}
+SCORE_COL = "mean_final_score"
+
+
+def load_features(paths: List[Path], set_labels: Optional[List[str]]) -> pd.DataFrame:
+    """Load and concatenate features.csv files, tagging each with its population."""
+    if set_labels and len(set_labels) != len(paths):
+        raise ValueError(f"--set-labels has {len(set_labels)} entries but --features has {len(paths)}")
+
+    frames = []
+    for i, p in enumerate(paths):
+        if not p.exists():
+            raise FileNotFoundError(f"features file not found: {p}")
+        df = pd.read_csv(p)
+        df["set"] = set_labels[i] if set_labels else p.parent.name
+        frames.append(df)
+        log.info("loaded %d teammates from %s (set=%s)", len(df), p, df["set"].iloc[0])
+
+    out = pd.concat(frames, ignore_index=True)
+    # Disambiguate identically-named agents coming from different populations.
+    if out["agent"].duplicated().any():
+        out["agent"] = out["set"] + ":" + out["agent"].astype(str)
+    return out
+
+
+def select_feature_matrix(df: pd.DataFrame, drop_near_constant: bool = True
+                          ) -> Tuple[np.ndarray, List[str], List[str]]:
+    """Pick numeric feature columns, drop near-constant ones, z-score the rest."""
+    feature_cols = [
+        c for c in df.columns
+        if c not in NON_FEATURE_COLS and c != "set" and pd.api.types.is_numeric_dtype(df[c])
+    ]
+    if not feature_cols:
+        raise ValueError("no numeric feature columns found")
+
+    X = df[feature_cols].to_numpy(dtype=np.float64)
+    if not np.isfinite(X).all():
+        bad = [feature_cols[j] for j in range(X.shape[1]) if not np.isfinite(X[:, j]).all()]
+        raise ValueError(f"non-finite values in feature columns: {bad}")
+
+    dropped: List[str] = []
+    if drop_near_constant:
+        std = X.std(axis=0)
+        keep_mask = std > 1e-12
+        dropped = [c for c, k in zip(feature_cols, keep_mask) if not k]
+        feature_cols = [c for c, k in zip(feature_cols, keep_mask) if k]
+        X = X[:, keep_mask]
+        if dropped:
+            log.info("dropped %d near-constant features: %s", len(dropped), dropped)
+
+    if X.shape[1] == 0:
+        raise ValueError("all features were near-constant; nothing to cluster on")
+
+    Xz = (X - X.mean(axis=0)) / X.std(axis=0)
+    return Xz, feature_cols, dropped
+
+
+def silhouette_from_distances(D: np.ndarray, labels: np.ndarray) -> float:
+    """Mean silhouette coefficient from a precomputed distance matrix (singletons contribute 0)."""
+    n = len(labels)
+    uniq = np.unique(labels)
+    if len(uniq) < 2 or len(uniq) >= n:
+        return float("nan")
+
+    sils = np.zeros(n)
+    for i in range(n):
+        own = labels == labels[i]
+        own_others = own.copy()
+        own_others[i] = False
+        if own_others.sum() == 0:
+            sils[i] = 0.0  # singleton
+            continue
+        a = D[i, own_others].mean()
+        b = np.inf
+        for c in uniq:
+            if c == labels[i]:
+                continue
+            b = min(b, D[i, labels == c].mean())
+        sils[i] = 0.0 if max(a, b) == 0 else (b - a) / max(a, b)
+    return float(sils.mean())
+
+
+def cluster_medoid(D: np.ndarray, idx: np.ndarray) -> int:
+    """Index (into the full array) of the cluster member minimizing total in-cluster distance."""
+    sub = D[np.ix_(idx, idx)]
+    return int(idx[int(np.argmin(sub.sum(axis=1)))])
+
+
+def distinguishing_features(Xz: np.ndarray, feature_cols: List[str], member_idx: np.ndarray,
+                            top_n: int = 5) -> List[Tuple[str, float]]:
+    """Features whose in-cluster mean deviates most from the population mean (z units)."""
+    means = Xz[member_idx].mean(axis=0)
+    order = np.argsort(-np.abs(means))[:top_n]
+    return [(feature_cols[j], float(means[j])) for j in order]
+
+
+def score_ci(values: np.ndarray) -> Tuple[float, Optional[Tuple[float, float]]]:
+    """Mean + 95% bootstrap CI via the repo's rliable machinery, if available."""
+    values = np.asarray(values, dtype=np.float64)
+    if values.size == 0:
+        return float("nan"), None
+    if values.size < 2:
+        return float(values.mean()), None
+    try:
+        from common.stat_utils import compute_aggregate_stat_and_ci_per_task
+        point, interval = compute_aggregate_stat_and_ci_per_task(
+            values.reshape(-1, 1), "mean", return_interval_est=True
+        )
+        return float(np.asarray(point).squeeze()), (
+            float(np.asarray(interval).ravel()[0]), float(np.asarray(interval).ravel()[1])
+        )
+    except Exception as e:  # pragma: no cover - CI is a nicety, never fatal
+        log.warning("rliable CI unavailable (%s); reporting mean only", e)
+        return float(values.mean()), None
+
+
+def apply_group_weights(Xz: np.ndarray, feature_cols: List[str], grp: Dict[str, str]
+                        ) -> Tuple[np.ndarray, Dict[str, float], Dict[str, int]]:
+    """Scale each z-scored column by 1 / sqrt(number of columns in its group)."""
+    counts: Dict[str, int] = {}
+    for c in feature_cols:
+        counts[grp[c]] = counts.get(grp[c], 0) + 1
+    w = np.array([1.0 / np.sqrt(counts[grp[c]]) for c in feature_cols])
+    return Xz * w[None, :], {c: float(v) for c, v in zip(feature_cols, w)}, counts
+
+
+def group_distance_shares(X: np.ndarray, feature_cols: List[str], grp: Dict[str, str]
+                          ) -> Dict[str, float]:
+    """Fraction of total pairwise squared Euclidean distance carried by each group."""
+    n = X.shape[0]
+    per_col = np.zeros(X.shape[1])
+    for j in range(X.shape[1]):
+        d = X[:, j][:, None] - X[:, j][None, :]
+        per_col[j] = (d ** 2).sum() / 2.0
+    tot = per_col.sum()
+    out: Dict[str, float] = {}
+    for c, v in zip(feature_cols, per_col):
+        out[grp[c]] = out.get(grp[c], 0.0) + float(v / tot) if tot > 0 else 0.0
+    return out
+
+
+def run(df: pd.DataFrame, metric: str, linkage_method: str, k: Optional[int],
+        k_min: int, k_max: int, top_n: int, k_tolerance: float = 0.0,
+        min_cluster_size: int = 1, group_mode: str = "none") -> Dict:
+    Xz, feature_cols, dropped = select_feature_matrix(df)
+    grp: Dict[str, str] = {}
+    group_w: Dict[str, float] = {}
+    group_counts: Dict[str, int] = {}
+    shares_before: Dict[str, float] = {}
+    shares_after: Dict[str, float] = {}
+    try:  # group shares are reported even without weighting, when every column has a group
+        grp = feature_groups.group_of(feature_cols)
+        shares_before = group_distance_shares(Xz, feature_cols, grp)
+    except KeyError:
+        if group_mode != "none":
+            raise
+        grp = {}
+    singleton_dropped: List[str] = []
+    if group_mode != "none":
+        # drop groups reduced to a single column
+        counts0: Dict[str, int] = {}
+        for c in feature_cols:
+            counts0[grp[c]] = counts0.get(grp[c], 0) + 1
+        singleton_dropped = [c for c in feature_cols if counts0[grp[c]] == 1]
+        if singleton_dropped:
+            log.info("dropping single-column groups: %s", singleton_dropped)
+            keep_s = [c not in singleton_dropped for c in feature_cols]
+            Xz = Xz[:, keep_s]
+            feature_cols = [c for c, k in zip(feature_cols, keep_s) if k]
+            grp = {c: grp[c] for c in feature_cols}
+            shares_before = group_distance_shares(Xz, feature_cols, grp)
+        Xz, group_w, group_counts = apply_group_weights(Xz, feature_cols, grp)
+        shares_after = group_distance_shares(Xz, feature_cols, grp)
+        log.info("group weighting (%s): %s", group_mode,
+                 {g: f"m={m} w={1/np.sqrt(m):.2f}" for g, m in sorted(group_counts.items())})
+        log.info("share of squared distance before -> after: %s",
+                 {g: f"{shares_before[g]:.2f}->{shares_after[g]:.2f}" for g in sorted(shares_before)})
+    # report z-deviations on the unweighted scale
+    Xz_report = Xz
+    if group_w:
+        Xz_report = Xz_report / np.array([group_w[c] for c in feature_cols])[None, :]
+    n = Xz.shape[0]
+    if n < 3:
+        raise ValueError(f"need >=3 teammates to cluster, got {n}")
+
+    D = squareform(pdist(Xz, metric=metric))
+    Z = linkage(pdist(Xz, metric=metric), method=linkage_method)
+
+    # cut_tree, not fcluster(maxclust): maxclust can return fewer clusters than requested
+    k_hi = min(k_max, n - 1)
+    sweep: List[Tuple[int, float]] = []
+    labels_by_k: Dict[int, np.ndarray] = {}
+    for kk in range(max(2, k_min), k_hi + 1):
+        lab = cut_tree(Z, n_clusters=kk).ravel() + 1
+        sweep.append((kk, silhouette_from_distances(D, lab)))
+        labels_by_k[kk] = lab
+
+    if k is None:
+        finite = [(kk, s) for kk, s in sweep if np.isfinite(s)]
+        if not finite:
+            k = 2
+            log.warning("silhouette undefined for every k (population too small?); "
+                        "defaulting to k=2 -- treat the partition as unvalidated")
+        else:
+            best = max(s for _, s in finite)
+            # finest partition within tolerance of the best silhouette
+            candidates = [kk for kk, s in finite if s >= best - k_tolerance]
+            if min_cluster_size > 1:
+                def _min_size(kk: int) -> int:
+                    lab = cut_tree(Z, n_clusters=kk).ravel()
+                    return int(np.bincount(lab).min())
+                sized = [kk for kk in candidates if _min_size(kk) >= min_cluster_size]
+                if not sized:
+                    # re-run the tolerance rule over cuts satisfying the size floor
+                    sized_all = [(kk, s) for kk, s in finite if _min_size(kk) >= min_cluster_size]
+                    if sized_all:
+                        best_sized = max(s for _, s in sized_all)
+                        sized = [kk for kk, s in sized_all if s >= best_sized - k_tolerance]
+                        log.warning("no k within tolerance satisfies min-cluster-size=%d; "
+                                    "restricting to sized cuts %s (best sized silhouette %.3f)",
+                                    min_cluster_size, [kk for kk, _ in sized_all], best_sized)
+                    else:
+                        log.warning("no candidate k satisfies min-cluster-size=%d; "
+                                    "ignoring the guard", min_cluster_size)
+                if sized:
+                    candidates = sized
+            k = max(candidates) if k_tolerance > 0 else max(finite, key=lambda t: t[1])[0]
+            log.info("auto-selected k=%d (silhouette %.3f, best %.3f, tolerance %.3f)",
+                     k, dict(sweep)[k], best, k_tolerance)
+
+    labels = cut_tree(Z, n_clusters=k).ravel() + 1
+    order = leaves_list(Z)
+
+    clusters = []
+    for c in sorted(np.unique(labels)):
+        member_idx = np.where(labels == c)[0]
+        medoid = cluster_medoid(D, member_idx)
+        scores = df[SCORE_COL].to_numpy()[member_idx] if SCORE_COL in df.columns else np.array([])
+        mean_score, ci = score_ci(scores)
+        clusters.append({
+            "cluster": int(c),
+            "size": int(len(member_idx)),
+            "members": [str(x) for x in df["agent"].to_numpy()[member_idx]],
+            "sets": sorted({str(x) for x in df["set"].to_numpy()[member_idx]}),
+            "medoid": str(df["agent"].to_numpy()[medoid]),
+            "mean_return": mean_score,
+            "return_ci": ci,
+            "distinguishing": distinguishing_features(Xz_report, feature_cols, member_idx, top_n),
+        })
+
+    # competence confound check
+    eta_sq = float("nan")
+    if SCORE_COL in df.columns:
+        y = df[SCORE_COL].to_numpy(dtype=np.float64)
+        if y.std() > 1e-12:
+            grand = y.mean()
+            ss_between = sum(len(np.where(labels == c)[0]) * (y[labels == c].mean() - grand) ** 2
+                             for c in np.unique(labels))
+            ss_total = ((y - grand) ** 2).sum()
+            eta_sq = float(ss_between / ss_total) if ss_total > 0 else float("nan")
+
+    return {
+        "k": int(k), "labels": labels, "sweep": sweep, "clusters": clusters,
+        "labels_by_k": labels_by_k,
+        "feature_cols": feature_cols, "dropped": dropped, "order": order,
+        "eta_sq_return": eta_sq, "n": n, "metric": metric, "linkage": linkage_method,
+        "group_mode": group_mode, "groups": grp, "group_counts": group_counts, "group_w": group_w,
+        "group_shares_before": shares_before, "group_shares_after": shares_after,
+        "silhouette": float(dict(sweep).get(int(k), float("nan"))),
+    }
+
+
+def write_markdown(res: Dict, df: pd.DataFrame, out: Path) -> None:
+    L: List[str] = []
+    L.append("# Convention clusters\n")
+    L.append(f"- teammates: **{res['n']}**  |  features used: **{len(res['feature_cols'])}**"
+             f"  |  distance: `{res['metric']}`  |  linkage: `{res['linkage']}`")
+    L.append(f"- selected **k = {res['k']}**")
+    if res["dropped"]:
+        L.append(f"- dropped {len(res['dropped'])} near-constant features: "
+                 f"{', '.join(f'`{d}`' for d in res['dropped'])}")
+    if res.get("group_mode", "none") != "none":
+        L.append(f"- **group weighting** (`{res['group_mode']}`): each column scaled by 1/sqrt(group size) "
+                 "so every a-priori group contributes equally to expected squared distance")
+    if res.get("group_shares_before"):
+        counts = {g: sum(1 for c in res["groups"].values() if c == g) for g in res["group_shares_before"]}
+        L.append("")
+        L.append("| group | columns | share of sq. distance, unweighted | weighted |")
+        L.append("|---|---|---|---|")
+        for g in sorted(counts):
+            after = res["group_shares_after"].get(g, res["group_shares_before"][g])
+            L.append(f"| {g} | {counts[g]} | {res['group_shares_before'][g]:.2f} | {after:.2f} |")
+    L.append("")
+
+    L.append("## Silhouette sweep\n")
+    L.append("| k | mean silhouette |")
+    L.append("|---|---|")
+    for kk, s in res["sweep"]:
+        mark = "  **<- selected**" if kk == res["k"] else ""
+        L.append(f"| {kk} | {s:.3f}{mark} |")
+    L.append("")
+    L.append("> Silhouette ranges from -1 to 1; values near 0 mean the clusters overlap heavily "
+             "and the partition is weakly supported.\n")
+
+    eta = res["eta_sq_return"]
+    L.append("## Competence-confound check\n")
+    if np.isfinite(eta):
+        L.append(f"Fraction of return variance explained by cluster identity (eta^2): **{eta:.3f}**.")
+        L.append("")
+        L.append("> High eta^2 means the clustering is largely recovering *how good* teammates are "
+                 "rather than *what convention* they play. Low eta^2 supports a convention reading.\n")
+    else:
+        L.append("Return variance unavailable or degenerate; confound check skipped.\n")
+
+    L.append("## Clusters\n")
+    L.append("| cluster | size | populations | medoid (record this one) | mean return [95% CI] |")
+    L.append("|---|---|---|---|---|")
+    for c in res["clusters"]:
+        ci = c["return_ci"]
+        ci_s = f"{c['mean_return']:.2f} [{ci[0]:.2f}, {ci[1]:.2f}]" if ci else f"{c['mean_return']:.2f}"
+        L.append(f"| {c['cluster']} | {c['size']} | {', '.join(c['sets'])} | `{c['medoid']}` | {ci_s} |")
+    L.append("")
+
+    L.append("## Distinguishing features per cluster\n")
+    L.append("Deviation of the cluster mean from the population mean, in standard deviations.\n")
+    for c in res["clusters"]:
+        L.append(f"### Cluster {c['cluster']} (n={c['size']}, medoid `{c['medoid']}`)\n")
+        L.append("| feature | z-deviation |")
+        L.append("|---|---|")
+        for name, z in c["distinguishing"]:
+            g = f" ({res['groups'][name]})" if res.get("groups") else ""
+            L.append(f"| `{name}`{g} | {z:+.2f} |")
+        L.append("")
+        L.append(f"Members: {', '.join('`' + m + '`' for m in c['members'])}\n")
+        L.append("_Convention description (fill in after watching the medoid rollout):_ TODO\n")
+
+    out.write_text("\n".join(L))
+    log.info("wrote %s", out)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--features", nargs="+", required=True, type=Path,
+                   help="One or more features.csv paths.")
+    p.add_argument("--set-labels", nargs="+", default=None,
+                   help="Population label per --features entry.")
+    p.add_argument("--output-dir", type=Path, required=True)
+    p.add_argument("--metric", default="cosine", choices=["cosine", "euclidean", "correlation"],
+                   help="Distance on z-scored features.")
+    p.add_argument("--linkage", default="average", choices=["average", "complete", "single", "ward"],
+                   help="ward requires --metric euclidean.")
+    p.add_argument("--k", type=int, default=None, help="Number of clusters; default = best silhouette.")
+    p.add_argument("--min-cluster-size", type=int, default=1,
+                   help="Reject candidate k's producing any cluster smaller than this.")
+    p.add_argument("--k-tolerance", type=float, default=0.0,
+                   help="Select the largest k whose silhouette is within this margin of the max.")
+    p.add_argument("--k-min", type=int, default=2)
+    p.add_argument("--k-max", type=int, default=8)
+    p.add_argument("--top-n", type=int, default=5, help="Distinguishing features to list per cluster.")
+    p.add_argument("--drop-features", nargs="*", default=None,
+                   help="Feature columns to remove before clustering.")
+    p.add_argument("--exclude", nargs="*", default=None,
+                   help="Drop teammates whose name contains any of these substrings.")
+    p.add_argument("--groups", default="none", choices=["none", "split"],
+                   help="Feature-group weighting mode (feature_groups.py).")
+    p.add_argument("--exclude-groups", nargs="*", default=[],
+                   help="Drop every column of these feature groups.")
+    args = p.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if args.linkage == "ward" and args.metric != "euclidean":
+        p.error("--linkage ward requires --metric euclidean")
+
+    df = load_features(args.features, args.set_labels)
+    drop_features = list(args.drop_features or [])
+    drop_features += [c for c in feature_groups.DERIVE_INPUTS if c not in drop_features]
+    if args.exclude_groups:
+        allg = feature_groups.groups()
+        bad = [g for g in args.exclude_groups if g not in allg]
+        if bad:
+            p.error(f"--exclude-groups unknown: {bad}; choose from {sorted(allg)}")
+        drop_features += [c for g in args.exclude_groups for c in allg[g] if c not in drop_features]
+    if drop_features:
+        present = [c for c in drop_features if c in df.columns]
+        missing = [c for c in drop_features if c not in df.columns]
+        if missing:
+            log.warning("--drop-features not found in columns (ignored): %s", missing)
+        if present:
+            log.info("dropping %d screened-out features: %s", len(present), present)
+            df = df.drop(columns=present)
+    if args.exclude:
+        mask = df["agent"].apply(lambda a: not any(s in str(a) for s in args.exclude))
+        dropped_names = df.loc[~mask, "agent"].tolist()
+        if dropped_names:
+            log.info("excluded %d teammates: %s", len(dropped_names), dropped_names)
+        df = df[mask].reset_index(drop=True)
+
+    res = run(df, args.metric, args.linkage, args.k, args.k_min, args.k_max, args.top_n,
+              k_tolerance=args.k_tolerance, min_cluster_size=args.min_cluster_size,
+              group_mode=args.groups)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    out_df = df[["agent", "set"]].copy()
+    out_df["cluster"] = res["labels"]
+    if SCORE_COL in df.columns:
+        out_df[SCORE_COL] = df[SCORE_COL]
+    out_df.to_csv(args.output_dir / "clusters.csv", index=False)
+    # every cut of the same dendrogram
+    byk = df[["agent"]].copy()
+    for kk, lab in sorted(res["labels_by_k"].items()):
+        byk[f"k{kk}"] = lab
+    byk.to_csv(args.output_dir / "labels_by_k.csv", index=False)
+    write_markdown(res, df, args.output_dir / "cluster_summary.md")
+    (args.output_dir / "features_used.txt").write_text("\n".join(res["feature_cols"]) + "\n")
+    if res["group_w"]:
+        (args.output_dir / "feature_weights.txt").write_text(
+            "".join(f"{c} {w:.6f}\n" for c, w in res["group_w"].items()))
+
+    print(f"\nk={res['k']}  n={res['n']}  features={len(res['feature_cols'])}")
+    for c in res["clusters"]:
+        print(f"  cluster {c['cluster']}: n={c['size']:2d}  medoid={c['medoid']}")
+    print(f"\nwrote {args.output_dir}/clusters.csv and cluster_summary.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/convention_analysis/extract_features.sh
+++ b/scripts/convention_analysis/extract_features.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Extract convention features for the Overcooked eval teammates of every layout (two GPU lanes).
+# Usage: extract_features.sh <out_dir> <cache_dir> <br_root> [gpu_a] [gpu_b]
+#   br_root: local copy of the eval-teammate BR checkpoints (see --br-root in
+#   compute_population_diversity.py), e.g. a download of jaxaht/eval-teammates-br/overcooked.
+set -uo pipefail
+OUT="${1:?out_dir}"; CACHE="${2:?cache_dir}"; BR_ROOT="${3:?br_root}"; GPU_A="${4:-0}"; GPU_B="${5:-1}"
+W="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export PYTHONPATH="$W"
+export XLA_PYTHON_CLIENT_PREALLOCATE=false
+PY="${PYTHON:-python}"
+cd "$W"
+mkdir -p "$OUT"
+LANE_A="cramped_room counter_circuit coord_ring"
+LANE_B="forced_coord asymm_advantages"
+run_lane() {
+  local gpu="$1" layouts="$2"
+  for layout in $layouts; do
+    echo "=== $layout gpu$gpu $(date +%H:%M:%S)"
+    CUDA_VISIBLE_DEVICES=$gpu $PY scripts/population_diversity/compute_population_diversity.py \
+      --env overcooked --variant "$layout" --full-heldout --br-paired --br-root "$BR_ROOT" \
+      --num-episodes 128 --batched --deterministic-reset \
+      --cache-dir "$CACHE/overcooked-$layout" \
+      --output-dir "$OUT/pd_$layout" > "$OUT/extract_$layout.log" 2>&1
+    echo "=== done $layout rc=$? $(date +%H:%M:%S)"
+  done
+}
+run_lane "$GPU_A" "$LANE_A" &
+run_lane "$GPU_B" "$LANE_B" &
+wait
+echo ALL DONE

--- a/scripts/convention_analysis/feature_groups.py
+++ b/scripts/convention_analysis/feature_groups.py
@@ -1,0 +1,134 @@
+"""Semantic feature groups and derived routing fractions for the Overcooked convention vocabulary."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+import numpy as np
+
+# Tracked agent's own per-episode counts, not the team score.
+THROUGHPUT = [
+    "delivery",
+    "PLACEMENT_IN_POT",
+]
+
+COUNTER_USE = [
+    # routing fractions from derive()
+    "onion_via_counter", "dish_via_counter", "soup_via_counter",
+    "onion_from_counter", "dish_from_counter", "soup_from_counter",
+    # drop fate (self-retrieve implied) and pickup origin
+    "handoff_given_frac", "dead_drop_frac", "handoff_received_frac",
+    "counter_item_dwell",
+]
+
+COUNTER_IDENTITY = [
+    "counter_entropy", "modal_counter_frac", "counter_item_mi",
+    "onion_counter_x", "onion_counter_y",
+    "dish_counter_x", "dish_counter_y",
+]
+
+MOVEMENT = [
+    "region_NW_frac", "region_NE_frac", "region_SW_frac",
+    "territory_overlap", "circulation_direction",
+    "STAY", "MOVEMENT", "IDLE_MOVEMENT", "IDLE_INTERACT_X", "IDLE_INTERACT_EMPTY",
+]
+
+ROLE = [
+    "onion_role_frac", "pot_role_frac", "plating_role_frac",
+    "pot_usage_entropy", "onion_pile_usage_entropy",
+    "plate_pile_usage_entropy", "goal_usage_entropy",
+    # favoured station instance
+    "modal_pot_x", "modal_pot_y", "modal_onion_pile_x", "modal_onion_pile_y",
+    "modal_plate_pile_x", "modal_plate_pile_y", "modal_goal_x", "modal_goal_y",
+]
+
+PARTNER_COUPLING = [
+    "mean_partner_distance",
+    # shared resource instances
+    "pot_sharing", "onion_pile_sharing", "plate_pile_sharing", "goal_sharing",
+    "route_partner_mi", "route_partner_phi", "switch_encounter_lift",
+    "region_conditional_lift", "yield_rate",
+    "move_dir_mi", "move_dir_mi_prox", "move_dir_mi_lag_self", "move_dir_mi_lag_partner",
+    "route_phase_mi", "action_mi_all", "action_mi_prox",
+]
+
+CONTENTION = [
+    "interact_into_partner", "blocked_partner_steps",
+    "contention_rate", "contention_giveway_rate", "anticipatory_avoid_rate",
+    "partner_block_rate", "block_asymmetry",
+]
+
+# Coupling features defined only when the agents are within a few cells of each other.
+PROXIMITY_CONDITIONED = ["yield_rate", "move_dir_mi_prox", "action_mi_prox", "switch_encounter_lift"]
+
+# Raw counts consumed by derive(); never clustered.
+DERIVE_INPUTS = [
+    "SOUP_PICKUP",
+    "put_onion_on_X", "put_dish_on_X", "put_soup_on_X",
+    "pickup_onion_from_X", "pickup_dish_from_X", "pickup_soup_from_X",
+    "pickup_onion_from_O", "pickup_dish_from_D",
+    "handoff_given", "handoff_received", "dead_drop", "self_retrieve",
+]
+
+# Numerator raw count of each DERIVED ratio (minimum-support screen).
+RATIO_NUMERATOR = {
+    "onion_via_counter": "put_onion_on_X", "dish_via_counter": "put_dish_on_X",
+    "soup_via_counter": "put_soup_on_X", "onion_from_counter": "pickup_onion_from_X",
+    "dish_from_counter": "pickup_dish_from_X", "soup_from_counter": "pickup_soup_from_X",
+    "handoff_given_frac": "handoff_given", "dead_drop_frac": "dead_drop",
+    "handoff_received_frac": "handoff_received",
+}
+MIN_EVENT_SUPPORT = 0.01  # population-mean numerator events per episode
+
+DERIVED = [
+    "onion_via_counter", "dish_via_counter", "soup_via_counter",
+    "onion_from_counter", "dish_from_counter", "soup_from_counter",
+    "handoff_given_frac", "dead_drop_frac", "handoff_received_frac",
+]
+
+
+def _ratio(num, den):
+    num = np.asarray(num, dtype=np.float64)
+    den = np.asarray(den, dtype=np.float64)
+    return np.where(den > 0, num / np.where(den > 0, den, 1.0), 0.0)
+
+
+def derive(df):
+    """Return a copy of df with the DERIVED routing-fraction columns added."""
+    d = df.copy()
+    g = lambda c: d[c].to_numpy(dtype=np.float64)  # noqa: E731
+    d["onion_via_counter"] = _ratio(g("put_onion_on_X"), g("put_onion_on_X") + g("PLACEMENT_IN_POT"))
+    d["dish_via_counter"] = _ratio(g("put_dish_on_X"), g("put_dish_on_X") + g("SOUP_PICKUP"))
+    d["soup_via_counter"] = _ratio(g("put_soup_on_X"), g("put_soup_on_X") + g("delivery"))
+    d["onion_from_counter"] = _ratio(g("pickup_onion_from_X"), g("pickup_onion_from_X") + g("pickup_onion_from_O"))
+    d["dish_from_counter"] = _ratio(g("pickup_dish_from_X"), g("pickup_dish_from_X") + g("pickup_dish_from_D"))
+    d["soup_from_counter"] = _ratio(g("pickup_soup_from_X"), g("pickup_soup_from_X") + g("SOUP_PICKUP"))
+    drops = g("handoff_given") + g("dead_drop") + g("self_retrieve")
+    d["handoff_given_frac"] = _ratio(g("handoff_given"), drops)
+    d["dead_drop_frac"] = _ratio(g("dead_drop"), drops)
+    picks = g("pickup_onion_from_X") + g("pickup_dish_from_X") + g("pickup_soup_from_X")
+    d["handoff_received_frac"] = _ratio(g("handoff_received"), picks)
+    return d
+
+
+def groups() -> Dict[str, List[str]]:
+    return {
+        "throughput": list(THROUGHPUT),
+        "counter_use": list(COUNTER_USE),
+        "counter_identity": list(COUNTER_IDENTITY),
+        "movement": list(MOVEMENT),
+        "role": list(ROLE),
+        "partner_coupling": list(PARTNER_COUPLING),
+        "contention": list(CONTENTION),
+    }
+
+
+def group_of(feature_cols: Iterable[str]) -> Dict[str, str]:
+    """Map feature -> group name; raises on an ungrouped feature."""
+    inv: Dict[str, str] = {}
+    for name, cols in groups().items():
+        for c in cols:
+            inv[c] = name
+    missing = [c for c in feature_cols if c not in inv]
+    if missing:
+        raise KeyError(f"features with no a-priori group (add them to feature_groups.py): {missing}")
+    return {c: inv[c] for c in feature_cols}

--- a/scripts/convention_analysis/plot_convention_clusters.py
+++ b/scripts/convention_analysis/plot_convention_clusters.py
@@ -1,0 +1,149 @@
+"""Visualize convention clusters produced by cluster_conventions.py.
+
+Reads a PD features.csv plus the clusters.csv assignment file and renders a single
+multi-panel figure:
+  (a) dendrogram of the agglomerative clustering (average linkage, cosine distance),
+  (b) 2D MDS embedding of the cosine-distance matrix, colored by cluster, medoids ringed,
+  (c) cosine-similarity heatmap reordered by the dendrogram leaf order.
+
+Example:
+    python scripts/convention_analysis/plot_convention_clusters.py \\
+        --features results/conv/pd_coord_ring/overcooked-coord_ring/features_derived.csv \\
+        --clusters results/conv/eval/coord_ring__split/clusters.csv \\
+        --title "coord_ring eval teammates" --out coord_ring_clusters.pdf
+"""
+from __future__ import annotations
+
+import re
+
+import argparse
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.patches import Patch
+from scipy.cluster.hierarchy import dendrogram, leaves_list, linkage
+from scipy.spatial.distance import pdist, squareform
+
+# Reuse the exact feature-selection + medoid logic the clustering used, so the picture
+# and the tables can never drift apart.
+from scripts.convention_analysis.cluster_conventions import NON_FEATURE_COLS, cluster_medoid, select_feature_matrix
+
+TAB10 = plt.get_cmap("tab10").colors
+
+
+def mds_2d(D: np.ndarray, seed: int = 0) -> np.ndarray:
+    """Classical (Torgerson) MDS to 2D from a precomputed distance matrix.
+
+    Deterministic and dependency-free (no sklearn). Double-center -0.5 D^2, take the top
+    two eigenvectors. seed is accepted only for API symmetry; the result is deterministic.
+    """
+    n = D.shape[0]
+    J = np.eye(n) - np.ones((n, n)) / n
+    B = -0.5 * J @ (D ** 2) @ J
+    B = (B + B.T) / 2  # enforce symmetry against fp drift
+    vals, vecs = np.linalg.eigh(B)
+    order = np.argsort(vals)[::-1]
+    top = order[:2]
+    L = np.sqrt(np.clip(vals[top], 0, None))
+    return vecs[:, top] * L
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--features", required=True, type=Path)
+    p.add_argument("--clusters", required=True, type=Path,
+                   help="clusters.csv from cluster_conventions.py (agent,set,cluster,...).")
+    p.add_argument("--metric", default="cosine")
+    p.add_argument("--linkage", default="average")
+    p.add_argument("--title", default="Convention clusters")
+    p.add_argument("--out", required=True, type=Path)
+    args = p.parse_args()
+
+    feats = pd.read_csv(args.features)
+    clus = pd.read_csv(args.clusters)
+
+    # clusters.csv may have dropped teammates (e.g. --exclude); align features to it and
+    # preserve clusters.csv row order so labels/positions stay consistent.
+    if "agent" not in feats.columns:
+        raise ValueError("features.csv has no 'agent' column")
+    feats = feats.set_index("agent").loc[clus["agent"]].reset_index()
+    labels = clus["cluster"].to_numpy()
+    names = clus["agent"].tolist()
+
+    Xz, feature_cols, dropped = select_feature_matrix(feats)
+    d = pdist(Xz, metric=args.metric)
+    D = squareform(d)
+    Z = linkage(d, method=args.linkage)
+    order = leaves_list(Z)
+
+    uniq = sorted(np.unique(labels))
+    color_of = {c: TAB10[i % len(TAB10)] for i, c in enumerate(uniq)}
+    medoids = {c: cluster_medoid(D, np.where(labels == c)[0]) for c in uniq}
+
+    fig = plt.figure(figsize=(15, 5))
+    gs = fig.add_gridspec(1, 3, width_ratios=[1.1, 1.0, 1.2], wspace=0.28)
+
+    # (a) dendrogram
+    ax0 = fig.add_subplot(gs[0, 0])
+    short = [re.sub(r"\s*\(0, (\d+)\)$", r" #\1", n) for n in names]
+    dendrogram(Z, labels=short, ax=ax0, color_threshold=0, above_threshold_color="0.6",
+               leaf_font_size=7)
+    ax0.set_title("(a) dendrogram (cosine, average)")
+    ax0.set_ylabel("merge distance")
+    for lbl in ax0.get_xticklabels():
+        idx = short.index(lbl.get_text())
+        lbl.set_color(color_of[labels[idx]])
+
+    # (b) MDS embedding
+    ax1 = fig.add_subplot(gs[0, 1])
+    XY = mds_2d(D)
+    for c in uniq:
+        m = labels == c
+        ax1.scatter(XY[m, 0], XY[m, 1], s=55, color=color_of[c], edgecolor="white",
+                    linewidth=0.6, label=f"cluster {c} (n={int(m.sum())})", zorder=3)
+    # ring + label the medoids
+    for c in uniq:
+        mi = medoids[c]
+        ax1.scatter(XY[mi, 0], XY[mi, 1], s=180, facecolor="none", edgecolor="black",
+                    linewidth=1.6, zorder=4)
+        ax1.annotate(short[mi], (XY[mi, 0], XY[mi, 1]), fontsize=7, xytext=(4, 4),
+                     textcoords="offset points")
+    ax1.set_title("(b) MDS of cosine distances\n(black ring = cluster medoid)")
+    ax1.set_xlabel("MDS-1"); ax1.set_ylabel("MDS-2")
+    ax1.legend(fontsize=6, loc="best", framealpha=0.9)
+
+    # (c) cosine-similarity heatmap, dendrogram-ordered
+    ax2 = fig.add_subplot(gs[0, 2])
+    S = 1.0 - D  # cosine similarity
+    So = S[np.ix_(order, order)]
+    im = ax2.imshow(So, cmap="viridis", vmin=np.percentile(S, 2), vmax=1.0)
+    ax2.set_title("(c) cosine similarity (leaf-ordered)")
+    ax2.set_xticks(range(len(order)))
+    ax2.set_yticks(range(len(order)))
+    ax2.set_xticklabels([short[i] for i in order], rotation=90, fontsize=5)
+    ax2.set_yticklabels([short[i] for i in order], fontsize=5)
+    for tick, i in zip(ax2.get_xticklabels(), order):
+        tick.set_color(color_of[labels[i]])
+    for tick, i in zip(ax2.get_yticklabels(), order):
+        tick.set_color(color_of[labels[i]])
+    fig.colorbar(im, ax=ax2, fraction=0.046, pad=0.04)
+
+    fig.suptitle(args.title, fontsize=13, y=1.02)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(args.out, bbox_inches="tight", dpi=150)
+    png = args.out.with_suffix(".png")
+    fig.savefig(png, bbox_inches="tight", dpi=150)
+    print(f"wrote {args.out}\nwrote {png}")
+    print(f"features used: {len(feature_cols)}  dropped: {dropped}")
+    print(f"medoids: " + ", ".join(f"c{c}={short[medoids[c]]}" for c in uniq))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/convention_analysis/run_pipeline.py
+++ b/scripts/convention_analysis/run_pipeline.py
@@ -1,0 +1,131 @@
+"""Screen and cluster every extracted population under one feature root.
+
+    python scripts/convention_analysis/run_pipeline.py --pd-root results/conv_v12 --out results/conv_v12/eval
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pandas as pd
+
+from scripts.convention_analysis import feature_groups
+
+ROOT = Path(__file__).resolve().parents[2]
+
+HERE = "scripts/convention_analysis"
+
+
+def discover(pd_root: Path) -> List[Tuple[str, str]]:
+    """(name, variant) for every pd_<name>/overcooked-<variant>/features.csv."""
+    # keep one variant per population (shortest directory name)
+    best: Dict[str, str] = {}
+    for f in sorted(pd_root.glob("pd_*/overcooked-*/features.csv")):
+        name, variant = f.parents[1].name[len("pd_"):], f.parent.name[len("overcooked-"):]
+        if name not in best or len(variant) < len(best[name]):
+            best[name] = variant
+    out = sorted(best.items())
+    if not out:
+        raise SystemExit(f"no pd_*/overcooked-*/features.csv under {pd_root}")
+    return out
+
+
+def sh(cmd: List[str]) -> str:
+    env = {**os.environ, "PYTHONPATH": str(ROOT), "JAX_PLATFORMS": "cpu"}
+    r = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=ROOT)
+    if r.returncode != 0:
+        print(r.stdout[-2000:], r.stderr[-4000:])
+        raise SystemExit(f"command failed: {' '.join(cmd)}")
+    return r.stdout + r.stderr
+
+
+def parse_summary(md: Path) -> Dict:
+    out: Dict = {}
+    for line in md.read_text().splitlines():
+        if line.startswith("- selected **k = "):
+            out["k"] = int(line.split("k = ")[1].split("**")[0])
+        if "eta^2): **" in line:
+            out["eta_sq"] = float(line.split("**")[1])
+        if "**<- selected**" in line:
+            out["silhouette"] = float(line.split("|")[2].split("**")[0])
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--pd-root", type=Path, required=True,
+                   help="Directory holding pd_<name>/overcooked-<variant>/features.csv.")
+    p.add_argument("--out", type=Path, required=True)
+    p.add_argument("--modes", nargs="+", default=["split"], choices=["none", "split"])
+    p.add_argument("--k-tolerance", type=float, default=0.05)
+    p.add_argument("--min-cluster-size", type=int, default=2)
+    p.add_argument("--exclude-groups", nargs="*", default=["throughput"])
+    p.add_argument("--extra-drop", nargs="*", default=[], help="Dropped in every run.")
+    p.add_argument("--only", nargs="*", default=None, help="Restrict to these population names.")
+    args = p.parse_args()
+
+    pops = discover(args.pd_root)
+    if args.only:
+        pops = [(n, v) for n, v in pops if n in args.only]
+    out = args.out
+    (out / "drop_lists").mkdir(parents=True, exist_ok=True)
+
+    drops: Dict[str, List[str]] = {}
+    derived: Dict[str, Path] = {}
+    for name, variant in pops:
+        raw = args.pd_root / f"pd_{name}" / f"overcooked-{variant}" / "features.csv"
+        derived[name] = raw.with_name("features_derived.csv")
+        feature_groups.derive(pd.read_csv(raw)).to_csv(derived[name], index=False)
+
+        cs = derived[name].parent / "cell_support.csv"
+        cmd = [sys.executable, f"{HERE}/screen_features.py",
+               "--features", f"{derived[name]}:{name}",
+               "--output", str(out / "drop_lists" / f"screen_{name}.md"),
+               "--drop-list-dir", str(out / "drop_lists")]
+        if cs.exists():
+            cmd += ["--cell-support", f"{cs}:{name}"]
+        else:
+            print(f"warning: no cell support for {name}; cell-support rule skipped")
+        sh(cmd)
+        drops[name] = (out / "drop_lists" / f"{name}.txt").read_text().split()
+
+    rows = []
+    for name, _ in pops:
+        for mode in args.modes:
+            od = out / f"{name}__{mode}"
+            cmd = [sys.executable, f"{HERE}/cluster_conventions.py",
+                   "--features", str(derived[name]), "--set-labels", name, "--output-dir", str(od),
+                   "--k-tolerance", str(args.k_tolerance), "--min-cluster-size", str(args.min_cluster_size),
+                   "--groups", mode, "--drop-features", *drops[name], *args.extra_drop]
+            if args.exclude_groups:
+                cmd += ["--exclude-groups", *args.exclude_groups]
+            log = sh(cmd)
+            row = {"population": name, "mode": mode, **parse_summary(od / "cluster_summary.md")}
+            row["n_features"] = int([l for l in log.splitlines() if l.startswith("k=")][0].split("features=")[1])
+            sizes = pd.read_csv(od / "clusters.csv")["cluster"].value_counts().sort_values(ascending=False)
+            row["sizes"] = "/".join(str(x) for x in sizes.tolist())
+            rows.append(row)
+            print(f"{name:26s} {mode:6s} k={row.get('k')} sil={row.get('silhouette')} "
+                  f"eta2={row.get('eta_sq')} features={row['n_features']} sizes={row['sizes']}")
+
+    res = pd.DataFrame(rows)
+    res.to_csv(out / "summary.csv", index=False)
+    L = ["# Convention clustering\n", f"feature root: `{args.pd_root}`\n",
+         "## Summary\n", res.to_markdown(index=False), "", "## Structural drop lists\n"]
+    for name, lst in drops.items():
+        L.append(f"- **{name}** ({len(lst)}): {' '.join(f'`{x}`' for x in lst) or '(none)'}")
+    (out / "report.md").write_text("\n".join(L) + "\n")
+    json.dump({"drop_lists": drops, "exclude_groups": args.exclude_groups, "extra_drop": args.extra_drop,
+               "modes": args.modes, "k_tolerance": args.k_tolerance,
+               "min_cluster_size": args.min_cluster_size}, open(out / "meta.json", "w"), indent=1)
+    print(f"\nwrote {out / 'report.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/convention_analysis/screen_features.py
+++ b/scripts/convention_analysis/screen_features.py
@@ -1,0 +1,259 @@
+"""Structural feature screening per Overcooked task; writes one drop list per task.
+
+    python scripts/convention_analysis/screen_features.py --features features_derived.csv:coord_ring \
+        --cell-support cell_support.csv:coord_ring --output screen.md --drop-list-dir drop_lists
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+
+from scripts.convention_analysis.feature_groups import (
+    CONTENTION, MIN_EVENT_SUPPORT, PROXIMITY_CONDITIONED, RATIO_NUMERATOR,
+)
+
+# cell-coordinate feature -> (support basis in cell_support.csv, axis)
+CELL_VALUED_COLUMNS: Dict[str, tuple] = {
+    "onion_counter_x": ("modal_onion", "x"), "onion_counter_y": ("modal_onion", "y"),
+    "dish_counter_x": ("modal_dish", "x"), "dish_counter_y": ("modal_dish", "y"),
+}
+
+
+def axis_support(support: pd.DataFrame, basis: str, axis: str) -> List[int]:
+    """Distinct values of `axis` across teammates for one support basis."""
+    col = f"{basis}_{axis}"
+    if col not in support.columns:
+        return []
+    if basis.startswith("modal_"):
+        vals = support.loc[support[col] >= 0, col].to_numpy(dtype=int)
+        return sorted(set(int(v) for v in vals))
+    out: set = set()
+    for s in support[col].fillna(""):
+        out.update(int(v) for v in str(s).split("|") if v != "")
+    return sorted(out)
+
+NON_FEATURE_COLS = {"agent", "env", "num_episodes", "mean_final_score", "mean_episode_length"}
+
+NEAR_CONSTANT_STD = 1e-12
+REL_SPREAD_THRESH = 0.01
+MEDIAN_TOL = 1e-6
+
+
+def feature_stats(x: np.ndarray) -> Dict[str, float]:
+    med = float(np.median(x))
+    return {
+        "std": float(x.std()),
+        "rel_spread": float(x.std() / (abs(float(x.mean())) + 1e-8)),
+        "n_unique": int(len(np.unique(x))),
+        "frac_at_median": float(np.mean(np.abs(x - med) <= MEDIAN_TOL)),
+    }
+
+
+def degenerate_cell_columns(support_csv: Path) -> Dict[str, str]:
+    """Cell-valued columns whose axis carries a single value population-wide -> {column: reason}."""
+    support = pd.read_csv(support_csv)
+    out: Dict[str, str] = {}
+    for col, (basis, axis) in CELL_VALUED_COLUMNS.items():
+        sup = axis_support(support, basis, axis)
+        if len(sup) <= 1:
+            out[col] = f"single {axis}-value {sup} across all teammates"
+    return out
+
+
+def unsupported_ratio_columns(df: pd.DataFrame) -> Dict[str, str]:
+    """Derived fractions whose numerator event is essentially unobserved -> {column: reason}."""
+    out: Dict[str, str] = {}
+    for col, num in RATIO_NUMERATOR.items():
+        if col in df.columns and num in df.columns:
+            rate = float(df[num].mean())
+            if rate < MIN_EVENT_SUPPORT:
+                out[col] = f"numerator {num} mean {rate:.4f}/episode < {MIN_EVENT_SUPPORT}"
+    return out
+
+
+def disconnected_layout_columns(df: pd.DataFrame) -> Dict[str, str]:
+    """Contention and proximity-conditioned columns when the two agents start in different components."""
+    envs = set(df["env"].astype(str)) if "env" in df.columns else set()
+    if len(envs) != 1 or not next(iter(envs)).startswith("overcooked-"):
+        return {}
+    from envs.overcooked.augmented_layouts import augmented_layouts
+    layout = augmented_layouts[next(iter(envs))[len("overcooked-"):]]
+    comp = np.asarray(layout["free_space_map"]).ravel()[np.asarray(layout["agent_idx"])]
+    if len(set(comp.tolist())) == 1:
+        return {}
+    reason = f"agents start in different layout components {comp.tolist()}"
+    return {c: reason for c in CONTENTION + PROXIMITY_CONDITIONED}
+
+
+def is_degenerate(s: Dict[str, float]) -> bool:
+    """Exactly constant across teammates."""
+    return s["std"] <= NEAR_CONSTANT_STD
+
+
+def is_suspect(s: Dict[str, float]) -> bool:
+    """Diagnostic only; never drops."""
+    return s["n_unique"] <= 2 or s["rel_spread"] < REL_SPREAD_THRESH
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--features", nargs="+", required=True,
+                   help="path:task_label entries (bare path: label = parent dir name).")
+    p.add_argument("--output", type=Path, required=True, help="markdown report path.")
+    p.add_argument("--cell-support", nargs="*", default=[],
+                   help="path:task_label entries pointing at cell_support.csv files.")
+    p.add_argument("--drop-list-dir", type=Path, default=None,
+                   help="Also write each drop list to <dir>/<task>.txt.")
+    args = p.parse_args()
+
+    tasks: Dict[str, pd.DataFrame] = {}
+    for entry in args.features:
+        if ":" in entry and not entry.startswith("/"):
+            path_s, label = entry.rsplit(":", 1)
+        elif entry.count(":") >= 1:
+            path_s, label = entry.rsplit(":", 1)
+        else:
+            path_s, label = entry, Path(entry).parent.name
+        path = Path(path_s)
+        if not path.exists():
+            raise FileNotFoundError(path)
+        tasks[label] = pd.read_csv(path)
+
+    # common numeric feature columns, in first-task order
+    first = next(iter(tasks.values()))
+    feature_cols = [
+        c for c in first.columns
+        if c not in NON_FEATURE_COLS and c != "set"
+        and pd.api.types.is_numeric_dtype(first[c])
+        and all(c in df.columns for df in tasks.values())
+    ]
+
+    stats: Dict[str, Dict[str, Dict[str, float]]] = {}
+    per_task_drop: Dict[str, List[str]] = {label: [] for label in tasks}
+    for feat in feature_cols:
+        per_task = {
+            label: feature_stats(df[feat].to_numpy(dtype=np.float64))
+            for label, df in tasks.items()
+        }
+        stats[feat] = per_task
+        for label, s in per_task.items():
+            if is_degenerate(s):
+                per_task_drop[label].append(feat)
+
+    # second rule: cell-support degeneracy
+    cell_drop: Dict[str, Dict[str, str]] = {}
+    for entry in args.cell_support:
+        path_s, label = entry.rsplit(":", 1)
+        if label not in tasks:
+            raise SystemExit(f"--cell-support label {label!r} is not one of {sorted(tasks)}")
+        found = degenerate_cell_columns(Path(path_s))
+        # only drop columns that are actually in this feature set
+        cell_drop[label] = {c: r for c, r in found.items() if c in feature_cols}
+        for col in cell_drop[label]:
+            if col not in per_task_drop[label]:
+                per_task_drop[label].append(col)
+
+    # third rule: ratio support
+    ratio_drop: Dict[str, Dict[str, str]] = {}
+    for label, df in tasks.items():
+        found = unsupported_ratio_columns(df)
+        ratio_drop[label] = {c: r for c, r in found.items() if c in feature_cols}
+        for col in ratio_drop[label]:
+            if col not in per_task_drop[label]:
+                per_task_drop[label].append(col)
+
+    # fourth rule: split layouts
+    split_drop: Dict[str, Dict[str, str]] = {}
+    for label, df in tasks.items():
+        found = disconnected_layout_columns(df)
+        split_drop[label] = {c: r for c, r in found.items() if c in feature_cols}
+        for col in split_drop[label]:
+            if col not in per_task_drop[label]:
+                per_task_drop[label].append(col)
+
+    L: List[str] = []
+    L.append("# Feature structural screen\n")
+    L.append(f"- tasks: {', '.join(tasks)}  |  features screened: {len(feature_cols)}")
+    L.append(f"- degeneracy rule (structural): std <= {NEAR_CONSTANT_STD:g}; "
+             "dropped per task if degenerate on THAT task")
+    L.append(f"- diagnostic only (~, never drops): n_unique <= 2 OR relative spread < {REL_SPREAD_THRESH}\n")
+    L.append("## Per-feature per-task stats\n")
+    L.append("std / rel_spread / n_unique / frac_within_1e-6_of_median; * = dropped (constant) on that task, "
+             "~ = low-spread diagnostic flag\n")
+    header = "| feature | " + " | ".join(tasks) + " | dropped everywhere |"
+    L.append(header)
+    L.append("|---" * (len(tasks) + 2) + "|")
+    for feat in feature_cols:
+        cells = []
+        for label in tasks:
+            s = stats[feat][label]
+            mark = "*" if is_degenerate(s) else ("~" if is_suspect(s) else "")
+            cells.append(f"{s['std']:.3g}/{s['rel_spread']:.3g}/{s['n_unique']}/"
+                         f"{s['frac_at_median']:.2f}{mark}")
+        drop = "**DROP**" if all(feat in lst for lst in per_task_drop.values()) else ""
+        L.append(f"| `{feat}` | " + " | ".join(cells) + f" | {drop} |")
+    L.append("")
+
+    if any(ratio_drop.values()):
+        L.append("## Ratio-support rule (derived fractions)\n")
+        for label, found in ratio_drop.items():
+            for col, reason in found.items():
+                L.append(f"- {label}: `{col}` ({reason})")
+        L.append("")
+
+    if any(split_drop.values()):
+        L.append("## Split-layout rule\n")
+        for label, found in split_drop.items():
+            if found:
+                L.append(f"- {label}: {' '.join('`'+c+'`' for c in found)} "
+                         f"({next(iter(found.values()))})")
+        L.append("")
+
+    if cell_drop:
+        L.append("## Cell-support rule (coordinate features)\n")
+        L.append("A coordinate column is dropped when every teammate's *usual* cell shares "
+                 "one value on that axis, so the column cannot express any between-teammate "
+                 "difference on this layout. Computed before the 128-episode averaging, "
+                 "which is what makes it immune to the off-wall drops that defeat the "
+                 "variance and reliability rules.\n")
+        for label, found in cell_drop.items():
+            L.append(f"### {label}\n")
+            if found:
+                for col, reason in found.items():
+                    L.append(f"- `{col}` -- {reason}")
+            else:
+                L.append("(nothing dropped by this rule)")
+            L.append("")
+
+    emit = per_task_drop
+    L.append("## Per-task drop lists\n")
+    L.append("Each list is the set of features degenerate on THAT task; feed the "
+             "matching list to `cluster_conventions.py --drop-features` when "
+             "clustering that task alone.\n")
+    for label, lst in per_task_drop.items():
+        L.append(f"### {label} ({len(lst)} dropped)\n")
+        L.append(" ".join(lst) if lst else "(none)")
+        L.append("")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(L))
+    if args.drop_list_dir is not None:
+        args.drop_list_dir.mkdir(parents=True, exist_ok=True)
+        for label, lst in emit.items():
+            (args.drop_list_dir / f"{label}.txt").write_text(" ".join(lst))
+        print(f"wrote {len(emit)} drop list(s) to {args.drop_list_dir}")
+    print(f"screened {len(feature_cols)} features over {len(tasks)} tasks")
+    for label, lst in emit.items():
+        print(f"  {label}: {len(lst)} dropped: {' '.join(lst) if lst else '(none)'}")
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/population_diversity/compute_population_diversity.py
+++ b/scripts/population_diversity/compute_population_diversity.py
@@ -1,4 +1,6 @@
-# Population Diversity CLI. Runs rollouts, computes PD, writes heatmap + PCA + features.csv + pd.json.
+# Population Diversity CLI: rollouts -> theta features -> PD, features.csv, pd.json, heatmap + PCA.
+# Example: python scripts/population_diversity/compute_population_diversity.py --env overcooked \
+#   --variant coord_ring --full-heldout --br-paired --br-root <br_root> --batched --cache-dir results/pd_cache
 from __future__ import annotations
 
 import argparse
@@ -7,6 +9,7 @@ import json
 import logging
 import os
 import sys
+import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -15,18 +18,16 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
-
 from envs import make_env
 from envs.log_wrapper import LogWrapper
 
 from scripts.population_diversity.pd_events import (
     HANABI_FEATURE_NAMES,
     LBF_FEATURE_NAMES,
-    OVERCOOKED_FEATURE_NAMES,
     hanabi_feature_names,
+    OVERCOOKED_CONTINGENT_FEATURE_NAMES,
+    OVERCOOKED_FEATURE_NAMES,
+    OVERCOOKED_V5_FEATURE_NAMES,
 )
 from scripts.population_diversity.pd_plots import (
     population_diversity,
@@ -47,12 +48,25 @@ from scripts.population_diversity.pd_rollouts import (
     build_lbf_agents,
     rollout_two_policy,
     rollout_simple_self_play,
-    OvercookedEpisodeCounts,
-    overcooked_episode_to_vector,
-    overcooked_step_update,
     build_overcooked_agents,
     load_full_heldout_for_pd,
     load_brs_for_pd,
+    rollout_two_policy_batched,
+)
+from scripts.population_diversity.pd_traj_cache import (
+    OvercookedTrajRecorder,
+    save_batched_traj,
+    cache_path,
+    load_episodes,
+    replay_counts,
+)
+from scripts.population_diversity.pd_overcooked_features import (
+    OvercookedEpisodeCounts,
+    episode_contingency_features,
+    episode_v5_features,
+    overcooked_cell_support,
+    overcooked_episode_to_vector,
+    overcooked_step_update,
 )
 
 log = logging.getLogger("compute_pd")
@@ -65,7 +79,7 @@ class EnvConfig:
     feature_names: List[str]
     build_env: Callable
     build_agents: Callable
-    rollout: Callable                            # self-play rollout (legacy)
+    rollout: Callable                            # self-play rollout
     to_vector: Callable[[Any, float, float], np.ndarray] = field(default=lambda *_: np.zeros(1))
     rollout_two_policy: Callable = field(default=lambda *args, **kwargs: [])  # BR-paired rollout
 
@@ -181,17 +195,21 @@ def env_config_for_lbf(variant: str = "lbf_7x7_nolevels") -> EnvConfig:
         agents = build_lbf_agents(grid_size=cfg["grid_size"], num_fruits=cfg["num_fruits"])
         return agents, None
 
-    def _rollout(env, policy, layout, num_eps, seed, params=None):
-        hz = min(int(getattr(getattr(env._env, "env", None), "time_limit", 128)), 128)
+    def _horizon(env):
+        return min(int(getattr(getattr(env._env, "env", None), "time_limit", 128)), 128)
+
+    def _rollout(env, policy, layout, num_eps, seed, params=None, recorder=None):
         return rollout_simple_self_play(
-            env, policy, num_eps, seed, LBFEpisodeCounts, partial(lbf_step_update, horizon=hz), max_steps=128, params=params,
+            env, policy, num_eps, seed, LBFEpisodeCounts, partial(lbf_step_update, horizon=_horizon(env)),
+            max_steps=128, params=params, recorder=recorder,
         )
 
-    def _rollout_two_policy(env, policy_a, params_a, policy_b, params_b, layout, num_eps, seed):
-        hz = min(int(getattr(getattr(env._env, "env", None), "time_limit", 128)), 128)
+    def _rollout_two_policy(env, policy_a, params_a, policy_b, params_b, layout, num_eps, seed,
+                            recorder=None):
         return rollout_two_policy(
             env, policy_a, params_a, policy_b, params_b,
-            num_eps, seed, LBFEpisodeCounts, partial(lbf_step_update, horizon=hz), max_steps=128,
+            num_eps, seed, LBFEpisodeCounts, partial(lbf_step_update, horizon=_horizon(env)),
+            max_steps=128, recorder=recorder,
         )
 
     return EnvConfig(
@@ -208,7 +226,8 @@ def env_config_for_lbf(variant: str = "lbf_7x7_nolevels") -> EnvConfig:
 
 
 
-def env_config_for_overcooked(layout_name: str = "cramped_room") -> EnvConfig:
+def env_config_for_overcooked(layout_name: str = "cramped_room",
+                              deterministic_reset: bool = False) -> EnvConfig:
     from envs.overcooked.augmented_layouts import augmented_layouts
 
     layout = augmented_layouts[layout_name]
@@ -216,7 +235,7 @@ def env_config_for_overcooked(layout_name: str = "cramped_room") -> EnvConfig:
     def _build_env():
         env_kwargs = {
             "layout": layout_name,
-            "random_obj_state": True,
+            "random_obj_state": not deterministic_reset,
             "do_reward_shaping": True,
             "reward_shaping_params": {
                 "PLACEMENT_IN_POT_REW": 0.5,
@@ -227,7 +246,15 @@ def env_config_for_overcooked(layout_name: str = "cramped_room") -> EnvConfig:
                 "COUNTER_DROP_REWARD": 0.0,
             },
         }
+        if deterministic_reset:
+            # Fixed start cells; agent_idx is swapped below so the tracked teammate (agent_1) takes agent_0's cell.
+            env_kwargs["random_reset"] = False
         env = make_env("overcooked-v1", env_kwargs)
+        if deterministic_reset:
+            from flax.core.frozen_dict import FrozenDict
+            base = env.env  # unwrap to the jaxmarl Overcooked env
+            idx = jnp.asarray(base.layout["agent_idx"])[::-1]
+            base.layout = FrozenDict({**dict(base.layout), "agent_idx": idx})
         env = LogWrapper(env)
         return env, env_kwargs
 
@@ -235,15 +262,18 @@ def env_config_for_overcooked(layout_name: str = "cramped_room") -> EnvConfig:
         agents = build_overcooked_agents(layout=layout)
         return agents, None
 
-    def _rollout(env, policy, layout_obj, num_eps, seed, params=None):
+    def _rollout(env, policy, layout_obj, num_eps, seed, params=None, recorder=None):
         return rollout_simple_self_play(
-            env, policy, num_eps, seed, OvercookedEpisodeCounts, overcooked_step_update, max_steps=400, params=params,
+            env, policy, num_eps, seed, OvercookedEpisodeCounts, overcooked_step_update,
+            max_steps=400, params=params, recorder=recorder,
         )
 
-    def _rollout_two_policy(env, policy_a, params_a, policy_b, params_b, layout_obj, num_eps, seed):
+    def _rollout_two_policy(env, policy_a, params_a, policy_b, params_b, layout_obj, num_eps, seed,
+                            recorder=None):
         return rollout_two_policy(
             env, policy_a, params_a, policy_b, params_b,
             num_eps, seed, OvercookedEpisodeCounts, overcooked_step_update, max_steps=400,
+            recorder=recorder,
         )
 
     return EnvConfig(
@@ -260,6 +290,134 @@ def env_config_for_overcooked(layout_name: str = "cramped_room") -> EnvConfig:
 
 
 
+def _theta_from_counts(env_cfg: EnvConfig, ep_counts) -> np.ndarray:
+    ep_vectors = np.stack(
+        [env_cfg.to_vector(c, env_cfg.score_norm, env_cfg.length_norm) for c in ep_counts]
+    )
+    return ep_vectors.mean(axis=0)
+
+
+def _record_from_counts(env_cfg: EnvConfig, agent_name: str, num_episodes: int, ep_counts,
+                        extra: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
+    theta = _theta_from_counts(env_cfg, ep_counts)
+    return dict(
+        agent=agent_name,
+        env=env_cfg.name,
+        num_episodes=num_episodes,
+        **{name: float(theta[i]) for i, name in enumerate(env_cfg.feature_names)},
+        **(extra or {}),
+        mean_final_score=float(np.mean([c.final_score for c in ep_counts])),
+        mean_episode_length=float(np.mean([c.episode_length for c in ep_counts])),
+    )
+
+
+def _write_outputs(env_cfg: EnvConfig, agent_names, per_agent_records, theta_rows,
+                   num_episodes: int, seed: int, output_dir: Path,
+                   support_rows: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
+    """Write features.csv, cell_support.csv, pd.json and the PCA / cosine-heatmap PDFs."""
+    theta_mat = np.stack(theta_rows)
+    pd_payload = population_diversity(theta_mat)
+
+    csv_path = output_dir / "features.csv"
+    with csv_path.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(per_agent_records[0].keys()))
+        writer.writeheader()
+        writer.writerows(per_agent_records)
+    if support_rows:
+        with (output_dir / "cell_support.csv").open("w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(support_rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(support_rows)
+
+    json_payload = {
+        "env": env_cfg.name,
+        "num_agents": len(agent_names),
+        "num_episodes": num_episodes,
+        "seed": seed,
+        "feature_names": env_cfg.feature_names,
+        "agent_names": agent_names,
+        "theta": theta_mat.tolist(),
+        "pd": pd_payload,
+    }
+    with (output_dir / "pd.json").open("w") as fh:
+        json.dump(json_payload, fh, indent=2)
+
+    save_pca_plot(
+        np.array(pd_payload["theta_norm"]), agent_names,
+        output_dir / f"pca_{env_cfg.name}.pdf",
+        f"PCA of normalized theta vectors -- {env_cfg.name}",
+    )
+    save_cosine_heatmap(
+        np.array(pd_payload["cosine"]), agent_names,
+        output_dir / f"heatmap_{env_cfg.name}.pdf",
+        f"Pairwise cosine similarity -- {env_cfg.name}",
+    )
+    log.info(
+        "  PD = det(K) = %.6e  (log det = %.4f, sign = %d)  -- %s",
+        pd_payload["det_K"], pd_payload["log_det_K"], pd_payload["sign"], env_cfg.name,
+    )
+    return json_payload
+
+
+def _agent_sort_key(stem: str):
+    """Numeric sort so `agent_7` precedes `agent_11`."""
+    import re as _re
+    return [int(x) if x.isdigit() else x for x in _re.split(r"(\d+)", stem)]
+
+
+def _features_from_cache_file(env_cfg: EnvConfig, f: Path, contingent: bool = True,
+                              v5: bool = True):
+    """(agent_name, ep_counts, features record, cell-support row) for one cached teammate."""
+    eps = load_episodes(f)
+    ep_counts = replay_counts(f)
+    agent_name = str(np.load(f, allow_pickle=False)["agent"])
+    extra: Dict[str, float] = {}
+    if contingent:
+        per_ep = np.stack([episode_contingency_features(e) for e in eps])
+        extra = {name: float(per_ep[:, i].mean())
+                 for i, name in enumerate(OVERCOOKED_CONTINGENT_FEATURE_NAMES)}
+    if v5:
+        per_ep5 = np.stack([episode_v5_features(e) for e in eps])
+        extra.update({name: float(per_ep5[:, i].mean())
+                      for i, name in enumerate(OVERCOOKED_V5_FEATURE_NAMES)})
+    record = _record_from_counts(env_cfg, agent_name, len(ep_counts), ep_counts, extra=extra)
+    support = {"agent": agent_name, **overcooked_cell_support(ep_counts)}
+    return agent_name, ep_counts, record, support
+
+
+def compute_pd_from_cache(
+    env_cfg: EnvConfig,
+    cache_dir: Path,
+    output_dir: Path,
+    seed: int = 0,
+    contingent: bool = True,
+    v5: bool = True,
+) -> Dict[str, Any]:
+    """Recompute features from a trajectory cache on CPU."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    task_dir = Path(cache_dir) / env_cfg.name.replace("/", "_")
+    files = sorted(task_dir.glob("*.npz"), key=lambda f: _agent_sort_key(f.stem))
+    if not files:
+        raise FileNotFoundError(f"no cache files under {task_dir}")
+    log.info("recomputing features from %d cached teammates in %s", len(files), task_dir)
+
+    agent_names: List[str] = []
+    theta_rows: List[np.ndarray] = []
+    records: List[Dict[str, Any]] = []
+    support_rows: List[Dict[str, Any]] = []
+    for f in files:
+        agent_name, ep_counts, record, support = _features_from_cache_file(env_cfg, f, contingent, v5)
+        support_rows.append(support)
+        records.append(record)
+        agent_names.append(agent_name)
+        theta_rows.append(_theta_from_counts(env_cfg, ep_counts))
+        log.info("  %s: %d episodes", agent_name, len(ep_counts))
+
+    num_episodes = int(np.median([r["num_episodes"] for r in records]))
+    return _write_outputs(env_cfg, agent_names, records, theta_rows,
+                          num_episodes, seed, output_dir, support_rows=support_rows)
+
+
 def compute_pd_for_env(
     env_cfg: EnvConfig,
     num_episodes: int,
@@ -270,6 +428,8 @@ def compute_pd_for_env(
     task_name: str | None = None,
     br_paired: bool = False,
     br_root: Path | None = None,
+    cache_dir: Path | None = None,
+    batched: bool = False,
 ) -> Dict[str, Any]:
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -282,15 +442,12 @@ def compute_pd_for_env(
         heldout = load_full_heldout_for_pd(env, env_kwargs, task_name, heldout_yaml_key, seed)
         log.info("loaded %d agents from heldout_set.%s", len(heldout), heldout_yaml_key)
         agents = {label: (entry[0], entry[1]) for label, entry in heldout.items()}
-        # Rebuild layout (Hanabi needs this; LBF/Overcooked layout=None)
-        if env_cfg.name in HANABI_VARIANTS or env_cfg.name == "hanabi":
-            cfg = HANABI_VARIANTS.get(env_cfg.name, HANABI_VARIANTS["hanabi"])
-            num_actions = env.action_space("agent_0").n
+        if env_cfg.name in HANABI_VARIANTS:
+            # Hanabi needs the action layout to decode actions; LBF/Overcooked use None.
+            cfg = HANABI_VARIANTS[env_cfg.name]
             layout = HanabiActionLayout(
-                hand_size=cfg["hand_size"],
-                num_colors=cfg["num_colors"],
-                num_ranks=cfg["num_ranks"],
-                num_actions=num_actions,
+                hand_size=cfg["hand_size"], num_colors=cfg["num_colors"],
+                num_ranks=cfg["num_ranks"], num_actions=env.action_space("agent_0").n,
             )
         else:
             layout = None
@@ -298,22 +455,18 @@ def compute_pd_for_env(
         agents_dict, layout = env_cfg.build_agents(env, env_kwargs)
         agents = {name: (policy, None) for name, policy in agents_dict.items()}
 
-    # Load BRs if requested. Canonical ZSC-Eval PD pairs each partner with its
-    # best-response. If a partner's BR is missing on disk, fall back to
-    # self-play for THAT partner with a logged warning.
+    # BR-paired: theta is attributed to the teammate (agent_1), BR is agent_0; missing BR -> self-play.
     brs: Dict[str, Tuple[Any, Any]] = {}
     if br_paired:
         if br_root is None:
             raise ValueError("br_paired requires br_root")
         if task_name is None:
-            raise ValueError("br_paired requires task_name (e.g. 'mini-hanabi', 'lbf/lbf_7x7_nolevels')")
-        # Derive layout_prefix from task_name for OC-style HF naming
-        # (e.g. coord_ring_<name>_<idx>_serious). Strip 'overcooked-v1/' prefix.
+            raise ValueError("br_paired requires task_name (e.g. 'mini-hanabi', 'lbf/lbf_7x7_nolevels', 'overcooked-v1/counter_circuit')")
+        # layout_prefix for HF-style BR checkpoint naming
         layout_prefix = None
         if task_name.startswith("overcooked-v1/"):
-            layout_prefix = task_name.split("/", 1)[1]  # 'coord_ring' etc.
+            layout_prefix = task_name.split("/", 1)[1]
         elif task_name.startswith("lbf/"):
-            # LBF dirs may use 'lbf_7x7_nolevels' as a subdir prefix; try it
             layout_prefix = task_name.split("/", 1)[1]
         log.info("loading BRs for %d partners from %s (layout_prefix=%s)",
                  len(agents), br_root, layout_prefix)
@@ -328,94 +481,79 @@ def compute_pd_for_env(
     theta_rows: List[np.ndarray] = []
     agent_names: List[str] = []
     per_agent_records: List[Dict[str, Any]] = []
+    support_rows: List[Dict[str, Any]] = []
     pairing_modes: List[str] = []
 
+    is_overcooked = env_cfg.name.startswith("overcooked")
+    if (cache_dir is not None or batched) and not is_overcooked:
+        raise NotImplementedError(
+            "the trajectory cache and the batched rollout are implemented for Overcooked "
+            "only; LBF still recomputes features inside the sequential rollout loop."
+        )
+    if batched and cache_dir is None:
+        raise ValueError("--batched requires --cache-dir (the batched output IS the cache)")
+
     for agent_name, (policy, params) in agents.items():
-        partner_label = "BR" if (br_paired and agent_name in brs) else "self-play"
-        pairing_modes.append(partner_label)
-        log.info("  rollouts: %s (%s)", agent_name, partner_label)
         if br_paired and agent_name in brs:
+            pairing = "BR"
+        else:
+            pairing = "self-play"
+        pairing_modes.append(pairing)
+        if batched:
+            # Slot assignment mirrors the sequential branches below exactly.
+            if pairing == "BR":
+                a0, a1 = (policy, params), brs[agent_name]
+            else:
+                a0, a1 = (policy, params), (policy, params)
+            log.info("  batched rollout: %s (%s)", agent_name, pairing)
+            t0 = time.time()
+            traj = rollout_two_policy_batched(
+                env, a0[0], a0[1], a1[0], a1[1], num_episodes, seed, max_steps=400,
+            )
+            cpath = cache_path(cache_dir, env_cfg.name, agent_name)
+            nbytes = save_batched_traj(traj, agent_name, env_cfg.name, seed, cpath)
+            del traj
+            log.info("    %.1fs wall; cache %s (%.1f MB)", time.time() - t0, cpath, nbytes / 1e6)
+            _, ep_counts, record, support = _features_from_cache_file(env_cfg, cpath)
+            record["pairing"] = pairing
+            theta_rows.append(_theta_from_counts(env_cfg, ep_counts))
+            agent_names.append(agent_name)
+            per_agent_records.append(record)
+            support_rows.append(support)
+            continue
+
+        recorder = OvercookedTrajRecorder(agent_name, env_cfg.name, seed) if cache_dir else None
+        log.info("  rollouts: %s (%s)", agent_name, pairing)
+        if pairing == "BR":
+            # Heldout partner = agent_0, its BR = agent_1 (ZSC-Eval slot order).
             br_policy, br_params = brs[agent_name]
             ep_counts = env_cfg.rollout_two_policy(
                 env, policy, params, br_policy, br_params, layout, num_episodes, seed,
+                recorder=recorder,
             )
         else:
-            ep_counts = env_cfg.rollout(env, policy, layout, num_episodes, seed, params=params)
-        ep_vectors = np.stack(
-            [env_cfg.to_vector(c, env_cfg.score_norm, env_cfg.length_norm) for c in ep_counts]
-        )
-        theta = ep_vectors.mean(axis=0)
-        theta_rows.append(theta)
+            ep_counts = env_cfg.rollout(env, policy, layout, num_episodes, seed, params=params,
+                                        recorder=recorder)
+        if recorder is not None:
+            cpath = cache_path(cache_dir, env_cfg.name, agent_name)
+            nbytes = recorder.save(cpath)
+            log.info("    cached trajectories -> %s (%.1f MB)", cpath, nbytes / 1e6)
+        theta_rows.append(_theta_from_counts(env_cfg, ep_counts))
         agent_names.append(agent_name)
-
         per_agent_records.append(
-            dict(
-                agent=agent_name,
-                env=env_cfg.name,
-                pairing=partner_label,
-                num_episodes=num_episodes,
-                **{
-                    name: float(theta[i]) for i, name in enumerate(env_cfg.feature_names)
-                },
-                mean_final_score=float(np.mean([c.final_score for c in ep_counts])),
-                mean_episode_length=float(np.mean([c.episode_length for c in ep_counts])),
-            )
-        )
+            _record_from_counts(env_cfg, agent_name, num_episodes, ep_counts,
+                                extra={"pairing": pairing}))
+        if is_overcooked:
+            support_rows.append({"agent": agent_name, **overcooked_cell_support(ep_counts)})
 
-    theta = np.stack(theta_rows)
     if len(set(pairing_modes)) > 1:
-        n_br = pairing_modes.count("BR")
         log.warning(
-            "PD theta mixes %d BR rows with %d self-play rows in one det(K); they are not comparable "
+            "PD theta mixes pairing modes %s in one det(K); rows are not comparable "
             "(missing BRs fell back to self-play). See the per-row 'pairing' field.",
-            n_br, len(pairing_modes) - n_br,
+            {m: pairing_modes.count(m) for m in set(pairing_modes)},
         )
-    pd_payload = population_diversity(theta)
-
-    csv_path = output_dir / "features.csv"
-    with csv_path.open("w", newline="") as fh:
-        writer = csv.DictWriter(fh, fieldnames=list(per_agent_records[0].keys()))
-        writer.writeheader()
-        writer.writerows(per_agent_records)
-
-    json_payload = {
-        "env": env_cfg.name,
-        "num_agents": len(agent_names),
-        "num_episodes": num_episodes,
-        "seed": seed,
-        "feature_names": env_cfg.feature_names,
-        "agent_names": agent_names,
-        "pairing": pairing_modes,
-        "theta": theta.tolist(),
-        "pd": pd_payload,
-    }
-    with (output_dir / "pd.json").open("w") as fh:
-        json.dump(json_payload, fh, indent=2)
-
-    # PCA on the SAME normalized theta that K/cosine/heatmap use, so every
-    # downstream figure is consistent with the det(K) metric. Raw theta stays
-    # available in pd.json (pd_payload['theta_raw']) and the top-level 'theta'.
-    save_pca_plot(
-        np.array(pd_payload["theta_norm"]),
-        agent_names,
-        output_dir / f"pca_{env_cfg.name}.pdf",
-        f"PCA of normalized theta vectors -- {env_cfg.name}",
-    )
-    save_cosine_heatmap(
-        np.array(pd_payload["cosine"]),
-        agent_names,
-        output_dir / f"heatmap_{env_cfg.name}.pdf",
-        f"Pairwise cosine similarity -- {env_cfg.name}",
-    )
-
-    log.info(
-        "  PD = det(K) = %.6e  (log det = %.4f, sign = %d)  -- %s",
-        pd_payload["det_K"],
-        pd_payload["log_det_K"],
-        pd_payload["sign"],
-        env_cfg.name,
-    )
-    return json_payload
+    return _write_outputs(env_cfg, agent_names, per_agent_records, theta_rows,
+                          num_episodes, seed, output_dir, support_rows=support_rows)
 
 
 def main() -> int:
@@ -424,45 +562,64 @@ def main() -> int:
         "--env",
         choices=["hanabi", "mini-hanabi", "lbf", "overcooked", "all"],
         default="mini-hanabi",
-        help="Environment to compute PD for. 'all' iterates over hanabi+mini-hanabi+lbf+overcooked.",
+        help="Environment; 'all' runs hanabi, mini-hanabi, lbf and overcooked.",
     )
     parser.add_argument(
         "--variant",
         default=None,
-        help=(
-            "Layout variant for lbf or overcooked. "
-            "lbf: lbf_7x7_nolevels (default) or lbf_12x12. "
-            "overcooked: cramped_room (default), coord_ring, etc. Ignored for hanabi/mini-hanabi."
-        ),
+        help="Variant for the chosen env: lbf_7x7_nolevels (default) / lbf_12x12; overcooked layouts. Ignored for hanabi.",
     )
     parser.add_argument("--num-episodes", type=int, default=128)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(
         "--output-dir",
         default="results/population_diversity",
-        help="Per-env subdirectories are created under this root.",
+        help="Root output directory.",
     )
     parser.add_argument(
         "--full-heldout",
         action="store_true",
-        help="Use the full eval set from evaluation/configs/global_heldout_settings.yaml (heuristics + RL partners + BC + OBL) instead of the heuristic-only suite.",
+        help="Use the full heldout eval set instead of the heuristic suite.",
     )
     parser.add_argument(
         "--br-paired",
         action="store_true",
-        help=(
-            "Pair each partner with its trained best-response (canonical Wang et al. 2024 PD). "
-            "Requires --br-root pointing at a directory tree of saved_train_run BR checkpoints. "
-            "If a BR is missing for a partner, that partner falls back to self-play with a logged warning."
-        ),
+        help="Pair each partner with its best response (requires --br-root).",
     )
     parser.add_argument(
         "--br-root",
         default=None,
-        help=(
-            "Root directory for BR checkpoints. Expected layout: <br_root>/<partner_name>/saved_train_run/. "
-            "Typical setup: download jaxaht/eval-teammates-br/<env>/ from HF and point --br-root at the local copy."
-        ),
+        help="Root of BR checkpoints: <br_root>/<partner>/saved_train_run/.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help="Write per-step transitions to <cache-dir>/<task>/<agent>.npz (Overcooked only).",
+    )
+    parser.add_argument(
+        "--batched",
+        action="store_true",
+        help="Use the vmapped batched rollout (requires --cache-dir).",
+    )
+    parser.add_argument(
+        "--from-cache",
+        action="store_true",
+        help="Recompute features from an existing --cache-dir without rollouts.",
+    )
+    parser.add_argument(
+        "--deterministic-reset",
+        action="store_true",
+        help="Overcooked only: fixed start cells and empty pots.",
+    )
+    parser.add_argument(
+        "--no-contingent",
+        action="store_true",
+        help="With --from-cache, omit the partner-contingent features.",
+    )
+    parser.add_argument(
+        "--no-v5",
+        action="store_true",
+        help="With --from-cache, omit the contention and action-MI features.",
     )
     args = parser.parse_args()
 
@@ -501,7 +658,8 @@ def main() -> int:
                 out_subdir = f"lbf-{variant}"
             elif env_name == "overcooked":
                 variant = args.variant or "cramped_room"
-                env_cfg = env_config_for_overcooked(variant)
+                env_cfg = env_config_for_overcooked(
+                    variant, deterministic_reset=args.deterministic_reset)
                 yaml_key = f"overcooked-v1/{variant}"
                 task_name = f"overcooked-v1/{variant}"
                 out_subdir = f"overcooked-{variant}"
@@ -511,6 +669,17 @@ def main() -> int:
                 out_subdir = f"{out_subdir}_full"
             if args.br_paired:
                 out_subdir = f"{out_subdir}_brpaired"
+            if args.from_cache:
+                if not args.cache_dir:
+                    raise ValueError("--from-cache requires --cache-dir")
+                payload = compute_pd_from_cache(
+                    env_cfg, Path(args.cache_dir), output_root / out_subdir,
+                    seed=args.seed, contingent=not args.no_contingent,
+                    v5=not args.no_v5,
+                )
+                summary["runs"].append({"env": env_name, "pd": payload["pd"]["det_K"],
+                                        "n_agents": payload["num_agents"]})
+                continue
             payload = compute_pd_for_env(
                 env_cfg,
                 args.num_episodes,
@@ -521,6 +690,8 @@ def main() -> int:
                 task_name=task_name if args.full_heldout else None,
                 br_paired=args.br_paired,
                 br_root=br_root,
+                cache_dir=Path(args.cache_dir) if args.cache_dir else None,
+                batched=args.batched,
             )
             summary["runs"].append({"env": env_name, "pd": payload["pd"]["det_K"], "n_agents": payload["num_agents"]})
         except NotImplementedError as exc:

--- a/scripts/population_diversity/pd_events.py
+++ b/scripts/population_diversity/pd_events.py
@@ -46,59 +46,50 @@ LBF_FEATURE_NAMES = [
     "retreat_from_fruit",
     "collision_with_partner",
     "noop",
-    # Per-fruit-level loads (extension to lift feature dimension above heldout
-    # population size, Wang et al. 2024 framework adapted to LBF).
+    # Per-fruit-level loads.
     "load_lvl_1",
     "load_lvl_2",
     "load_lvl_3",
-    # Partner-distance state distributions
+    # Partner-distance state distributions.
     "state_partner_adjacent",
     "state_partner_mid",
     "state_partner_far",
-    # Coordination-behavior events (extending vocab to lift D above heldout N).
+    # Coordination-behavior events.
     "wait_for_partner",         # adjacent to fruit, partner not adjacent, took noop
     "target_conflict",          # both agents move toward the same nearest fruit
-    "solo_attempt_lvl_2",       # tried LOAD alone on a lvl-2 fruit (succeeded or failed)
+    "solo_attempt_lvl_2",       # tried LOAD alone on a lvl-2 fruit
     "solo_attempt_lvl_3",       # tried LOAD alone on a lvl-3 fruit
     "coop_load_lvl_2",          # successful cooperative load of a lvl-2 fruit
     "coop_load_lvl_3",          # successful cooperative load of a lvl-3 fruit
-    # Spatial visitation (4-quadrant; integer count of steps spent in each).
+    # Spatial visitation (steps spent in each quadrant).
     "quadrant_NW_visit",
     "quadrant_NE_visit",
     "quadrant_SW_visit",
     "quadrant_SE_visit",
-    # Tempo: early- vs late-game load events.
+    # Tempo.
     "early_game_load",          # successful load in first third of episode
     "late_game_load",           # successful load in last third
     # Partner-distance + opportunity.
     "partner_distance_sum",     # cumulative Manhattan distance to partner
     "noop_when_food_visible",   # idled while >= 1 uneaten fruit on map
-    # --- derived vocabulary (all normalized to [0, 1]-ish scales) ---
-    # Relative spatial configuration w.r.t. the partner (fraction of steps).
-    "rel_north_frac",           # tracked agent strictly north of partner (smaller row)
+    # Relative position w.r.t. the partner (fraction of steps).
+    "rel_north_frac",           # strictly north of partner (smaller row)
     "rel_south_frac",
     "rel_east_frac",            # strictly east of partner (larger col)
     "rel_west_frac",
-    # Territorial overlap: Jaccard of visited-cell sets (tracked agent vs partner).
-    "territory_overlap",
-    # Among cooperatively-loaded fruits, fraction where the tracked agent arrived first.
-    "arrival_first_rate",
-    # Mean length of a "loitering next to fruit without loading" run, / episode length.
-    "mean_wait_at_fruit",
-    # Tempo: steps per successful load by the tracked agent.
-    "steps_per_load",
-    # Manhattan-optimal / actual move count, averaged over inter-load segments.
-    "path_efficiency",
-    # --- sabotage vocabulary (force_coop LBF: every fruit needs BOTH agents) ---
-    # A "join opportunity" = partner adjacent to a fruit it cannot load alone, tracked
-    # agent NOT adjacent to it. Cooperating means closing distance; declining is the
-    # LBF form of sabotage. Rates are conditioned on an opportunity existing.
-    "decline_to_join_rate",     # fraction of join opportunities where distance did not shrink
-    "abandon_partner_rate",     # fraction where the agent moved strictly AWAY (active refusal)
+    "territory_overlap",        # Jaccard of visited-cell sets with the partner
+    "arrival_first_rate",       # frac of coop loads where the tracked agent arrived first
+    "mean_wait_at_fruit",       # mean loiter-at-fruit run length, / episode length
+    "steps_per_load",           # steps per successful load by the tracked agent
+    "path_efficiency",          # Manhattan-optimal / actual move count over inter-load segments
+    # Sabotage (force_coop): a "join opportunity" is partner adjacent to a fruit it
+    # cannot load alone while the tracked agent is not adjacent.
+    "decline_to_join_rate",     # frac of join opportunities where distance did not shrink
+    "abandon_partner_rate",     # frac where the agent moved strictly away
     "join_latency",             # mean steps partner waited before the agent joined, / ep_len
 ]
 
-# overcooked events (wang+2024 SHAPED_INFOS)
+# overcooked events (SHAPED_INFOS)
 OVERCOOKED_SHAPED_INFOS = [
     "put_onion_on_X",
     "put_dish_on_X",
@@ -108,7 +99,6 @@ OVERCOOKED_SHAPED_INFOS = [
     "pickup_dish_from_X",
     "pickup_dish_from_D",
     "pickup_soup_from_X",
-    "USEFUL_DISH_PICKUP",
     "SOUP_PICKUP",
     "PLACEMENT_IN_POT",
     "delivery",
@@ -119,39 +109,80 @@ OVERCOOKED_SHAPED_INFOS = [
     "IDLE_INTERACT_EMPTY",
 ]
 
-# Features computed by our detectors (vs. env-emitted SHAPED_INFOS).
-# Appended after shaped_infos so the original 17 columns keep their positions.
+# Extended overcooked vocabulary, appended after the shaped_infos block.
 OVERCOOKED_DERIVED_FEATURE_NAMES = [
-    # Handoff: who put what on which counter, and who took it back off.
+    # Handoffs via counters.
     "handoff_given",            # tracked agent placed, partner later picked up
     "handoff_received",         # partner placed, tracked agent later picked up
     "dead_drop",                # tracked agent placed, still there at episode end
     "self_retrieve",            # tracked agent placed and picked back up itself
     "counter_entropy",          # normalized entropy of placements over counters
-    # Resource choice: fraction of uses that went to the canonically-first
-    # instance of each resource. 0.0 when the layout has < 2 of that resource.
-    "pot_first_frac",
-    "onion_pile_first_frac",
-    "plate_pile_first_frac",
-    "goal_first_frac",
+    "modal_counter_frac",       # fraction of placements on the most-used cell; 0.0 with no placements
+    # Item-conditioned counter identity (onion vs plate-family); 0.0 when no such placements.
+    "counter_item_mi",          # Miller-Madow I(placement cell; item type) / log(min(#cells, #items))
+    "onion_counter_x",          # x of the most-used onion placement cell, / (W - 1)
+    "onion_counter_y",          # y of the most-used onion placement cell, / (H - 1)
+    "dish_counter_x",           # x of the most-used plate/soup placement cell, / (W - 1)
+    "dish_counter_y",           # y of the most-used plate/soup placement cell, / (H - 1)
     # Spatial / territorial.
     "region_NW_frac",
     "region_NE_frac",
     "region_SW_frac",
-    "region_SE_frac",
     "territory_overlap",        # Jaccard of visited tiles with the partner
     # Role specialization.
     "onion_role_frac",
-    "role_purity",
-    # Delivery tempo.
-    "deliveries_per_100_steps",
-    "mean_inter_delivery_interval",
     # Partner-relational.
     "mean_partner_distance",
     "interact_into_partner",
     "blocked_partner_steps",
+    # Layout-portable convention features.
+    "counter_item_dwell",       # median steps a tracked-agent counter drop sits before pickup, / ep_len
+    "circulation_direction",    # net signed rotation around the layout centroid, in [-1, 1]
+    # Normalized usage entropy over instances of each resource kind; 0.0 when < 2 instances or unused.
+    "pot_usage_entropy",
+    "onion_pile_usage_entropy",
+    "plate_pile_usage_entropy",
+    "goal_usage_entropy",
+    # Role composition (same denominator as onion_role_frac); 0.0 for an idle agent.
+    "pot_role_frac",            # PLACEMENT_IN_POT / n_role
+    "plating_role_frac",        # (dish pickups from D or X + SOUP_PICKUP) / n_role
+    # Station choice; 0.0 on layouts with < 2 instances of the kind or when unused.
+    "modal_pot_x",              # x of the tracked agent's most-used pot, / (W - 1)
+    "modal_pot_y",              # y of the tracked agent's most-used pot, / (H - 1)
+    "modal_onion_pile_x", "modal_onion_pile_y",
+    "modal_plate_pile_x", "modal_plate_pile_y",
+    "modal_goal_x", "modal_goal_y",
+    "pot_sharing",              # sum_i min(p_i, q_i) over pots: tracked vs partner usage distributions
+    "onion_pile_sharing",
+    "plate_pile_sharing",
+    "goal_sharing",
 ]
 
 OVERCOOKED_FEATURE_NAMES = list(OVERCOOKED_SHAPED_INFOS) + list(
     OVERCOOKED_DERIVED_FEATURE_NAMES
 )
+
+# Partner-contingent features (pd_overcooked_features.episode_contingency_features).
+OVERCOOKED_CONTINGENT_FEATURE_NAMES = [
+    "route_partner_mi",
+    "route_partner_phi",
+    "switch_encounter_lift",
+    "region_conditional_lift",
+    "yield_rate",
+]
+
+# Contention and action-MI features (pd_overcooked_features.episode_v5_features).
+OVERCOOKED_V5_FEATURE_NAMES = [
+    "contention_rate",
+    "contention_giveway_rate",
+    "anticipatory_avoid_rate",
+    "partner_block_rate",
+    "block_asymmetry",
+    "move_dir_mi",
+    "move_dir_mi_prox",
+    "move_dir_mi_lag_self",
+    "move_dir_mi_lag_partner",
+    "route_phase_mi",
+    "action_mi_all",
+    "action_mi_prox",
+]

--- a/scripts/population_diversity/pd_overcooked_features.py
+++ b/scripts/population_diversity/pd_overcooked_features.py
@@ -1,0 +1,856 @@
+"""Overcooked feature computation from recorded trajectories: per-step event counters,
+per-episode feature vectors, partner-contingent statistics, and counter-cell support."""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import jax.numpy as jnp
+import numpy as np
+
+from scripts.population_diversity.pd_events import (
+    OVERCOOKED_FEATURE_NAMES,
+    OVERCOOKED_SHAPED_INFOS,
+)
+
+_OC_UP, _OC_DOWN, _OC_RIGHT, _OC_LEFT, _OC_STAY, _OC_INTERACT = range(6)
+
+
+_OC_RESOURCE_KINDS = ("pot", "onion_pile", "plate_pile", "goal")
+
+# overcooked object codes (jaxmarl OBJECT_TO_INDEX)
+_OC_EMPTY, _OC_WALL, _OC_ONION, _OC_ONION_PILE = 1, 2, 3, 4
+_OC_PLATE, _OC_PLATE_PILE, _OC_GOAL, _OC_POT, _OC_DISH, _OC_AGENT = 5, 6, 7, 8, 9, 10
+_OC_POT_EMPTY = 23  # pot status when no onions are in the pot
+
+# DIR_TO_VEC, indexed by move action (up/down/right/left == 0/1/2/3).
+_OC_DIR_TO_VEC = ((0, -1), (0, 1), (1, 0), (-1, 0))
+
+# counter-mediated events, split into "put an item down" and "take an item back".
+_OC_PUT_ON_COUNTER = {
+    "put_onion_on_X": _OC_ONION,
+    "put_dish_on_X": _OC_PLATE,
+    "put_soup_on_X": _OC_DISH,
+}
+_OC_PICKUP_FROM_COUNTER = ("pickup_onion_from_X", "pickup_dish_from_X", "pickup_soup_from_X")
+
+_OC_ITEM_FAMILY = {_OC_ONION: 0, _OC_PLATE: 1, _OC_DISH: 1}
+_OC_MI_MIN_PLACEMENTS = 4  # below this the plug-in MI is dominated by its own bias
+
+
+@dataclass
+class OvercookedEpisodeCounts:
+    """per-episode overcooked shaped_infos event counts."""
+    counts_by_event: Dict[str, int] = field(default_factory=lambda: {ev: 0 for ev in OVERCOOKED_SHAPED_INFOS})
+    n_steps: int = 0
+    n_handoff_given: int = 0
+    n_handoff_received: int = 0
+    n_self_retrieve: int = 0
+    n_region_NW: int = 0
+    n_region_NE: int = 0
+    n_region_SW: int = 0
+    n_region_SE: int = 0
+    n_interact_into_partner: int = 0
+    n_blocked_partner: int = 0
+    partner_dist_sum: float = 0.0
+    dist_norm: int = 0  # (height + width) of the walkable grid
+    grid_h: int = 0     # height of the walkable grid (for normalizing cell positions)
+    grid_w: int = 0     # width of the walkable grid
+    dwell_steps: list = field(default_factory=list)  # sit-steps of each tracked-agent drop that got picked up
+    ang_signed_sum: float = 0.0       # signed angular displacement around the layout centroid
+    ang_abs_sum: float = 0.0
+    # per-resource-kind, per-instance usage counts by the tracked agent (kind -> pos -> uses)
+    resource_usage: Dict[str, Dict[Tuple[int, int], int]] = field(
+        default_factory=lambda: {k: {} for k in _OC_RESOURCE_KINDS}
+    )
+    # same, for the PARTNER (only used relative to the tracked agent's usage: *_sharing)
+    resource_usage_partner: Dict[str, Dict[Tuple[int, int], int]] = field(
+        default_factory=lambda: {k: {} for k in _OC_RESOURCE_KINDS}
+    )
+    counter_ledger: Dict[Tuple[int, int], Tuple[int, int, int]] = field(default_factory=dict)
+    # counter position -> number of placements by the tracked agent
+    placements_by_pos: Dict[Tuple[int, int], int] = field(default_factory=dict)
+    placements_by_pos_item: Dict[Tuple[Tuple[int, int], int], int] = field(default_factory=dict)
+    visited_self: set = field(default_factory=set)
+    visited_partner: set = field(default_factory=set)
+    # canonical (sorted by (y, x)) instance positions per resource kind, cached at step 0
+    resource_pos: Optional[Dict[str, List[Tuple[int, int]]]] = None
+    final_score: float = 0.0
+    episode_length: int = 0
+
+
+def overcooked_episode_to_vector(
+    counts: OvercookedEpisodeCounts, return_norm: float = 0.0, length_norm: float = 0.0
+) -> np.ndarray:
+    """per-episode overcooked counts to the theta contribution vector."""
+    ev = counts.counts_by_event
+    feats = [float(ev.get(name, 0)) for name in OVERCOOKED_SHAPED_INFOS]
+
+    ep_len = max(1, int(counts.n_steps) or int(counts.episode_length) or 1)
+
+    # items the tracked agent left on a counter that were never picked back up
+    dead_drop = sum(1 for placer, _item, _t in counts.counter_ledger.values() if placer == 1)
+
+    # how spread out the tracked agent's counter usage was
+    placement_counts = list(counts.placements_by_pos.values())
+    total_placements = sum(placement_counts)
+    counter_entropy = 0.0
+    if total_placements >= 2 and len(placement_counts) >= 2:
+        entropy = 0.0
+        for n in placement_counts:
+            p = n / total_placements
+            if p > 0.0:
+                entropy -= p * np.log(p)
+        counter_entropy = entropy / np.log(len(placement_counts))
+
+    modal_counter_frac = 0.0
+    if total_placements > 0:
+        modal_counter_frac = max(counts.placements_by_pos.values()) / total_placements
+
+    norm_x = max(1, (counts.grid_w or 1) - 1)
+    norm_y = max(1, (counts.grid_h or 1) - 1)
+
+    def _modal_cell(items: Tuple[int, ...]) -> Optional[Tuple[int, int]]:
+        """most-placed cell restricted to `items`; None if no such placement."""
+        agg: Dict[Tuple[int, int], int] = {}
+        for (pos, item), n in counts.placements_by_pos_item.items():
+            if item in items:
+                agg[pos] = agg.get(pos, 0) + n
+        if not agg:
+            return None
+        # tie-break on lowest (y, x)
+        return min(agg.items(), key=lambda kv: (-kv[1], kv[0][1], kv[0][0]))[0]
+
+    _ONION_ITEMS = (_OC_ONION,)
+    _DISH_ITEMS = (_OC_PLATE, _OC_DISH)  # empty plate and plated soup
+    onion_cell = _modal_cell(_ONION_ITEMS)
+    dish_cell = _modal_cell(_DISH_ITEMS)
+    onion_counter_x = float(onion_cell[0]) / norm_x if onion_cell else 0.0
+    onion_counter_y = float(onion_cell[1]) / norm_y if onion_cell else 0.0
+    dish_counter_x = float(dish_cell[0]) / norm_x if dish_cell else 0.0
+    dish_counter_y = float(dish_cell[1]) / norm_y if dish_cell else 0.0
+
+    counter_item_mi = 0.0
+    if counts.placements_by_pos_item:
+        cells = sorted({pos for pos, _ in counts.placements_by_pos_item})
+        fams = sorted({_OC_ITEM_FAMILY.get(item, 0) for _, item in counts.placements_by_pos_item})
+        n_pl = float(sum(counts.placements_by_pos_item.values()))
+        if len(cells) >= 2 and len(fams) >= 2 and n_pl >= _OC_MI_MIN_PLACEMENTS:
+            joint = np.zeros((len(cells), len(fams)), dtype=np.float64)
+            ci = {c: i for i, c in enumerate(cells)}
+            fi = {f: i for i, f in enumerate(fams)}
+            for (pos, item), n in counts.placements_by_pos_item.items():
+                joint[ci[pos], fi[_OC_ITEM_FAMILY.get(item, 0)]] += n
+
+            def _H(cnt: np.ndarray) -> float:
+                p = cnt[cnt > 0] / n_pl
+                return float(-(p * np.log(p)).sum()) + (p.size - 1) / (2.0 * n_pl)
+
+            mi = _H(joint.sum(axis=1)) + _H(joint.sum(axis=0)) - _H(joint.reshape(-1))
+            denom = np.log(min(len(cells), len(fams)))
+            counter_item_mi = float(np.clip(mi / denom, 0.0, 1.0)) if denom > 0 else 0.0
+
+    region_fracs = [
+        counts.n_region_NW / ep_len,
+        counts.n_region_NE / ep_len,
+        counts.n_region_SW / ep_len,
+    ]
+
+    union = counts.visited_self | counts.visited_partner
+    territory_overlap = (
+        len(counts.visited_self & counts.visited_partner) / len(union) if union else 0.0
+    )
+
+    n_onion = (
+        ev.get("pickup_onion_from_O", 0)
+        + ev.get("pickup_onion_from_X", 0)
+        + ev.get("put_onion_on_X", 0)
+        + ev.get("PLACEMENT_IN_POT", 0)
+    )
+    n_plate = (
+        ev.get("pickup_dish_from_D", 0)
+        + ev.get("pickup_dish_from_X", 0)
+        + ev.get("put_dish_on_X", 0)
+        + ev.get("SOUP_PICKUP", 0)
+        + ev.get("pickup_soup_from_X", 0)
+        + ev.get("put_soup_on_X", 0)
+        + ev.get("delivery", 0)
+    )
+    n_role = n_onion + n_plate
+    onion_role_frac = (n_onion / n_role) if n_role > 0 else 0.0
+    pot_role_frac = (ev.get("PLACEMENT_IN_POT", 0) / n_role) if n_role > 0 else 0.0
+    plating_role_frac = (
+        (ev.get("pickup_dish_from_D", 0) + ev.get("pickup_dish_from_X", 0)
+         + ev.get("SOUP_PICKUP", 0)) / n_role
+    ) if n_role > 0 else 0.0
+
+    mean_partner_distance = (counts.partner_dist_sum / ep_len) / max(1, counts.dist_norm)
+
+    remaining = [
+        max(0, ep_len - t) for placer, _item, t in counts.counter_ledger.values() if placer == 1
+    ]
+    dwell_all = counts.dwell_steps + remaining
+    counter_item_dwell = float(np.median(dwell_all)) / ep_len if dwell_all else 0.0
+
+    circulation_direction = (
+        counts.ang_signed_sum / counts.ang_abs_sum if counts.ang_abs_sum > 0 else 0.0
+    )
+
+    def _usage_entropy(kind: str) -> float:
+        # 0.0 when the layout has < 2 instances OR the agent never used the kind
+        positions = (counts.resource_pos or {}).get(kind, [])
+        usage = counts.resource_usage.get(kind, {})
+        total = sum(usage.values())
+        if len(positions) < 2 or total <= 0:
+            return 0.0
+        entropy = 0.0
+        for pos in positions:
+            p = usage.get(pos, 0) / total
+            if p > 0.0:
+                entropy -= p * np.log(p)
+        return entropy / np.log(len(positions))
+
+    def _usage_sharing(kind: str) -> float:
+        positions = (counts.resource_pos or {}).get(kind, [])
+        mine = counts.resource_usage.get(kind, {})
+        theirs = counts.resource_usage_partner.get(kind, {})
+        tm, tt = sum(mine.values()), sum(theirs.values())
+        if len(positions) < 2 or tm <= 0 or tt <= 0:
+            return 0.0
+        return float(sum(min(mine.get(pos, 0) / tm, theirs.get(pos, 0) / tt) for pos in positions))
+
+    def _modal_resource(kind: str) -> Tuple[float, float]:
+        positions = (counts.resource_pos or {}).get(kind, [])
+        usage = counts.resource_usage.get(kind, {})
+        if len(positions) < 2 or not usage:
+            return 0.0, 0.0
+        pos = min(usage.items(), key=lambda kv: (-kv[1], kv[0][1], kv[0][0]))[0]
+        return float(pos[0]) / norm_x, float(pos[1]) / norm_y
+
+    pot_usage_entropy = _usage_entropy("pot")
+    modal_pot_x, modal_pot_y = _modal_resource("pot")
+    modal_onion_pile_x, modal_onion_pile_y = _modal_resource("onion_pile")
+    modal_plate_pile_x, modal_plate_pile_y = _modal_resource("plate_pile")
+    modal_goal_x, modal_goal_y = _modal_resource("goal")
+    pot_sharing = _usage_sharing("pot")
+    onion_pile_sharing = _usage_sharing("onion_pile")
+    plate_pile_sharing = _usage_sharing("plate_pile")
+    goal_sharing = _usage_sharing("goal")
+    onion_pile_usage_entropy = _usage_entropy("onion_pile")
+    plate_pile_usage_entropy = _usage_entropy("plate_pile")
+    goal_usage_entropy = _usage_entropy("goal")
+
+    feats += [
+        float(counts.n_handoff_given),
+        float(counts.n_handoff_received),
+        float(dead_drop),
+        float(counts.n_self_retrieve),
+        float(counter_entropy),
+        float(modal_counter_frac),
+        float(counter_item_mi),
+        float(onion_counter_x),
+        float(onion_counter_y),
+        float(dish_counter_x),
+        float(dish_counter_y),
+        *[float(x) for x in region_fracs],
+        float(territory_overlap),
+        float(onion_role_frac),
+        float(mean_partner_distance),
+        float(counts.n_interact_into_partner),
+        float(counts.n_blocked_partner),
+        float(counter_item_dwell),
+        float(circulation_direction),
+        float(pot_usage_entropy),
+        float(onion_pile_usage_entropy),
+        float(plate_pile_usage_entropy),
+        float(goal_usage_entropy),
+        float(pot_role_frac),
+        float(plating_role_frac),
+        float(modal_pot_x),
+        float(modal_pot_y),
+        float(modal_onion_pile_x),
+        float(modal_onion_pile_y),
+        float(modal_plate_pile_x),
+        float(modal_plate_pile_y),
+        float(modal_goal_x),
+        float(modal_goal_y),
+        float(pot_sharing),
+        float(onion_pile_sharing),
+        float(plate_pile_sharing),
+        float(goal_sharing),
+    ]
+    assert len(feats) == len(OVERCOOKED_FEATURE_NAMES), (
+        f"overcooked feature vector length {len(feats)} != {len(OVERCOOKED_FEATURE_NAMES)} names"
+    )
+    return np.array(feats, dtype=np.float64)
+
+
+def _oc_scan_resources(mm: np.ndarray, pad: int, H: int, W: int) -> Dict[str, List[Tuple[int, int]]]:
+    """positions (x, y) of each static resource, in canonical (y, x)-sorted order."""
+    code_to_kind = {
+        _OC_POT: "pot",
+        _OC_ONION_PILE: "onion_pile",
+        _OC_PLATE_PILE: "plate_pile",
+        _OC_GOAL: "goal",
+    }
+    out: Dict[str, List[Tuple[int, int]]] = {k: [] for k in _OC_RESOURCE_KINDS}
+    for y in range(H):
+        for x in range(W):
+            py, px = pad + y, pad + x
+            if not (0 <= py < mm.shape[0] and 0 <= px < mm.shape[1]):
+                continue
+            kind = code_to_kind.get(int(mm[py, px, 0]))
+            if kind is not None:
+                out[kind].append((x, y))  # scanned in (y, x) order already
+    return out
+
+
+def _oc_classify_event(inv0: int, inv1: int, obj: int) -> Optional[str]:
+    """map an inventory transition + faced-cell object to a shaped_infos event name."""
+    if inv0 == inv1:
+        return None
+    if inv0 == _OC_EMPTY and inv1 == _OC_ONION:
+        return "pickup_onion_from_O" if obj == _OC_ONION_PILE else "pickup_onion_from_X"
+    if inv0 == _OC_EMPTY and inv1 == _OC_PLATE:
+        return "pickup_dish_from_D" if obj == _OC_PLATE_PILE else "pickup_dish_from_X"
+    if inv0 == _OC_EMPTY and inv1 == _OC_DISH:
+        return "pickup_soup_from_X"
+    if inv0 == _OC_PLATE and inv1 == _OC_DISH:
+        return "SOUP_PICKUP"
+    if inv0 == _OC_ONION and inv1 == _OC_EMPTY:
+        return "PLACEMENT_IN_POT" if obj == _OC_POT else "put_onion_on_X"
+    if inv0 == _OC_PLATE and inv1 == _OC_EMPTY:
+        return "put_dish_on_X"
+    if inv0 == _OC_DISH and inv1 == _OC_EMPTY:
+        return "delivery" if obj == _OC_GOAL else "put_soup_on_X"
+    return None
+
+
+def overcooked_step_update(
+    counts: OvercookedEpisodeCounts,
+    a0: int,
+    a1: int,
+    r0: float,
+    r1: float,
+    state_pre,
+    state_post,
+    info: Dict,
+) -> None:
+    """reconstruct shaped_infos events from overcooked state transitions."""
+    EMPTY, WALL, ONION, ONION_PILE, PLATE, PLATE_PILE, GOAL, POT, DISH = (
+        _OC_EMPTY, _OC_WALL, _OC_ONION, _OC_ONION_PILE, _OC_PLATE,
+        _OC_PLATE_PILE, _OC_GOAL, _OC_POT, _OC_DISH)
+    STAY_A, INTERACT_A = 4, 5
+    POT_EMPTY = _OC_POT_EMPTY
+
+    def _unwrap(s):
+        while hasattr(s, "env_state"):
+            s = s.env_state
+        return s
+
+    sp, sq = _unwrap(state_pre), _unwrap(state_post)
+    try:
+        inv_pre = np.asarray(sp.agent_inv).reshape(-1)
+        inv_post = np.asarray(sq.agent_inv).reshape(-1)
+        pos_pre = np.asarray(sp.agent_pos).reshape(-1, 2)
+        pos_post = np.asarray(sq.agent_pos).reshape(-1, 2)
+        adir = np.asarray(sp.agent_dir).reshape(-1, 2)
+        mm = np.asarray(sp.maze_map)
+        wm = np.asarray(sp.wall_map)
+    except AttributeError:
+        return  # not an overcooked state, nothing to reconstruct
+
+    pad = (mm.shape[0] - wm.shape[0]) // 2
+    ev = counts.counts_by_event
+    H, W = int(wm.shape[0]), int(wm.shape[1])
+
+    i = 1
+    action = int(a1)
+    inv0, inv1 = int(inv_pre[i]), int(inv_post[i])
+    fx = int(pos_pre[i][0] + adir[i][0])
+    fy = int(pos_pre[i][1] + adir[i][1])
+    on_grid = (0 <= fx < W) and (0 <= fy < H)
+    py, px = pad + fy, pad + fx
+    obj = int(mm[py, px, 0]) if (0 <= py < mm.shape[0] and 0 <= px < mm.shape[1]) else EMPTY
+    is_table = bool(wm[fy, fx]) if on_grid else False
+    moved = not np.array_equal(pos_pre[i], pos_post[i])
+
+    _overcooked_derived_update(
+        counts, a0, a1, inv_pre, inv_post, pos_pre, pos_post, adir, mm, pad, H, W, wm,
+    )
+
+    if inv0 != inv1:
+        # interact succeeded, classify by inventory delta + faced cell
+        if inv0 == EMPTY and inv1 == ONION:
+            ev["pickup_onion_from_O" if obj == ONION_PILE else "pickup_onion_from_X"] += 1
+        elif inv0 == EMPTY and inv1 == PLATE:
+            ev["pickup_dish_from_D" if obj == PLATE_PILE else "pickup_dish_from_X"] += 1
+        elif inv0 == EMPTY and inv1 == DISH:
+            ev["pickup_soup_from_X"] += 1
+        elif inv0 == PLATE and inv1 == DISH:
+            ev["SOUP_PICKUP"] += 1
+        elif inv0 == ONION and inv1 == EMPTY:
+            ev["PLACEMENT_IN_POT" if obj == POT else "put_onion_on_X"] += 1
+        elif inv0 == PLATE and inv1 == EMPTY:
+            ev["put_dish_on_X"] += 1
+        elif inv0 == DISH and inv1 == EMPTY:
+            ev["delivery" if obj == GOAL else "put_soup_on_X"] += 1
+    else:
+        # no inventory change, movement / stay / no-op interact
+        if action == STAY_A:
+            ev["STAY"] += 1
+        elif action == INTERACT_A:
+            if is_table and obj not in (WALL, EMPTY):
+                ev["IDLE_INTERACT_X"] += 1
+            else:
+                ev["IDLE_INTERACT_EMPTY"] += 1
+        elif moved:
+            ev["MOVEMENT"] += 1
+        else:
+            ev["IDLE_MOVEMENT"] += 1
+
+
+def _overcooked_derived_update(
+    counts: OvercookedEpisodeCounts,
+    a0: int, a1: int,
+    inv_pre: np.ndarray, inv_post: np.ndarray,
+    pos_pre: np.ndarray, pos_post: np.ndarray,
+    adir: np.ndarray, mm: np.ndarray, pad: int, H: int, W: int,
+    wm: Optional[np.ndarray] = None,
+) -> None:
+    """extended-vocabulary bookkeeping for overcooked."""
+    TRACKED, PARTNER = 1, 0
+    INTERACT_A = 5
+    actions = (int(a0), int(a1))
+
+    counts.n_steps += 1
+    step_idx = counts.n_steps - 1
+    counts.dist_norm = H + W
+    counts.grid_h, counts.grid_w = H, W
+
+    if counts.resource_pos is None:
+        counts.resource_pos = _oc_scan_resources(mm, pad, H, W)
+
+    faced: List[Tuple[int, int, int]] = []
+    for j in (0, 1):
+        fx = int(pos_pre[j][0] + adir[j][0])
+        fy = int(pos_pre[j][1] + adir[j][1])
+        py, px = pad + fy, pad + fx
+        if 0 <= py < mm.shape[0] and 0 <= px < mm.shape[1]:
+            obj = int(mm[py, px, 0])
+        else:
+            obj = _OC_EMPTY
+        faced.append((fx, fy, obj))
+
+    events = [
+        _oc_classify_event(int(inv_pre[j]), int(inv_post[j]), faced[j][2]) for j in (0, 1)
+    ]
+
+    for j in (0, 1):
+        if events[j] not in _OC_PICKUP_FROM_COUNTER:
+            continue
+        entry = counts.counter_ledger.pop((faced[j][0], faced[j][1]), None)
+        if entry is None:
+            continue  # item wasn't placed by either agent this episode
+        placer = entry[0]
+        if placer == TRACKED:
+            # dwell time of a tracked-agent drop, resolved at pickup (by either agent)
+            counts.dwell_steps.append(max(0, step_idx - entry[2]))
+        if j == TRACKED:
+            if placer == PARTNER:
+                counts.n_handoff_received += 1
+            else:
+                counts.n_self_retrieve += 1
+        elif placer == TRACKED:
+            counts.n_handoff_given += 1
+
+    for j in (0, 1):
+        item = _OC_PUT_ON_COUNTER.get(events[j] or "")
+        if item is None:
+            continue
+        pos = (faced[j][0], faced[j][1])
+        counts.counter_ledger[pos] = (j, item, step_idx)
+        if j == TRACKED:
+            counts.placements_by_pos[pos] = counts.placements_by_pos.get(pos, 0) + 1
+            key = (pos, int(item))
+            counts.placements_by_pos_item[key] = counts.placements_by_pos_item.get(key, 0) + 1
+
+    event_to_resource = {
+        "PLACEMENT_IN_POT": "pot",
+        "SOUP_PICKUP": "pot",
+        "pickup_onion_from_O": "onion_pile",
+        "pickup_dish_from_D": "plate_pile",
+        "delivery": "goal",
+    }
+    for j, store in ((TRACKED, counts.resource_usage), (1 - TRACKED, counts.resource_usage_partner)):
+        kind = event_to_resource.get(events[j] or "")
+        if kind is not None:
+            positions = counts.resource_pos.get(kind, [])
+            used = (faced[j][0], faced[j][1])
+            if used in positions:
+                kind_usage = store.setdefault(kind, {})
+                kind_usage[used] = kind_usage.get(used, 0) + 1
+
+    sx, sy = int(pos_pre[TRACKED][0]), int(pos_pre[TRACKED][1])
+    mid_x, mid_y = W / 2.0, H / 2.0
+    if sy < mid_y and sx < mid_x:
+        counts.n_region_NW += 1
+    elif sy < mid_y:
+        counts.n_region_NE += 1
+    elif sx < mid_x:
+        counts.n_region_SW += 1
+    else:
+        counts.n_region_SE += 1
+
+    counts.visited_self.add((sx, sy))
+    counts.visited_self.add((int(pos_post[TRACKED][0]), int(pos_post[TRACKED][1])))
+    counts.visited_partner.add((int(pos_pre[PARTNER][0]), int(pos_pre[PARTNER][1])))
+    counts.visited_partner.add((int(pos_post[PARTNER][0]), int(pos_post[PARTNER][1])))
+
+    counts.partner_dist_sum += abs(sx - int(pos_pre[PARTNER][0])) + abs(
+        sy - int(pos_pre[PARTNER][1])
+    )
+
+    if actions[TRACKED] == INTERACT_A and faced[TRACKED][2] == _OC_AGENT:
+        counts.n_interact_into_partner += 1
+
+    partner_action = actions[PARTNER]
+    if 0 <= partner_action < len(_OC_DIR_TO_VEC) and np.array_equal(
+        pos_pre[PARTNER], pos_post[PARTNER]
+    ):
+        dx, dy = _OC_DIR_TO_VEC[partner_action]
+        target = (int(pos_pre[PARTNER][0]) + dx, int(pos_pre[PARTNER][1]) + dy)
+        if (sx, sy) == target:
+            counts.n_blocked_partner += 1
+
+    cx0, cy0 = (W - 1) / 2.0, (H - 1) / 2.0
+    ex, ey = int(pos_post[TRACKED][0]), int(pos_post[TRACKED][1])
+    if (sx, sy) != (ex, ey):
+        v_pre = (sx - cx0, sy - cy0)
+        v_post = (ex - cx0, ey - cy0)
+        if (v_pre != (0.0, 0.0)) and (v_post != (0.0, 0.0)):
+            da = float(np.arctan2(v_post[1], v_post[0]) - np.arctan2(v_pre[1], v_pre[0]))
+            if da > np.pi:
+                da -= 2.0 * np.pi
+            elif da < -np.pi:
+                da += 2.0 * np.pi
+            if da != 0.0:
+                counts.ang_signed_sum += da
+                counts.ang_abs_sum += abs(da)
+
+
+
+USED_CELL_MIN_FRAC = 0.05
+
+
+def _episode_modal_cell(placements_by_pos_item, items):
+    agg: Dict[Tuple[int, int], int] = {}
+    for (pos, item), n in placements_by_pos_item.items():
+        if items is None or item in items:
+            agg[pos] = agg.get(pos, 0) + n
+    if not agg:
+        return None
+    return min(agg.items(), key=lambda kv: (-kv[1], kv[0][1], kv[0][0]))[0]
+
+
+def overcooked_cell_support(ep_counts: List[OvercookedEpisodeCounts]) -> Dict[str, Any]:
+    """Per-teammate modal placement cell (all items / onions / plates) and the set of."""
+    subsets = {"all": None, "onion": (_OC_ONION,), "dish": (_OC_PLATE, _OC_DISH)}
+    row: Dict[str, Any] = {"n_episodes": len(ep_counts)}
+    for name, items in subsets.items():
+        cells = [c for c in (_episode_modal_cell(ep.placements_by_pos_item, items) for ep in ep_counts)
+                 if c is not None]
+        if cells:
+            cell, n_modal = Counter(cells).most_common(1)[0]
+            row[f"modal_{name}_x"], row[f"modal_{name}_y"] = int(cell[0]), int(cell[1])
+            row[f"modal_{name}_frac"] = float(n_modal) / len(cells)
+            row[f"modal_{name}_n_distinct_ep"] = int(len(set(cells)))
+        else:
+            row[f"modal_{name}_x"] = row[f"modal_{name}_y"] = -1
+            row[f"modal_{name}_frac"] = 0.0
+            row[f"modal_{name}_n_distinct_ep"] = 0
+    pooled: Dict[Tuple[int, int], int] = {}
+    for ep in ep_counts:
+        for (pos, _item), n in ep.placements_by_pos_item.items():
+            pooled[pos] = pooled.get(pos, 0) + n
+    tot = float(sum(pooled.values()))
+    used = {pos for pos, n in pooled.items() if tot > 0 and n / tot >= USED_CELL_MIN_FRAC}
+    row["used_all_x"] = "|".join(str(v) for v in sorted({p[0] for p in used}))
+    row["used_all_y"] = "|".join(str(v) for v in sorted({p[1] for p in used}))
+    return row
+
+
+_MIN_SAMPLES = 20
+# Manhattan distance at which the two agents count as "in an encounter".
+_CLOSE_DIST = 2
+# Reaction window (steps) for attributing a direction switch to an encounter.
+_REACT_WINDOW = 3
+
+
+
+def _wrap_pi(a: np.ndarray) -> np.ndarray:
+    return (a + np.pi) % (2.0 * np.pi) - np.pi
+
+
+def _step_directions(pos_pre: np.ndarray, pos_post: np.ndarray, cx: float, cy: float
+                     ) -> Tuple[np.ndarray, np.ndarray]:
+    """Per-step signed circulation direction around the layout centroid."""
+    v_pre = pos_pre.astype(np.float64) - np.array([cx, cy])
+    v_post = pos_post.astype(np.float64) - np.array([cx, cy])
+    moved = np.any(pos_pre != pos_post, axis=-1)
+    nonzero = (np.abs(v_pre).sum(-1) > 0) & (np.abs(v_post).sum(-1) > 0)
+    da = _wrap_pi(np.arctan2(v_post[:, 1], v_post[:, 0]) - np.arctan2(v_pre[:, 1], v_pre[:, 0]))
+    valid = moved & nonzero & (da != 0.0)
+    return np.sign(da), valid
+
+
+def _mi_normalized(x: np.ndarray, y: np.ndarray) -> float:
+    """Miller-Madow-corrected I(x; y) / H(x) for two binary variables, in [0, 1]."""
+    n = x.size
+    if n < _MIN_SAMPLES:
+        return 0.0
+    xs, ys = np.unique(x), np.unique(y)
+    if xs.size < 2 or ys.size < 2:
+        return 0.0  # one of the variables is constant -> no information to share
+
+    def _H(counts: np.ndarray) -> float:
+        p = counts[counts > 0] / n
+        h = float(-(p * np.log(p)).sum())
+        return h + (p.size - 1) / (2.0 * n)  # Miller-Madow
+
+    joint = np.array([[np.sum((x == a) & (y == b)) for b in ys] for a in xs], dtype=np.float64)
+    h_x = _H(joint.sum(axis=1))
+    h_y = _H(joint.sum(axis=0))
+    h_xy = _H(joint.reshape(-1))
+    if h_x <= 0.0:
+        return 0.0
+    return float(np.clip((h_x + h_y - h_xy) / h_x, 0.0, 1.0))
+
+
+def _phi(x: np.ndarray, y: np.ndarray) -> float:
+    """Pearson correlation of two +-1 variables (the signed twin of the MI)."""
+    if x.size < _MIN_SAMPLES or x.std() == 0.0 or y.std() == 0.0:
+        return 0.0
+    return float(np.clip(np.corrcoef(x, y)[0, 1], -1.0, 1.0))
+
+
+def episode_contingency_features(ep) -> np.ndarray:
+    """Compute the partner-contingent block for one CachedEpisode."""
+    TRACKED, PARTNER = 1, 0
+    T = len(ep)
+    H, W = ep.H, ep.W
+    cx, cy = (W - 1) / 2.0, (H - 1) / 2.0
+
+    s_pre = ep.pos_pre[:, TRACKED, :]
+    s_post = ep.pos_post[:, TRACKED, :]
+    p_pre = ep.pos_pre[:, PARTNER, :]
+    p_post = ep.pos_post[:, PARTNER, :]
+
+    d_self, v_self = _step_directions(s_pre, s_post, cx, cy)
+    d_part, v_part = _step_directions(p_pre, p_post, cx, cy)
+
+    a_self = np.arctan2(s_pre[:, 1] - cy, s_pre[:, 0] - cx)
+    a_part = np.arctan2(p_pre[:, 1] - cy, p_pre[:, 0] - cx)
+    r_self = np.abs(s_pre - np.array([cx, cy])).sum(-1)
+    r_part = np.abs(p_pre - np.array([cx, cy])).sum(-1)
+    dphi = _wrap_pi(a_part - a_self)
+    v_bear = (r_self > 0) & (r_part > 0) & (dphi != 0.0)
+    bearing = np.sign(dphi)
+
+    m = v_self & v_bear
+    route_partner_mi = _mi_normalized(d_self[m], bearing[m])
+    route_partner_phi = _phi(d_self[m], bearing[m])
+
+    dist = np.abs(s_pre - p_pre).sum(-1)
+    close = dist <= _CLOSE_DIST
+
+    idx = np.flatnonzero(v_self)
+    switch_encounter_lift = 0.0
+    if idx.size >= _MIN_SAMPLES:
+        later = idx[1:]
+        switched = (d_self[idx][1:] != d_self[idx][:-1]).astype(np.float64)
+        # was there a close approach in the _REACT_WINDOW steps before `later`?
+        cum = np.concatenate([[0], np.cumsum(close.astype(np.int64))])
+        lo = np.maximum(0, later - _REACT_WINDOW)
+        recent = (cum[later] - cum[lo]) > 0
+        if recent.any() and (~recent).any():
+            switch_encounter_lift = float(switched[recent].mean() - switched.mean())
+
+    right = s_pre[:, 0] > cx
+    p_right = p_pre[:, 0] > cx
+    region_conditional_lift = 0.0
+    if p_right.sum() >= _MIN_SAMPLES and T > 0:
+        region_conditional_lift = float(right[p_right].mean() - right.mean())
+
+    yield_rate = 0.0
+    starts = np.flatnonzero(close & ~np.concatenate([[False], close[:-1]]))
+    if starts.size:
+        n_self = n_part = 0
+        for t0 in starts:
+            t1 = min(T, t0 + _REACT_WINDOW + 1)
+            rs = _reversed_in(d_self, v_self, t0, t1)
+            rp = _reversed_in(d_part, v_part, t0, t1)
+            if rs and not rp:
+                n_self += 1
+            elif rp and not rs:
+                n_part += 1
+        if n_self + n_part > 0:
+            yield_rate = n_self / (n_self + n_part)
+
+    return np.array([
+        route_partner_mi,
+        route_partner_phi,
+        switch_encounter_lift,
+        region_conditional_lift,
+        yield_rate,
+    ], dtype=np.float64)
+
+
+def _reversed_in(d: np.ndarray, valid: np.ndarray, t0: int, t1: int) -> bool:
+    """Did the direction sequence flip sign inside [t0, t1)?."""
+    seq = d[t0:t1][valid[t0:t1]]
+    return bool(seq.size >= 2 and np.any(seq[1:] != seq[:-1]))
+
+
+_PHASE_WINDOW = 15
+# Circular shifts used to build the null for the MI excess statistics.
+_NULL_SHIFTS = (53, 101, 157, 211, 277)
+# Steps allowed for a contention to resolve / for an anticipatory reroute.
+_RESOLVE_WINDOW = 5
+_ANTICIPATE_WINDOW = 3
+# Ring separation at or below which a step counts as "proximate".
+_PROX_SEP = 2
+# Overcooked move actions (up/down/right/left); 4 = stay, 5 = interact.
+_MOVE_ACTIONS = (0, 1, 2, 3)
+_N_ACTIONS = 6
+
+
+
+
+def _portable_steps(ep, cx: float, cy: float):
+    """Layout-portable stand-ins for the ring bookkeeping."""
+    TRACKED, PARTNER = 1, 0
+    d_s, v_s = _step_directions(ep.pos_pre[:, TRACKED], ep.pos_post[:, TRACKED], cx, cy)
+    d_p, v_p = _step_directions(ep.pos_pre[:, PARTNER], ep.pos_post[:, PARTNER], cx, cy)
+    s = np.where(v_s, d_s, 0).astype(np.int64)
+    p = np.where(v_p, d_p, 0).astype(np.int64)
+    a = ep.pos_pre[:, TRACKED].astype(np.float64)
+    b = ep.pos_pre[:, PARTNER].astype(np.float64)
+    absep = np.abs(a - b).sum(axis=-1)
+    ang_a = np.arctan2(a[:, 1] - cy, a[:, 0] - cx)
+    ang_b = np.arctan2(b[:, 1] - cy, b[:, 0] - cx)
+    dang = _wrap_pi(ang_b - ang_a)
+    sep_signed = np.sign(dang).astype(np.int64)
+    sep_signed[absep == 0] = 0
+    return s, p, sep_signed, absep
+
+
+def _mi_maxnorm(x: np.ndarray, y: np.ndarray, k: int) -> float:
+    """Miller-Madow-corrected I(x; y) divided by log(k), the max entropy."""
+    n = x.size
+    if n < _MIN_SAMPLES:
+        return 0.0
+    xs, ys = np.unique(x), np.unique(y)
+    if xs.size < 2 or ys.size < 2:
+        return 0.0
+
+    def _H(counts: np.ndarray) -> float:
+        p = counts[counts > 0] / n
+        return float(-(p * np.log(p)).sum()) + (p.size - 1) / (2.0 * n)
+
+    joint = np.array([[np.sum((x == a) & (y == b)) for b in ys] for a in xs], dtype=np.float64)
+    mi = _H(joint.sum(axis=1)) + _H(joint.sum(axis=0)) - _H(joint.reshape(-1))
+    return float(mi / np.log(k))
+
+
+def _mi_excess(x: np.ndarray, y: np.ndarray, k: int) -> float:
+    """`_mi_maxnorm` minus its circular-shift null, clipped to [0, 1]."""
+    if x.size < _MIN_SAMPLES:
+        return 0.0
+    obs = _mi_maxnorm(x, y, k)
+    null = float(np.mean([_mi_maxnorm(x, np.roll(y, s), k) for s in _NULL_SHIFTS]))
+    return float(np.clip(obs - null, 0.0, 1.0))
+
+
+def episode_v5_features(ep) -> np.ndarray:
+    """Contention (Task A) + action-action MI (Task B) block for one CachedEpisode."""
+    TRACKED, PARTNER = 1, 0
+    T = len(ep)
+    cx, cy = (ep.W - 1) / 2.0, (ep.H - 1) / 2.0
+    s, p, sep, absep = _portable_steps(ep, cx, cy)   # rotational sense / Manhattan sep
+    act_s, act_p = ep.act[:, TRACKED].astype(np.int64), ep.act[:, PARTNER].astype(np.int64)
+
+    opposed = (s != 0) & (p != 0) & (s != p)
+    # The agent is moving along the arc towards the partner (shrinking it).
+    closing = opposed & (sep != 0) & (np.sign(s) == np.sign(sep)) & (absep <= 3)
+    contention_rate = float(closing.mean()) if T else 0.0
+
+    onsets = np.flatnonzero(closing & ~np.concatenate([[False], closing[:-1]]))
+    n_self = n_part = 0
+    for t0 in onsets:
+        d0s, d0p = s[t0], p[t0]
+        t_s = t_p = None
+        for t in range(t0 + 1, min(T, t0 + _RESOLVE_WINDOW + 1)):
+            if t_s is None and s[t] == -d0s:
+                t_s = t
+            if t_p is None and p[t] == -d0p:
+                t_p = t
+        if t_s is not None and (t_p is None or t_s < t_p):
+            n_self += 1
+        elif t_p is not None:
+            n_part += 1
+    contention_giveway_rate = n_self / (n_self + n_part) if (n_self + n_part) else 0.0
+
+    # Anticipatory: partner closing from >= 3 cells away, agent still opposed.
+    approach = ((p != 0) & (np.sign(p) == -np.sign(sep)) & (sep != 0)
+                & (absep >= 3) & (s != 0) & (s != p))
+    ai = np.flatnonzero(approach)
+    n_rev = 0
+    for t0 in ai:
+        if any(s[t] == -s[t0] for t in range(t0 + 1, min(T, t0 + _ANTICIPATE_WINDOW + 1))):
+            n_rev += 1
+    anticipatory_avoid_rate = n_rev / ai.size if ai.size else 0.0
+
+    adjacent = absep == 1
+    blocked_self = np.isin(act_s, _MOVE_ACTIONS) & (s == 0) & adjacent
+    blocked_part = np.isin(act_p, _MOVE_ACTIONS) & (p == 0) & adjacent
+    partner_block_rate = float(blocked_self.mean()) if T else 0.0
+    block_asymmetry = float(blocked_part.mean() - blocked_self.mean()) if T else 0.0
+
+    both = (s != 0) & (p != 0)
+    move_dir_mi = _mi_excess(s[both], p[both], 2)
+    prox = both & (absep <= _PROX_SEP)
+    move_dir_mi_prox = _mi_excess(s[prox], p[prox], 2)
+
+    lag_s = (s[1:] != 0) & (p[:-1] != 0)
+    move_dir_mi_lag_self = _mi_excess(s[1:][lag_s], p[:-1][lag_s], 2)
+    lag_p = (p[1:] != 0) & (s[:-1] != 0)
+    move_dir_mi_lag_partner = _mi_excess(p[1:][lag_p], s[:-1][lag_p], 2)
+
+    route_phase_mi = 0.0
+    if T >= _PHASE_WINDOW:
+        kern = np.ones(_PHASE_WINDOW)
+        ph_s = np.sign(np.convolve(s, kern, "valid"))
+        ph_p = np.sign(np.convolve(p, kern, "valid"))
+        q = (ph_s != 0) & (ph_p != 0)
+        route_phase_mi = _mi_excess(ph_s[q], ph_p[q], 2)
+
+    action_mi_all = _mi_excess(act_s, act_p, _N_ACTIONS)
+    pa = absep <= _PROX_SEP
+    action_mi_prox = _mi_excess(act_s[pa], act_p[pa], _N_ACTIONS)
+
+    return np.array([
+        contention_rate,
+        contention_giveway_rate,
+        anticipatory_avoid_rate,
+        partner_block_rate,
+        block_asymmetry,
+        move_dir_mi,
+        move_dir_mi_prox,
+        move_dir_mi_lag_self,
+        move_dir_mi_lag_partner,
+        route_phase_mi,
+        action_mi_all,
+        action_mi_prox,
+    ], dtype=np.float64)

--- a/scripts/population_diversity/pd_rollouts.py
+++ b/scripts/population_diversity/pd_rollouts.py
@@ -1,4 +1,4 @@
-# per-env rollout loops, episode-event counters, and BR loading.
+"""Population-diversity rollouts: rollout loops, LBF episode counters, policy loading."""
 from __future__ import annotations
 
 import logging
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+
 import numpy as np
 
 from scripts.population_diversity.pd_events import (
@@ -17,13 +18,11 @@ from scripts.population_diversity.pd_events import (
     hanabi_feature_names,
     HANABI_FEATURE_NAMES,
     LBF_FEATURE_NAMES,
-    OVERCOOKED_SHAPED_INFOS,
-    OVERCOOKED_FEATURE_NAMES,
 )
 
 log = logging.getLogger("compute_pd")
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def _unwrap_hanabi_state(env_state):
     s = env_state
@@ -440,7 +439,6 @@ class LBFEpisodeCounts:
     n_state_partner_adjacent: int = 0  # Manhattan distance == 1
     n_state_partner_mid: int = 0       # Manhattan distance 2-3
     n_state_partner_far: int = 0       # Manhattan distance > 3
-    # wider vocab additions (D=13 -> D=28) to push above heldout N
     n_wait_for_partner: int = 0
     n_target_conflict: int = 0
     n_solo_attempt_lvl_2: int = 0
@@ -468,11 +466,6 @@ class LBFEpisodeCounts:
     wait_run_cur: int = 0                # length of the run currently in progress
     path_eff_sum: float = 0.0
     path_eff_count: int = 0
-    # --- sabotage vocabulary (LBF force_coop: every fruit needs BOTH agents) ---
-    # "Join opportunity": the partner is adjacent to a fruit it CANNOT load alone, and
-    # the tracked agent is not adjacent to that fruit. The cooperative act is to close
-    # distance to it; declining is the LBF form of sabotage (refusing to approach an
-    # apple a teammate is standing at).
     n_join_opportunity: int = 0          # steps presenting such an opportunity
     n_decline_to_join: int = 0           # ... where the agent did NOT reduce its distance
     n_abandon_partner: int = 0           # ... where it strictly INCREASED its distance
@@ -480,7 +473,6 @@ class LBFEpisodeCounts:
     join_latency_count: int = 0          # number of resolved arrival episodes
     # (row, col) -> step at which the partner first became adjacent while self was not
     pending_join: Dict[Tuple[int, int], int] = field(default_factory=dict)
-    # --- non-feature bookkeeping (episode-level state carried across steps) ---
     visited_self: set = field(default_factory=set)
     visited_partner: set = field(default_factory=set)
     # (row, col) -> {agent_idx: first step index at which that agent was adjacent}
@@ -495,7 +487,6 @@ def lbf_episode_to_vector(counts: LBFEpisodeCounts, return_norm: float = 0.0, le
     """per-episode lbf counts to the theta contribution vector."""
     ep_len = max(1, int(counts.n_steps) or int(counts.episode_length) or 1)
 
-    # relative-position fractions
     rel_north = counts.n_rel_north / ep_len
     rel_south = counts.n_rel_south / ep_len
     rel_east = counts.n_rel_east / ep_len
@@ -519,9 +510,6 @@ def lbf_episode_to_vector(counts: LBFEpisodeCounts, return_norm: float = 0.0, le
     n_loads = counts.n_successful_load_alone + counts.n_successful_load_cooperative
     steps_per_load = ep_len / max(1, n_loads)
 
-    # sabotage rates: conditioned on an actual join opportunity existing, so they are
-    # not diluted by steps where there was nothing cooperative to do. 0.0 when the
-    # opportunity never arose (distinct from "declined every time", which is 1.0).
     decline_to_join_rate = (
         counts.n_decline_to_join / counts.n_join_opportunity
         if counts.n_join_opportunity > 0 else 0.0
@@ -617,6 +605,7 @@ def rollout_two_policy(
     counts_factory,
     feature_update,
     max_steps: int = 200,
+    recorder=None,
 ) -> List[Any]:
     """sequential rollout with two distinct policies, one per agent."""
     init_done = {k: jnp.zeros((1), dtype=bool) for k in env.agents + ["__all__"]}
@@ -676,6 +665,8 @@ def rollout_two_policy(
             # on the last step, use the true post-step state, not the auto-reset
             state_post = _true_post_state(env, env_state_pre, env_act, step_rng) if bool(done["__all__"]) else env_state
             feature_update(counts, act_0, act_1, r0, r1, env_state_pre, state_post, info)
+            if recorder is not None:
+                recorder.record_step(env_state_pre, state_post, act_0, act_1, r0, r1)
             episode_return += r0
             done_prev = done
 
@@ -684,6 +675,8 @@ def rollout_two_policy(
 
         counts.final_score = episode_return
         counts.episode_length = step_i + 1
+        if recorder is not None:
+            recorder.end_episode()
         results.append(counts)
 
     return results
@@ -698,6 +691,7 @@ def rollout_simple_self_play(
     feature_update,
     max_steps: int = 200,
     params=None,
+    recorder=None,
 ) -> List[Any]:
     """sequential self-play rollout for envs whose policies don't need aux_obs."""
     init_done = {k: jnp.zeros((1), dtype=bool) for k in env.agents + ["__all__"]}
@@ -757,6 +751,8 @@ def rollout_simple_self_play(
             # on the last step, use the true post-step state, not the auto-reset
             state_post = _true_post_state(env, env_state_pre, env_act, step_rng) if bool(done["__all__"]) else env_state
             feature_update(counts, act_0, act_1, r0, r1, env_state_pre, state_post, info)
+            if recorder is not None:
+                recorder.record_step(env_state_pre, state_post, act_0, act_1, r0, r1)
             episode_return += r0
             done_prev = done
 
@@ -765,6 +761,8 @@ def rollout_simple_self_play(
 
         counts.final_score = episode_return
         counts.episode_length = step_i + 1
+        if recorder is not None:
+            recorder.end_episode()
         results.append(counts)
 
     return results
@@ -787,7 +785,7 @@ def _lbf_agent_positions(state) -> Tuple[Tuple[int, int], Tuple[int, int]]:
 def _lbf_food_positions(state) -> List[Tuple[int, int, int]]:
     """(row, col, level) for foods still uneaten."""
     s = _lbf_unwrap(state)
-    # chex dataclasses are always truthy, so guard with `is not None` not `or` in case a fork stores an empty/None placeholder
+    # chex dataclasses are always truthy; guard with `is not None`
     food = getattr(s, "food_items", None)
     if food is None:
         food = getattr(s, "food", None)
@@ -824,19 +822,12 @@ def lbf_step_update(
     info: Dict,
     horizon: int = 100,
 ) -> None:
-    """update lbf event counts for the teammate being characterized (agent_1).
-
-    agent_1 is the teammate whose behaviour we are describing; agent_0 is its
-    paired best response (or, in self-play, a copy of the same policy). This
-    intentionally differs from ZSC-Eval, which attributes theta to the BR.
-    """
+    """update lbf event counts for the teammate being characterized (agent_1)."""
     pre_pos = _lbf_agent_positions(state_pre)
     post_pos = _lbf_agent_positions(state_post)
     foods_pre = _lbf_food_positions(state_pre)
     foods_post = _lbf_food_positions(state_post)
 
-    # Tracked teammate is agent_1; its partner (the paired BR) is agent_0.
-    # Local names kept as `br_*` for continuity with the rest of this function.
     br_pre = pre_pos[1]
     br_post = post_pos[1]
     partner_pre = pre_pos[0]
@@ -873,9 +864,6 @@ def lbf_step_update(
     counts.visited_self.add(br_post)
     counts.visited_partner.add(post_pos[0])
 
-    # first-arrival bookkeeping: earliest step at which each agent stood adjacent
-    # to each (still uneaten) fruit. `cur_step` may be -1 if unreadable; fall back
-    # to our own step counter so ordering is still well defined.
     order_idx = cur_step if cur_step >= 0 else counts.n_steps - 1
     for (r, c, _lvl) in foods_pre:
         key = (r, c)
@@ -885,8 +873,6 @@ def lbf_step_update(
         if abs(partner_pre[0] - r) + abs(partner_pre[1] - c) == 1 and 0 not in slot:
             slot[0] = order_idx
 
-    # cooperative loads: same definition as n_successful_load_cooperative below
-    # (tracked agent took LOAD, fruit vanished, both agents adjacent to it).
     if br_action == _LBF_LOAD:
         for (r, c, _lvl) in eaten_ext:
             if abs(br_pre[0] - r) + abs(br_pre[1] - c) != 1:
@@ -935,7 +921,7 @@ def lbf_step_update(
     else:
         counts.n_state_partner_far += 1
 
-    # per-fruit-level load: a fruit eaten this step is a LOAD for the BR only if the BR was adjacent and took LOAD; compare uneaten foods pre vs post
+    # per-fruit-level load: credited to the BR only if adjacent and took LOAD
     pre_food_set = {(r, c, lvl) for (r, c, lvl) in foods_pre}
     post_food_set = {(r, c, lvl) for (r, c, lvl) in foods_post}
     eaten_this_step = pre_food_set - post_food_set
@@ -976,13 +962,6 @@ def lbf_step_update(
     action = br_action
     reward = br_reward
 
-    # --- sabotage detection: declining to join a partner waiting at a fruit ---
-    # Under force_coop every fruit needs BOTH agents, so a partner standing adjacent to
-    # an uneaten fruit is stuck until the tracked agent arrives. Cooperating = reducing
-    # distance to THAT fruit; not doing so is the LBF sabotage signature. We evaluate
-    # this regardless of action type (a refusal can be a noop, a move away, or a
-    # pointless LOAD elsewhere), and we key on the specific fruit the partner is at,
-    # not the nearest fruit -- otherwise walking toward a different fruit masks it.
     join_targets = [
         (r, c) for (r, c, _lvl) in foods_pre
         if abs(partner_pre[0] - r) + abs(partner_pre[1] - c) == 1
@@ -1014,7 +993,7 @@ def lbf_step_update(
             counts.join_latency_sum += max(0, cur_step - counts.pending_join.pop(key))
             counts.join_latency_count += 1
 
-    # BR's starting quadrant this step; infer grid size from the max coord across both agents (avoids needing env_kwargs)
+    # BR's starting quadrant; grid size inferred from the max coord of both agents
     gs_proxy = max(my_pre[0], my_pre[1], partner_pre[0], partner_pre[1], 6) + 1
     mid = gs_proxy / 2.0
     if my_pre[0] < mid and my_pre[1] < mid:
@@ -1031,7 +1010,7 @@ def lbf_step_update(
         # subcategory: noop while fruit visible
         if len(foods_pre) > 0:
             counts.n_noop_when_food_visible += 1
-        # wait_for_partner: BR adjacent to a fruit, partner not adjacent to any fruit, and BR held position
+        # wait_for_partner: BR adjacent to a fruit, partner not, BR held position
         i_adjacent = any(
             abs(my_pre[0] - r) + abs(my_pre[1] - c) == 1 for (r, c, _) in foods_pre
         )
@@ -1043,8 +1022,6 @@ def lbf_step_update(
         return
 
     if action == _LBF_LOAD:
-        # classify the LOAD by fruit-adjacency, not BR-partner adjacency (LBF force_coop keeps both ~2 apart, never adjacent)
-        # coop = BR + partner both adjacent to the eaten fruit; alone = only BR adjacent; failed = ate nothing adjacent
         ate_with_partner = False  # BR ate a fruit and partner was adjacent to it
         ate_alone = False         # BR ate a fruit and partner was not adjacent
         for (r, c, lvl) in eaten_this_step:
@@ -1056,7 +1033,7 @@ def lbf_step_update(
             else:
                 ate_alone = True
 
-        # solo attempts at high-level fruits: BR adjacent to a lvl-2/3 fruit, took LOAD, partner not adjacent (eaten or not)
+        # solo attempt: BR adjacent to a lvl-2/3 fruit, took LOAD, partner not adjacent
         for (r, c, lvl) in foods_pre:
             if abs(my_pre[0] - r) + abs(my_pre[1] - c) != 1:
                 continue  # BR not adjacent to this fruit
@@ -1069,7 +1046,7 @@ def lbf_step_update(
                 counts.n_solo_attempt_lvl_3 += 1
 
         if ate_with_partner or ate_alone:
-            # early/late game (100-step LBF horizon); cur_step < 0 means step index unreadable, skip tempo binning
+            # cur_step < 0 means the step index is unreadable; skip tempo binning
             if 0 <= cur_step < early_thresh:
                 counts.n_early_game_load += 1
             elif cur_step >= late_thresh:
@@ -1082,7 +1059,6 @@ def lbf_step_update(
             counts.n_failed_load += 1
         return
 
-    # movement actions: N/S/E/W
     if action in (_LBF_N, _LBF_S, _LBF_E, _LBF_W):
         # collision: move attempted but position didn't change (likely partner-blocked)
         if my_pre == my_post:
@@ -1097,429 +1073,6 @@ def lbf_step_update(
             counts.n_retreat_from_fruit += 1
 
 
-
-
-# Overcooked action layout (JaxMARL Actions enum: up/down/right/left/stay/interact).
-# NOTE: right precedes left, and stay precedes interact -- do not "fix" this to
-# alphabetical/intuitive order. See jaxmarl/environments/overcooked/overcooked.py.
-_OC_UP, _OC_DOWN, _OC_RIGHT, _OC_LEFT, _OC_STAY, _OC_INTERACT = range(6)
-
-
-_OC_RESOURCE_KINDS = ("pot", "onion_pile", "plate_pile", "goal")
-
-# overcooked object codes (jaxmarl OBJECT_TO_INDEX)
-_OC_EMPTY, _OC_WALL, _OC_ONION, _OC_ONION_PILE = 1, 2, 3, 4
-_OC_PLATE, _OC_PLATE_PILE, _OC_GOAL, _OC_POT, _OC_DISH, _OC_AGENT = 5, 6, 7, 8, 9, 10
-_OC_POT_EMPTY = 23  # pot status when no onions are in the pot
-
-# DIR_TO_VEC, indexed by move action (up/down/right/left == 0/1/2/3).
-_OC_DIR_TO_VEC = ((0, -1), (0, 1), (1, 0), (-1, 0))
-
-# counter-mediated events, split into "put an item down" and "take an item back".
-_OC_PUT_ON_COUNTER = {
-    "put_onion_on_X": _OC_ONION,
-    "put_dish_on_X": _OC_PLATE,
-    "put_soup_on_X": _OC_DISH,
-}
-_OC_PICKUP_FROM_COUNTER = ("pickup_onion_from_X", "pickup_dish_from_X", "pickup_soup_from_X")
-
-
-@dataclass
-class OvercookedEpisodeCounts:
-    """per-episode overcooked shaped_infos event counts."""
-    counts_by_event: Dict[str, int] = field(default_factory=lambda: {ev: 0 for ev in OVERCOOKED_SHAPED_INFOS})
-    # --- derived vocabulary: raw accumulators ---
-    n_steps: int = 0
-    n_handoff_given: int = 0
-    n_handoff_received: int = 0
-    n_self_retrieve: int = 0
-    n_region_NW: int = 0
-    n_region_NE: int = 0
-    n_region_SW: int = 0
-    n_region_SE: int = 0
-    n_interact_into_partner: int = 0
-    n_blocked_partner: int = 0
-    partner_dist_sum: float = 0.0
-    dist_norm: int = 0  # (height + width) of the walkable grid
-    # per-resource-kind: total uses by the tracked agent, and uses of instance #0
-    resource_uses: Dict[str, int] = field(default_factory=lambda: {k: 0 for k in _OC_RESOURCE_KINDS})
-    resource_first: Dict[str, int] = field(default_factory=lambda: {k: 0 for k in _OC_RESOURCE_KINDS})
-    # --- non-feature bookkeeping (episode-level state carried across steps) ---
-    # counter position (x, y) -> (placing_agent_idx, item_code, step_idx)
-    counter_ledger: Dict[Tuple[int, int], Tuple[int, int, int]] = field(default_factory=dict)
-    # counter position -> number of placements by the tracked agent
-    placements_by_pos: Dict[Tuple[int, int], int] = field(default_factory=dict)
-    visited_self: set = field(default_factory=set)
-    visited_partner: set = field(default_factory=set)
-    delivery_steps: List[int] = field(default_factory=list)
-    # canonical (sorted by (y, x)) instance positions per resource kind, cached at step 0
-    resource_pos: Optional[Dict[str, List[Tuple[int, int]]]] = None
-    final_score: float = 0.0
-    episode_length: int = 0
-
-
-def overcooked_episode_to_vector(
-    counts: OvercookedEpisodeCounts, return_norm: float = 0.0, length_norm: float = 0.0
-) -> np.ndarray:
-    """per-episode overcooked counts to the theta contribution vector."""
-    ev = counts.counts_by_event
-    feats = [float(ev.get(name, 0)) for name in OVERCOOKED_SHAPED_INFOS]
-
-    ep_len = max(1, int(counts.n_steps) or int(counts.episode_length) or 1)
-
-    # items the tracked agent left on a counter that were never picked back up
-    dead_drop = sum(1 for placer, _item, _t in counts.counter_ledger.values() if placer == 1)
-
-    # how spread out the tracked agent's counter usage was
-    placement_counts = list(counts.placements_by_pos.values())
-    total_placements = sum(placement_counts)
-    counter_entropy = 0.0
-    if total_placements >= 2 and len(placement_counts) >= 2:
-        entropy = 0.0
-        for n in placement_counts:
-            p = n / total_placements
-            if p > 0.0:
-                entropy -= p * np.log(p)
-        counter_entropy = entropy / np.log(len(placement_counts))
-
-    # resource choice: only meaningful when the layout has >= 2 instances
-    resource_fracs = []
-    for kind in _OC_RESOURCE_KINDS:
-        positions = (counts.resource_pos or {}).get(kind, [])
-        uses = counts.resource_uses.get(kind, 0)
-        if len(positions) >= 2 and uses > 0:
-            resource_fracs.append(counts.resource_first.get(kind, 0) / uses)
-        else:
-            resource_fracs.append(0.0)
-
-    region_fracs = [
-        counts.n_region_NW / ep_len,
-        counts.n_region_NE / ep_len,
-        counts.n_region_SW / ep_len,
-        counts.n_region_SE / ep_len,
-    ]
-
-    union = counts.visited_self | counts.visited_partner
-    territory_overlap = (
-        len(counts.visited_self & counts.visited_partner) / len(union) if union else 0.0
-    )
-
-    n_onion = (
-        ev.get("pickup_onion_from_O", 0)
-        + ev.get("pickup_onion_from_X", 0)
-        + ev.get("put_onion_on_X", 0)
-        + ev.get("PLACEMENT_IN_POT", 0)
-    )
-    n_plate = (
-        ev.get("pickup_dish_from_D", 0)
-        + ev.get("pickup_dish_from_X", 0)
-        + ev.get("put_dish_on_X", 0)
-        + ev.get("SOUP_PICKUP", 0)
-        + ev.get("pickup_soup_from_X", 0)
-        + ev.get("put_soup_on_X", 0)
-        + ev.get("delivery", 0)
-    )
-    # An agent with NO role events has no role at all, so both features must be 0.
-    # Without this carve-out n_role=0 gives onion_role_frac=0 -> role_purity=1.0,
-    # i.e. a totally idle teammate would score as a maximally pure plate specialist.
-    n_role = n_onion + n_plate
-    onion_role_frac = (n_onion / n_role) if n_role > 0 else 0.0
-    role_purity = abs(2.0 * onion_role_frac - 1.0) if n_role > 0 else 0.0
-
-    deliveries_per_100_steps = 100.0 * ev.get("delivery", 0) / ep_len
-    if len(counts.delivery_steps) >= 2:
-        gaps = [
-            counts.delivery_steps[k] - counts.delivery_steps[k - 1]
-            for k in range(1, len(counts.delivery_steps))
-        ]
-        mean_inter_delivery_interval = (sum(gaps) / len(gaps)) / ep_len
-    else:
-        mean_inter_delivery_interval = 0.0
-
-    mean_partner_distance = (counts.partner_dist_sum / ep_len) / max(1, counts.dist_norm)
-
-    feats += [
-        float(counts.n_handoff_given),
-        float(counts.n_handoff_received),
-        float(dead_drop),
-        float(counts.n_self_retrieve),
-        float(counter_entropy),
-        *[float(x) for x in resource_fracs],
-        *[float(x) for x in region_fracs],
-        float(territory_overlap),
-        float(onion_role_frac),
-        float(role_purity),
-        float(deliveries_per_100_steps),
-        float(mean_inter_delivery_interval),
-        float(mean_partner_distance),
-        float(counts.n_interact_into_partner),
-        float(counts.n_blocked_partner),
-    ]
-    assert len(feats) == len(OVERCOOKED_FEATURE_NAMES), (
-        f"overcooked feature vector length {len(feats)} != {len(OVERCOOKED_FEATURE_NAMES)} names"
-    )
-    return np.array(feats, dtype=np.float64)
-
-
-def _oc_scan_resources(mm: np.ndarray, pad: int, H: int, W: int) -> Dict[str, List[Tuple[int, int]]]:
-    """positions (x, y) of each static resource, in canonical (y, x)-sorted order.
-
-    Scanned from maze_map rather than the layout dict so this works regardless of
-    how the env was constructed. Pot/pile/goal tiles are walls, so agents can
-    never stand on them and their maze_map codes are stable across the episode.
-    """
-    code_to_kind = {
-        _OC_POT: "pot",
-        _OC_ONION_PILE: "onion_pile",
-        _OC_PLATE_PILE: "plate_pile",
-        _OC_GOAL: "goal",
-    }
-    out: Dict[str, List[Tuple[int, int]]] = {k: [] for k in _OC_RESOURCE_KINDS}
-    for y in range(H):
-        for x in range(W):
-            py, px = pad + y, pad + x
-            if not (0 <= py < mm.shape[0] and 0 <= px < mm.shape[1]):
-                continue
-            kind = code_to_kind.get(int(mm[py, px, 0]))
-            if kind is not None:
-                out[kind].append((x, y))  # scanned in (y, x) order already
-    return out
-
-
-def _oc_classify_event(inv0: int, inv1: int, obj: int) -> Optional[str]:
-    """map an inventory transition + faced-cell object to a shaped_infos event name."""
-    if inv0 == inv1:
-        return None
-    if inv0 == _OC_EMPTY and inv1 == _OC_ONION:
-        return "pickup_onion_from_O" if obj == _OC_ONION_PILE else "pickup_onion_from_X"
-    if inv0 == _OC_EMPTY and inv1 == _OC_PLATE:
-        return "pickup_dish_from_D" if obj == _OC_PLATE_PILE else "pickup_dish_from_X"
-    if inv0 == _OC_EMPTY and inv1 == _OC_DISH:
-        return "pickup_soup_from_X"
-    if inv0 == _OC_PLATE and inv1 == _OC_DISH:
-        return "SOUP_PICKUP"
-    if inv0 == _OC_ONION and inv1 == _OC_EMPTY:
-        return "PLACEMENT_IN_POT" if obj == _OC_POT else "put_onion_on_X"
-    if inv0 == _OC_PLATE and inv1 == _OC_EMPTY:
-        return "put_dish_on_X"
-    if inv0 == _OC_DISH and inv1 == _OC_EMPTY:
-        return "delivery" if obj == _OC_GOAL else "put_soup_on_X"
-    return None
-
-
-def overcooked_step_update(
-    counts: OvercookedEpisodeCounts,
-    a0: int,
-    a1: int,
-    r0: float,
-    r1: float,
-    state_pre,
-    state_post,
-    info: Dict,
-) -> None:
-    """reconstruct shaped_infos events from overcooked state transitions."""
-    EMPTY, WALL, ONION, ONION_PILE, PLATE, PLATE_PILE, GOAL, POT, DISH = (
-        _OC_EMPTY, _OC_WALL, _OC_ONION, _OC_ONION_PILE, _OC_PLATE,
-        _OC_PLATE_PILE, _OC_GOAL, _OC_POT, _OC_DISH)
-    STAY_A, INTERACT_A = 4, 5
-    POT_EMPTY = _OC_POT_EMPTY
-
-    def _unwrap(s):
-        while hasattr(s, "env_state"):
-            s = s.env_state
-        return s
-
-    sp, sq = _unwrap(state_pre), _unwrap(state_post)
-    try:
-        inv_pre = np.asarray(sp.agent_inv).reshape(-1)
-        inv_post = np.asarray(sq.agent_inv).reshape(-1)
-        pos_pre = np.asarray(sp.agent_pos).reshape(-1, 2)
-        pos_post = np.asarray(sq.agent_pos).reshape(-1, 2)
-        adir = np.asarray(sp.agent_dir).reshape(-1, 2)
-        mm = np.asarray(sp.maze_map)
-        wm = np.asarray(sp.wall_map)
-    except AttributeError:
-        return  # not an overcooked state, nothing to reconstruct
-
-    pad = (mm.shape[0] - wm.shape[0]) // 2
-    ev = counts.counts_by_event
-    H, W = int(wm.shape[0]), int(wm.shape[1])
-
-    # agent_1 is the teammate being characterized; agent_0 is its paired best
-    # response (or a copy of itself in self-play). This intentionally differs
-    # from ZSC-Eval, which attributes theta to the BR instead of the teammate.
-    i = 1
-    action = int(a1)
-    inv0, inv1 = int(inv_pre[i]), int(inv_post[i])
-    fx = int(pos_pre[i][0] + adir[i][0])
-    fy = int(pos_pre[i][1] + adir[i][1])
-    on_grid = (0 <= fx < W) and (0 <= fy < H)
-    py, px = pad + fy, pad + fx
-    obj = int(mm[py, px, 0]) if (0 <= py < mm.shape[0] and 0 <= px < mm.shape[1]) else EMPTY
-    is_table = bool(wm[fy, fx]) if on_grid else False
-    moved = not np.array_equal(pos_pre[i], pos_post[i])
-
-    _overcooked_derived_update(
-        counts, a0, a1, inv_pre, inv_post, pos_pre, pos_post, adir, mm, pad, H, W,
-    )
-
-    if inv0 != inv1:
-        # interact succeeded, classify by inventory delta + faced cell
-        if inv0 == EMPTY and inv1 == ONION:
-            ev["pickup_onion_from_O" if obj == ONION_PILE else "pickup_onion_from_X"] += 1
-        elif inv0 == EMPTY and inv1 == PLATE:
-            ev["pickup_dish_from_D" if obj == PLATE_PILE else "pickup_dish_from_X"] += 1
-            num_notempty_pots = int(((mm[..., 0] == POT) & (mm[..., 2] != POT_EMPTY)).sum())
-            num_plates_held = int((inv_pre == PLATE).sum())
-            no_plates_on_counters = int((mm == PLATE).sum()) == 0
-            if num_plates_held < num_notempty_pots and no_plates_on_counters:
-                ev["USEFUL_DISH_PICKUP"] += 1
-        elif inv0 == EMPTY and inv1 == DISH:
-            ev["pickup_soup_from_X"] += 1
-        elif inv0 == PLATE and inv1 == DISH:
-            ev["SOUP_PICKUP"] += 1
-        elif inv0 == ONION and inv1 == EMPTY:
-            ev["PLACEMENT_IN_POT" if obj == POT else "put_onion_on_X"] += 1
-        elif inv0 == PLATE and inv1 == EMPTY:
-            ev["put_dish_on_X"] += 1
-        elif inv0 == DISH and inv1 == EMPTY:
-            ev["delivery" if obj == GOAL else "put_soup_on_X"] += 1
-    else:
-        # no inventory change, movement / stay / no-op interact
-        if action == STAY_A:
-            ev["STAY"] += 1
-        elif action == INTERACT_A:
-            if is_table and obj not in (WALL, EMPTY):
-                ev["IDLE_INTERACT_X"] += 1
-            else:
-                ev["IDLE_INTERACT_EMPTY"] += 1
-        elif moved:
-            ev["MOVEMENT"] += 1
-        else:
-            ev["IDLE_MOVEMENT"] += 1
-
-
-def _overcooked_derived_update(
-    counts: OvercookedEpisodeCounts,
-    a0: int, a1: int,
-    inv_pre: np.ndarray, inv_post: np.ndarray,
-    pos_pre: np.ndarray, pos_post: np.ndarray,
-    adir: np.ndarray, mm: np.ndarray, pad: int, H: int, W: int,
-) -> None:
-    """derived-vocabulary bookkeeping for overcooked.
-
-    Unlike the shaped_infos reconstruction, this inspects BOTH agents: the
-    counter ledger needs to know who put an item down in order to tell a
-    handoff from a self-retrieve. Only agent_1's behaviour becomes features.
-    """
-    TRACKED, PARTNER = 1, 0
-    INTERACT_A = 5
-    actions = (int(a0), int(a1))
-
-    counts.n_steps += 1
-    step_idx = counts.n_steps - 1
-    counts.dist_norm = H + W
-
-    if counts.resource_pos is None:
-        counts.resource_pos = _oc_scan_resources(mm, pad, H, W)
-
-    # faced cell + object for each agent (interact resolves against the PRE-step
-    # position and direction, matching the env's process_interact)
-    faced: List[Tuple[int, int, int]] = []
-    for j in (0, 1):
-        fx = int(pos_pre[j][0] + adir[j][0])
-        fy = int(pos_pre[j][1] + adir[j][1])
-        py, px = pad + fy, pad + fx
-        if 0 <= py < mm.shape[0] and 0 <= px < mm.shape[1]:
-            obj = int(mm[py, px, 0])
-        else:
-            obj = _OC_EMPTY
-        faced.append((fx, fy, obj))
-
-    events = [
-        _oc_classify_event(int(inv_pre[j]), int(inv_post[j]), faced[j][2]) for j in (0, 1)
-    ]
-
-    # --- counter ledger -------------------------------------------------
-    # Pickups are resolved BEFORE placements so an item can never be picked up
-    # on the same step it was put down.
-    for j in (0, 1):
-        if events[j] not in _OC_PICKUP_FROM_COUNTER:
-            continue
-        entry = counts.counter_ledger.pop((faced[j][0], faced[j][1]), None)
-        if entry is None:
-            continue  # item wasn't placed by either agent this episode
-        placer = entry[0]
-        if j == TRACKED:
-            if placer == PARTNER:
-                counts.n_handoff_received += 1
-            else:
-                counts.n_self_retrieve += 1
-        elif placer == TRACKED:
-            counts.n_handoff_given += 1
-
-    for j in (0, 1):
-        item = _OC_PUT_ON_COUNTER.get(events[j] or "")
-        if item is None:
-            continue
-        pos = (faced[j][0], faced[j][1])
-        counts.counter_ledger[pos] = (j, item, step_idx)
-        if j == TRACKED:
-            counts.placements_by_pos[pos] = counts.placements_by_pos.get(pos, 0) + 1
-
-    # --- resource choice (tracked agent only) ---------------------------
-    event_to_resource = {
-        "PLACEMENT_IN_POT": "pot",
-        "SOUP_PICKUP": "pot",
-        "pickup_onion_from_O": "onion_pile",
-        "pickup_dish_from_D": "plate_pile",
-        "delivery": "goal",
-    }
-    kind = event_to_resource.get(events[TRACKED] or "")
-    if kind is not None:
-        positions = counts.resource_pos.get(kind, [])
-        used = (faced[TRACKED][0], faced[TRACKED][1])
-        if used in positions:
-            counts.resource_uses[kind] += 1
-            if used == positions[0]:
-                counts.resource_first[kind] += 1
-
-    if events[TRACKED] == "delivery":
-        counts.delivery_steps.append(step_idx)
-
-    # --- spatial / territorial ------------------------------------------
-    sx, sy = int(pos_pre[TRACKED][0]), int(pos_pre[TRACKED][1])
-    mid_x, mid_y = W / 2.0, H / 2.0
-    if sy < mid_y and sx < mid_x:
-        counts.n_region_NW += 1
-    elif sy < mid_y:
-        counts.n_region_NE += 1
-    elif sx < mid_x:
-        counts.n_region_SW += 1
-    else:
-        counts.n_region_SE += 1
-
-    counts.visited_self.add((sx, sy))
-    counts.visited_self.add((int(pos_post[TRACKED][0]), int(pos_post[TRACKED][1])))
-    counts.visited_partner.add((int(pos_pre[PARTNER][0]), int(pos_pre[PARTNER][1])))
-    counts.visited_partner.add((int(pos_post[PARTNER][0]), int(pos_post[PARTNER][1])))
-
-    # --- partner-relational ---------------------------------------------
-    counts.partner_dist_sum += abs(sx - int(pos_pre[PARTNER][0])) + abs(
-        sy - int(pos_pre[PARTNER][1])
-    )
-
-    if actions[TRACKED] == INTERACT_A and faced[TRACKED][2] == _OC_AGENT:
-        counts.n_interact_into_partner += 1
-
-    partner_action = actions[PARTNER]
-    if 0 <= partner_action < len(_OC_DIR_TO_VEC) and np.array_equal(
-        pos_pre[PARTNER], pos_post[PARTNER]
-    ):
-        dx, dy = _OC_DIR_TO_VEC[partner_action]
-        target = (int(pos_pre[PARTNER][0]) + dx, int(pos_pre[PARTNER][1]) + dy)
-        if (sx, sy) == target:
-            counts.n_blocked_partner += 1
 
 
 def build_overcooked_agents(layout: dict) -> Dict[str, Any]:
@@ -1556,7 +1109,7 @@ def load_full_heldout_for_pd(
         )
     heldout_block = full_yaml["heldout_set"][heldout_yaml_key]
 
-    # pre-filter entries whose checkpoint paths or weight files don't exist locally; heuristic agents (no path/weight_file) always pass
+    # skip entries whose checkpoint paths don't exist locally
     from common.save_load_utils import REPO_PATH
 
     filtered = {}
@@ -1667,18 +1220,15 @@ def _match_partner_to_br(heldout_name: str, available_dirs: List[str], layout_pr
         ])
     candidates.extend(suffix_variants)
 
-    # 'br_for_<name>' prefix (mini-hanabi convention)
     for c in [base, base_us, heldout_name]:
         candidates.append(f"br_for_{c}")
 
-    # layout-prefixed (overcooked)
     if layout_prefix:
         prefixed: List[str] = []
         for c in list(candidates):
             prefixed.append(f"{layout_prefix}_{c}")
         candidates.extend(prefixed)
 
-    # direct match
     seen = set()
     for c in candidates:
         if c in seen:
@@ -1687,7 +1237,7 @@ def _match_partner_to_br(heldout_name: str, available_dirs: List[str], layout_pr
         if c in available_dirs:
             return c
 
-    # pop-methods whose outer idx doesn't line up with the dir name: match on the inner idx (comedi (-1, 0) -> comedi_1_0_serious)
+    # match on the inner idx only
     if inner_idx is not None:
         import re
         pat = re.compile(rf"^{re.escape(base_us)}_-?\d+_{inner_idx}(_.*)?$")
@@ -1783,3 +1333,101 @@ def _lbf_step_index(state) -> int:
         return int(sc)
     except (TypeError, ValueError):
         return -1
+
+
+
+
+def rollout_two_policy_batched(
+    env,
+    policy_a, params_a,
+    policy_b, params_b,
+    num_episodes: int,
+    seed: int,
+    max_steps: int = 400,
+) -> Dict[str, np.ndarray]:
+    """Run all episodes in parallel; return stacked raw trajectory arrays."""
+    init_done = {k: jnp.zeros((1), dtype=bool) for k in env.agents + ["__all__"]}
+
+    # episode keys, generated by the SAME chain the sequential path uses
+    rng_master = jax.random.PRNGKey(seed)
+    ep_keys = []
+    for _ in range(num_episodes):
+        rng_master, ep_rng = jax.random.split(rng_master)
+        ep_keys.append(ep_rng)
+    ep_keys = jnp.stack(ep_keys)
+
+    # static layout geometry, read once off a throwaway reset
+    _, probe_state = env.reset(jax.random.PRNGKey(0))
+    probe = probe_state
+    while hasattr(probe, "env_state"):
+        probe = probe.env_state
+    mm_shape = np.asarray(probe.maze_map).shape
+    wall_map = np.asarray(probe.wall_map).astype(bool)
+    H, W = int(wall_map.shape[0]), int(wall_map.shape[1])
+    pad = (mm_shape[0] - H) // 2
+
+    def _inner(s):
+        while hasattr(s, "env_state"):
+            s = s.env_state
+        return s
+
+    def run_episode(ep_rng):
+        ep_rng, reset_rng = jax.random.split(ep_rng)
+        obs, env_state = env.reset(reset_rng)
+        hstate_0 = policy_a.init_hstate(1, aux_info={"agent_id": 0})
+        hstate_1 = policy_b.init_hstate(1, aux_info={"agent_id": 1})
+
+        def scan_step(carry, _):
+            ep_rng, obs, env_state, done_prev, hstate_0, hstate_1 = carry
+
+            avail = jax.lax.stop_gradient(env.get_avail_actions(env_state))
+            avail_0 = avail["agent_0"].astype(jnp.float32)
+            avail_1 = avail["agent_1"].astype(jnp.float32)
+
+            ep_rng, a0_rng, a1_rng, step_rng = jax.random.split(ep_rng, 4)
+            act_0, hstate_0 = policy_a.get_action(
+                params=params_a, obs=obs["agent_0"].reshape(1, 1, -1),
+                done=done_prev["agent_0"].reshape(1, 1), avail_actions=avail_0,
+                hstate=hstate_0, rng=a0_rng, aux_obs=None, env_state=env_state,
+                test_mode=False,
+            )
+            act_1, hstate_1 = policy_b.get_action(
+                params=params_b, obs=obs["agent_1"].reshape(1, 1, -1),
+                done=done_prev["agent_1"].reshape(1, 1), avail_actions=avail_1,
+                hstate=hstate_1, rng=a1_rng, aux_obs=None, env_state=env_state,
+                test_mode=False,
+            )
+            act_0 = act_0.squeeze()
+            act_1 = act_1.squeeze()
+
+            env_act = {"agent_0": act_0, "agent_1": act_1}
+            sp = _inner(env_state)
+            obs_n, env_state_n, reward, done, info = env.step(step_rng, env_state, env_act)
+            sq = _inner(env_state_n)
+
+            out = dict(
+                act=jnp.stack([act_0, act_1]).astype(jnp.int8),
+                rew=jnp.stack([reward["agent_0"], reward["agent_1"]]).astype(jnp.float32),
+                inv_pre=sp.agent_inv.reshape(-1).astype(jnp.int16),
+                inv_post=sq.agent_inv.reshape(-1).astype(jnp.int16),
+                pos_pre=sp.agent_pos.reshape(-1, 2).astype(jnp.int16),
+                pos_post=sq.agent_pos.reshape(-1, 2).astype(jnp.int16),
+                dir_pre=sp.agent_dir.reshape(-1, 2).astype(jnp.int16),
+                mmw_pre=jax.lax.dynamic_slice(
+                    sp.maze_map, (pad, pad, 0), (H, W, 3)
+                ).astype(jnp.uint8),
+                mm_full_pre=sp.maze_map.astype(jnp.uint8),
+                done=done["__all__"].reshape(()),
+            )
+            done_next = {k: jnp.asarray(v).reshape(1) for k, v in done.items()}
+            return (ep_rng, obs_n, env_state_n, done_next, hstate_0, hstate_1), out
+
+        carry = (ep_rng, obs, env_state, init_done, hstate_0, hstate_1)
+        _, traj = jax.lax.scan(scan_step, carry, None, length=max_steps)
+        return traj
+
+    traj = jax.jit(jax.vmap(run_episode))(ep_keys)
+    out = {k: np.asarray(v) for k, v in traj.items()}
+    out["wall_map"] = wall_map
+    out["pad"], out["H"], out["W"] = pad, H, W
+    return out

--- a/scripts/population_diversity/pd_traj_cache.py
+++ b/scripts/population_diversity/pd_traj_cache.py
@@ -1,0 +1,245 @@
+# Trajectory cache: record raw per-step Overcooked transitions to a .npz per
+# (task, teammate) and replay them on CPU so features can be recomputed
+# without re-running rollouts.
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+log = logging.getLogger("compute_pd")
+
+CACHE_FORMAT_VERSION = 2
+
+
+def _unwrap(s):
+    while hasattr(s, "env_state"):
+        s = s.env_state
+    return s
+
+
+class _ReplayState:
+    """Duck-typed Overcooked env state exposing only what the updates read."""
+
+    __slots__ = ("agent_inv", "agent_pos", "agent_dir", "maze_map", "wall_map")
+
+    def __init__(self, agent_inv, agent_pos, agent_dir, maze_map, wall_map):
+        self.agent_inv = agent_inv
+        self.agent_pos = agent_pos
+        self.agent_dir = agent_dir
+        self.maze_map = maze_map
+        self.wall_map = wall_map
+
+
+class OvercookedTrajRecorder:
+    """Accumulate raw per-step Overcooked transitions for one (task, teammate)."""
+
+    def __init__(self, agent: str, task: str, seed: int):
+        self.agent = agent
+        self.task = task
+        self.seed = seed
+        self._ep_lengths: List[int] = []
+        self._cur = 0
+        self.act: List[np.ndarray] = []
+        self.rew: List[np.ndarray] = []
+        self.inv_pre: List[np.ndarray] = []
+        self.inv_post: List[np.ndarray] = []
+        self.pos_pre: List[np.ndarray] = []
+        self.pos_post: List[np.ndarray] = []
+        self.dir_pre: List[np.ndarray] = []
+        self.mmw_pre: List[np.ndarray] = []
+        self.wall_map: Optional[np.ndarray] = None
+        self.mm_template: Optional[np.ndarray] = None
+        self.pad: int = 0
+        self.H: int = 0
+        self.W: int = 0
+
+    def record_step(self, state_pre, state_post, a0: int, a1: int, r0: float, r1: float) -> None:
+        sp, sq = _unwrap(state_pre), _unwrap(state_post)
+        mm = np.asarray(sp.maze_map)
+        wm = np.asarray(sp.wall_map)
+        pad = (mm.shape[0] - wm.shape[0]) // 2
+        H, W = int(wm.shape[0]), int(wm.shape[1])
+
+        assert mm.min() >= 0 and mm.max() < 256, "maze_map does not fit in uint8"
+        if self.wall_map is None:
+            self.wall_map = wm.astype(bool)
+            self.mm_template = mm.astype(np.uint8)
+            self.pad, self.H, self.W = pad, H, W
+        else:
+            # Static-layout invariants; fail loudly rather than write a lossy cache.
+            assert (pad, H, W) == (self.pad, self.H, self.W), "layout geometry changed mid-run"
+            assert np.array_equal(wm.astype(bool), self.wall_map), "wall_map changed mid-run"
+            ring = self.mm_template.copy()
+            ring[pad:pad + H, pad:pad + W, :] = mm[pad:pad + H, pad:pad + W, :]
+            assert np.array_equal(ring, mm.astype(np.uint8)), (
+                "maze_map changed OUTSIDE the walkable window; cache would be lossy"
+            )
+
+        self.act.append(np.array([a0, a1], dtype=np.int8))
+        self.rew.append(np.array([r0, r1], dtype=np.float32))
+        self.inv_pre.append(np.asarray(sp.agent_inv).reshape(-1).astype(np.int16))
+        self.inv_post.append(np.asarray(sq.agent_inv).reshape(-1).astype(np.int16))
+        self.pos_pre.append(np.asarray(sp.agent_pos).reshape(-1, 2).astype(np.int16))
+        self.pos_post.append(np.asarray(sq.agent_pos).reshape(-1, 2).astype(np.int16))
+        self.dir_pre.append(np.asarray(sp.agent_dir).reshape(-1, 2).astype(np.int16))
+        self.mmw_pre.append(mm[pad:pad + H, pad:pad + W, :].astype(np.uint8))
+        self._cur += 1
+
+    def end_episode(self) -> None:
+        self._ep_lengths.append(self._cur)
+        self._cur = 0
+
+    def to_arrays(self) -> Dict[str, np.ndarray]:
+        if self.wall_map is None:
+            raise ValueError(f"no steps recorded for {self.agent}")
+        ep_ptr = np.concatenate([[0], np.cumsum(self._ep_lengths)]).astype(np.int32)
+        return dict(
+            version=np.int32(CACHE_FORMAT_VERSION),
+            ep_ptr=ep_ptr,
+            act=np.stack(self.act),
+            rew=np.stack(self.rew),
+            inv_pre=np.stack(self.inv_pre),
+            inv_post=np.stack(self.inv_post),
+            pos_pre=np.stack(self.pos_pre),
+            pos_post=np.stack(self.pos_post),
+            dir_pre=np.stack(self.dir_pre),
+            mmw_pre=np.stack(self.mmw_pre),
+            wall_map=self.wall_map,
+            mm_template=self.mm_template,
+            pad=np.int32(self.pad),
+            H=np.int32(self.H),
+            W=np.int32(self.W),
+            agent=np.array(self.agent),
+            task=np.array(self.task),
+            seed=np.int32(self.seed),
+        )
+
+    def save(self, path: Path) -> int:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        np.savez_compressed(path, **self.to_arrays())
+        return path.stat().st_size
+
+
+def cache_path(cache_root: Path, task: str, agent: str) -> Path:
+    safe = (
+        str(agent).replace(" ", "_").replace("(", "").replace(")", "")
+        .replace(",", "").replace("/", "_")
+    )
+    return Path(cache_root) / str(task).replace("/", "_") / f"{safe}.npz"
+
+
+class CachedEpisode:
+    """One episode's worth of raw arrays, sliced out of a cache file."""
+
+    __slots__ = ("act", "rew", "inv_pre", "inv_post", "pos_pre", "pos_post",
+                 "dir_pre", "mmw_pre", "wall_map", "mm_template", "pad", "H", "W")
+
+    def __init__(self, blob, lo: int, hi: int):
+        self.act = blob["act"][lo:hi]
+        self.rew = blob["rew"][lo:hi]
+        self.inv_pre = blob["inv_pre"][lo:hi]
+        self.inv_post = blob["inv_post"][lo:hi]
+        self.pos_pre = blob["pos_pre"][lo:hi]
+        self.pos_post = blob["pos_post"][lo:hi]
+        self.dir_pre = blob["dir_pre"][lo:hi]
+        self.mmw_pre = blob["mmw_pre"][lo:hi]
+        self.wall_map = blob["wall_map"]
+        self.mm_template = blob["mm_template"]
+        self.pad = int(blob["pad"])
+        self.H = int(blob["H"])
+        self.W = int(blob["W"])
+
+    def __len__(self) -> int:
+        return int(self.act.shape[0])
+
+    def maze_map(self, t: int) -> np.ndarray:
+        mm = self.mm_template.copy()
+        p, H, W = self.pad, self.H, self.W
+        mm[p:p + H, p:p + W, :] = self.mmw_pre[t]
+        return mm
+
+    def states(self, t: int):
+        pre = _ReplayState(self.inv_pre[t], self.pos_pre[t], self.dir_pre[t],
+                           self.maze_map(t), self.wall_map)
+        post = _ReplayState(self.inv_post[t], self.pos_post[t], self.dir_pre[t],
+                            self.maze_map(t), self.wall_map)
+        return pre, post
+
+
+def load_episodes(path: Path) -> List[CachedEpisode]:
+    blob = dict(np.load(path, allow_pickle=False))
+    ver = int(blob.get("version", 0))
+    if ver != CACHE_FORMAT_VERSION:
+        raise ValueError(f"{path}: cache format v{ver}, expected v{CACHE_FORMAT_VERSION}")
+    ptr = blob["ep_ptr"]
+    return [CachedEpisode(blob, int(ptr[i]), int(ptr[i + 1])) for i in range(len(ptr) - 1)]
+
+
+def replay_counts(path: Path) -> List[Any]:
+    """Rebuild per-episode OvercookedEpisodeCounts from a cache file by replaying `overcooked_step_update`."""
+    from scripts.population_diversity.pd_overcooked_features import (
+        OvercookedEpisodeCounts,
+        overcooked_step_update,
+    )
+
+    out = []
+    for ep in load_episodes(path):
+        counts = OvercookedEpisodeCounts()
+        ep_return = 0.0
+        for t in range(len(ep)):
+            pre, post = ep.states(t)
+            a0, a1 = int(ep.act[t][0]), int(ep.act[t][1])
+            r0, r1 = float(ep.rew[t][0]), float(ep.rew[t][1])
+            overcooked_step_update(counts, a0, a1, r0, r1, pre, post, {})
+            ep_return += r0
+        counts.final_score = ep_return
+        counts.episode_length = len(ep)
+        out.append(counts)
+    return out
+
+
+def save_batched_traj(traj: Dict[str, Any], agent: str, task: str, seed: int, path: Path) -> int:
+    """Persist the stacked output of `rollout_two_policy_batched` as a cache file."""
+    E, T = traj["act"].shape[0], traj["act"].shape[1]
+    pad, H, W = int(traj["pad"]), int(traj["H"]), int(traj["W"])
+
+    mm_full = traj["mm_full_pre"]
+    template = mm_full[0, 0].copy()
+    rebuilt = np.broadcast_to(template, mm_full.shape).copy()
+    rebuilt[:, :, pad:pad + H, pad:pad + W, :] = traj["mmw_pre"]
+    assert np.array_equal(rebuilt, mm_full), (
+        "maze_map changed OUTSIDE the walkable window; the window-only cache would be lossy"
+    )
+
+    # Fixed horizon: every episode must end exactly at T.
+    done = traj["done"]
+    assert bool(done[:, -1].all()) and not bool(done[:, :-1].any()), (
+        "episodes did not all terminate exactly at max_steps; fixed-length cache invalid"
+    )
+
+    def flat(k, dtype=None):
+        a = traj[k].reshape((E * T,) + traj[k].shape[2:])
+        return a if dtype is None else a.astype(dtype)
+
+    arrays = dict(
+        version=np.int32(CACHE_FORMAT_VERSION),
+        ep_ptr=(np.arange(E + 1) * T).astype(np.int32),
+        act=flat("act", np.int8),
+        rew=flat("rew", np.float32),
+        inv_pre=flat("inv_pre", np.int16),
+        inv_post=flat("inv_post", np.int16),
+        pos_pre=flat("pos_pre", np.int16),
+        pos_post=flat("pos_post", np.int16),
+        dir_pre=flat("dir_pre", np.int16),
+        mmw_pre=flat("mmw_pre", np.uint8),
+        wall_map=traj["wall_map"],
+        mm_template=template,
+        pad=np.int32(pad), H=np.int32(H), W=np.int32(W),
+        agent=np.array(agent), task=np.array(task), seed=np.int32(seed),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(path, **arrays)
+    return path.stat().st_size


### PR DESCRIPTION
Refines the Overcooked PD feature vocabulary and makes feature computation post hoc, so the eval teammate set can be clustered by behavioral convention.

- All Overcooked features are computed from recorded trajectories (`pd_overcooked_features.py`, `pd_traj_cache.py`): `--batched` runs a vmapped rollout that writes a per-teammate cache, `--from-cache` recomputes features on CPU without rollouts. `--deterministic-reset` fixes start cells so teammates are comparable.
- Vocabulary: adds 5 partner-contingent and 12 contention / action-MI features; drops the redundant throughput and by-construction columns (77-column feature rows).
- Adds `scripts/convention_analysis/` (derive routing fractions, screen dead columns per task, cluster with equal group weighting) and `extract_features.sh`, which runs `--full-heldout --br-paired` over the Overcooked layouts.
- Hanabi, the LBF variants, the terminal-state fix and the per-row `pairing` field are unchanged.

Checked on CPU: LBF and Overcooked heuristic self-play runs, the batched cache path, and `--from-cache` reproducing the batched run's features exactly; `run_pipeline.py` clusters a 20-teammate coord_ring population end to end.
