### PR TITLE
Check teammate config paths against Hugging Face weekly

### DIFF
--- a/.github/workflows/check-teammate-paths.yml
+++ b/.github/workflows/check-teammate-paths.yml
@@ -1,0 +1,27 @@
+name: Check teammate paths
+
+# The heldout and validation configs point at checkpoints hosted in our Hugging
+# Face dataset repos. This runs weekly rather than on pull requests, so that a
+# Hugging Face outage cannot block unrelated work.
+on:
+  schedule:
+    - cron: "0 12 * * 1" # Mondays at 12:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  teammate-paths:
+    name: Teammate paths exist on Hugging Face
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: python -m pip install huggingface-hub pytest pyyaml
+      - name: Check configured paths
+        run: pytest tests/test_teammate_paths_on_hf.py -m hf_data --run-hf-data -v

--- a/evaluation/configs/global_heldout_br.yaml
+++ b/evaluation/configs/global_heldout_br.yaml
@@ -1,0 +1,790 @@
+# @package _global_
+# Best-response policies for the held-out teammate set.
+
+best_response_set:
+  lbf/lbf_7x7_nolevels:
+    br_for_ippo_mlp_0:
+      path: "eval_teammates/lbf_7x7_nolevels/ippo_mlp_0_serious/2026-03-09_14-37-49/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_s2c0_2_0:
+      path: "eval_teammates/lbf_7x7_nolevels/ippo_mlp_s2c0_serious/2026-03-09_21-11-30/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf1_0:
+      path: "eval_teammates/lbf/brdiv/2025-04-16/11-32-07/saved_train_run"
+      actor_type: actor_with_conditional_critic
+      ckpt_key: final_params_br
+      idx_list: [0]
+      POP_SIZE: 5
+      test_mode: false
+
+    br_for_brdiv_conf1_1:
+      path: "eval_teammates/lbf/brdiv/2025-04-16/11-32-07/saved_train_run"
+      actor_type: actor_with_conditional_critic
+      ckpt_key: final_params_br
+      idx_list: [1]
+      POP_SIZE: 5
+      test_mode: false
+
+    br_for_brdiv_conf1_2:
+      path: "eval_teammates/lbf/brdiv/2025-04-16/11-32-07/saved_train_run"
+      actor_type: actor_with_conditional_critic
+      ckpt_key: final_params_br
+      idx_list: [2]
+      POP_SIZE: 5
+      test_mode: false
+
+    br_for_brdiv_conf2_0:
+      path: "eval_teammates/lbf/brdiv/2025-04-23/13-48-47/saved_train_run"
+      actor_type: actor_with_conditional_critic
+      ckpt_key: final_params_br
+      idx_list: [0]
+      POP_SIZE: 3
+      test_mode: false
+
+    br_for_brdiv_conf2_1:
+      path: "eval_teammates/lbf/brdiv/2025-04-23/13-48-47/saved_train_run"
+      actor_type: actor_with_conditional_critic
+      ckpt_key: final_params_br
+      idx_list: [1]
+      POP_SIZE: 3
+      test_mode: false
+
+    br_for_seq_agent_lexi:
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_lexi_serious/2026-03-09_22-00-17/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_seq_agent_rlexi:
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_rlexi_serious/2026-03-09_22-04-11/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_seq_agent_col:
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_col_serious/2026-03-10_11-34-55/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_seq_agent_rcol:
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_rcol_serious/2026-03-10_11-35-07/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    # retrained the nearest/farthest seq-agent BRs longer (6e7)
+    # see file log to get back 1e7 versions if needed
+    br_for_seq_agent_nearest:
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_nearest_long_6e7/2026-03-17_15-29-35/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_seq_agent_farthest:
+      path: "eval_teammates/lbf_7x7_nolevels/seq_agent_farthest_long_6e7/2026-03-17_15-30-02/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_0:
+      path: "eval_teammates/lbf_7x7_nolevels/lbrdiv_conf_1_0_serious/2026-03-26_14-39-54/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_1:
+      path: "eval_teammates/lbf_7x7_nolevels/lbrdiv_conf_1_1_serious/2026-03-27_08-00-13/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_2:
+      path: "eval_teammates/lbf_7x7_nolevels/lbrdiv_conf_1_2_serious/2026-03-26_15-26-40/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_0:
+      path: "eval_teammates/lbf_7x7_nolevels/comedi_1_0_serious/2026-03-29_14-57-30/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_1:
+      path: "eval_teammates/lbf_7x7_nolevels/comedi_1_1_serious/2026-03-29_15-35-46/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_2:
+      path: "eval_teammates/lbf_7x7_nolevels/comedi_1_2_serious/2026-03-29_16-14-12/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_3:
+      path: "eval_teammates/lbf_7x7_nolevels/comedi_1_3_serious/2026-03-29_16-52-38/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_4:
+      path: "eval_teammates/lbf_7x7_nolevels/comedi_1_4_serious/2026-03-29_17-30-53/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_entitled_agent:
+      path: "eval_teammates/lbf_7x7_nolevels/entitled_agent_serious/2026-05-05_10-30-43/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_greedy_closest_teammate:
+      actor_type: seq_agent
+      ordering_strategy: nearest_agent
+
+  overcooked-v1/cramped_room:
+    br_for_ippo_mlp_0:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_ippo_mlp_0_serious/2026-03-16_11-08-25/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_1:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_ippo_mlp_1_serious/2026-03-16_11-08-25/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_2:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_ippo_mlp_2_serious/2026-03-16_11-31-44/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf_0:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_brdiv_conf_0_serious/2026-03-16_11-31-44/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf_1:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_brdiv_conf_1_serious/2026-03-16_11-55-04/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_independent_agent_0_4:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_independent_agent_0_4_serious/2026-03-16_11-55-04/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_independent_agent_0:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_independent_agent_0_serious/2026-03-16_12-18-02/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_onion_agent_0_1:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_onion_agent_0_1_serious/2026-03-16_12-20-27/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_plate_agent_0_1:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_plate_agent_0_1_serious/2026-03-16_12-43-21/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_0:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_lbrdiv_conf_1_0_serious/2026-03-31_19-47-45/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_1:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_lbrdiv_conf_1_1_serious/2026-03-31_19-47-45/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_2:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_lbrdiv_conf_1_2_serious/2026-03-31_20-11-22/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_0:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_comedi_1_0_serious/2026-03-31_20-11-22/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_1:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_comedi_1_1_serious/2026-03-31_20-34-43/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_2:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_comedi_1_2_serious/2026-03-31_20-34-44/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_3:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_comedi_1_3_serious/2026-03-31_20-58-12/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_4:
+      path: "eval_teammates/overcooked_v1_cramped_room/cramped_room_comedi_1_4_serious/2026-03-31_20-58-12/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+  overcooked-v1/asymm_advantages:
+    br_for_ippo_mlp_0:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_ippo_mlp_0_serious/2026-03-16_12-44-48/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_1:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_ippo_mlp_1_serious/2026-03-16_13-08-19/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_2:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_ippo_mlp_2_serious/2026-03-16_13-12-02/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf_0:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_brdiv_conf_0_serious/2026-03-16_13-35-34/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf_1:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_brdiv_conf_1_serious/2026-03-16_13-39-19/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf_2:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_brdiv_conf_2_serious/2026-03-16_14-41-26/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_independent_agent_0:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_independent_agent_0_serious/2026-03-16_14-41-26/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_onion_agent_0:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_onion_agent_0_serious/2026-03-16_15-08-51/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_plate_agent_0:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_plate_agent_0_serious/2026-03-16_15-11-58/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_0:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_lbrdiv_conf_1_0_serious/2026-03-31_21-21-36/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_1:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_lbrdiv_conf_1_1_serious/2026-03-31_21-21-36/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_2:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_lbrdiv_conf_1_2_serious/2026-03-31_21-49-29/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_0:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_comedi_1_0_serious/2026-03-31_21-49-29/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_1:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_comedi_1_1_serious/2026-03-31_22-17-28/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_2:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_comedi_1_2_serious/2026-03-31_22-17-28/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_3:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_comedi_1_3_serious/2026-03-31_22-45-22/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_4:
+      path: "eval_teammates/overcooked_v1_asymm_advantages/asymm_advantages_comedi_1_4_serious/2026-03-31_22-45-22/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+  overcooked-v1/counter_circuit:
+    br_for_ippo_mlp_cc_0:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_cc_0_serious/2026-03-16_15-37-34/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_cc_1:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_cc_1_serious/2026-03-16_15-40-58/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_cc_2:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_cc_2_serious/2026-03-16_16-01-42/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_pass_0:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_pass_0_serious/2026-03-16_16-04-58/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_pass_1:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_pass_1_serious/2026-03-16_16-25-49/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_pass_2:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_ippo_mlp_pass_2_serious/2026-03-16_16-29-00/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_independent_agent_0:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_independent_agent_0_serious/2026-03-16_16-49-59/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_onion_agent_0:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_onion_agent_0_serious/2026-03-16_19-56-09/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_plate_agent_0:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_plate_agent_0_serious/2026-03-16_19-56-09/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_onion_agent_0_9:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_onion_agent_0_9_serious/2026-03-16_20-22-17/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_plate_agent_0_9:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_plate_agent_0_9_serious/2026-03-16_20-22-27/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_0:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_lbrdiv_conf_1_0_serious/2026-03-31_23-13-25/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_1:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_lbrdiv_conf_1_1_serious/2026-03-31_23-13-25/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_2:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_lbrdiv_conf_1_2_serious/2026-04-01_08-46-15/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_0:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_comedi_1_0_serious/2026-04-01_08-46-15/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_1:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_comedi_1_1_serious/2026-04-01_09-11-00/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_2:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_comedi_1_2_serious/2026-04-01_09-11-00/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_3:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_comedi_1_3_serious/2026-04-01_09-35-44/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_4:
+      path: "eval_teammates/overcooked_v1_counter_circuit/counter_circuit_comedi_1_4_serious/2026-04-01_09-35-44/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+  overcooked-v1/coord_ring:
+    br_for_ippo_mlp_1:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_ippo_mlp_1_serious/2026-03-16_20-48-58/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_2:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_ippo_mlp_2_serious/2026-03-16_20-49-15/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_3:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_ippo_mlp_3_serious/2026-03-16_21-12-48/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf1_1:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_brdiv_conf1_1_serious/2026-03-16_21-13-18/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf1_2:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_brdiv_conf1_2_serious/2026-03-16_21-36-51/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf2_0:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_brdiv_conf2_0_serious/2026-03-16_21-37-32/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_independent_agent_0:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_independent_agent_0_serious/2026-03-16_22-00-43/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_onion_agent_0:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_onion_agent_0_serious/2026-03-16_22-01-32/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_plate_agent_0:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_plate_agent_0_serious/2026-03-16_22-26-32/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_0:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_lbrdiv_conf_1_0_serious/2026-04-01_10-00-27/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_1:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_lbrdiv_conf_1_1_serious/2026-04-01_10-00-27/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_2:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_lbrdiv_conf_1_2_serious/2026-04-01_10-24-20/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_0:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_comedi_1_0_serious/2026-04-01_10-24-22/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_1:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_comedi_1_1_serious/2026-04-01_10-48-16/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_2:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_comedi_1_2_serious/2026-04-01_10-48-16/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_3:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_comedi_1_3_serious/2026-04-01_11-12-21/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_4:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_comedi_1_4_serious/2026-04-01_11-12-21/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_human_proxy:
+      path: "eval_teammates/overcooked_v1_coord_ring/coord_ring_BC_0/2026-05-05_20-08-22/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+  overcooked-v1/forced_coord:
+    br_for_ippo_mlp_0:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_ippo_mlp_0_serious/2026-03-16_22-27-05/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_1:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_ippo_mlp_1_serious/2026-03-17_08-04-53/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_2:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_ippo_mlp_2_serious/2026-03-17_08-04-53/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf1_0:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_brdiv_conf1_0_serious/2026-03-17_08-24-58/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf1_2:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_brdiv_conf1_2_serious/2026-03-17_08-25-00/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf2_1:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_brdiv_conf2_1_serious/2026-03-17_08-44-38/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf3_0:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_brdiv_conf3_0_serious/2026-03-17_08-44-42/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf3_2:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_brdiv_conf3_2_serious/2026-03-17_09-04-28/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_independent_agent_0_6:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_independent_agent_0_6_serious/2026-03-17_09-04-28/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_0:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_lbrdiv_conf_1_0_serious/2026-04-01_11-36-25/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_1:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_lbrdiv_conf_1_1_serious/2026-04-01_11-36-29/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1_2:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_lbrdiv_conf_1_2_serious/2026-04-01_11-56-23/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_0:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_comedi_1_0_serious/2026-04-01_11-56-22/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_1:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_comedi_1_1_serious/2026-04-01_12-16-04/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_2:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_comedi_1_2_serious/2026-04-01_12-17-45/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_3:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_comedi_1_3_serious/2026-04-01_12-35-44/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_1_4:
+      path: "eval_teammates/overcooked_v1_forced_coord/forced_coord_comedi_1_4_serious/2026-04-01_12-42-01/ego_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true

--- a/evaluation/configs/heldout_xp.yaml
+++ b/evaluation/configs/heldout_xp.yaml
@@ -1,11 +1,15 @@
 defaults:
   - task: lbf/lbf_7x7_nolevels # overcooked-v1/cramped_room # task configs
   - global_heldout_settings # global settings for heldout evaluation
+  # To evaluate against trained best responses instead of the heldout agents
+  # themselves, uncomment the line below and comment out `best_response_set`
+  # further down. The BR checkpoints live in the jaxaht/eval-teammates-br dataset
+  # and total ~72GB, so they are not downloaded by default.
   # - global_heldout_br # best responses to global heldout set
   - hydra: hydra_simple
   - _self_
 
-# Set best response set to heldout set
+# Set best response set to heldout set. Comment this out when using global_heldout_br.
 best_response_set: ${heldout_set}
 
 ENV_NAME: ${task.ENV_NAME}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ include = ["agents*", "common*", "envs*", "evaluation*", "ego_agent_training*", 
 [tool.pytest.ini_options]
 markers = [
     "eval_data: requires locally downloaded eval teammate checkpoints",
+    "hf_data: queries the Hugging Face dataset repos over the network",
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-hf-data",
+        action="store_true",
+        default=False,
+        help="Run tests that query the Hugging Face dataset repos over the network.",
+    )

--- a/tests/test_teammate_paths_on_hf.py
+++ b/tests/test_teammate_paths_on_hf.py
@@ -1,0 +1,94 @@
+"""Check that teammate checkpoint paths in the config files exist on Hugging Face.
+
+The heldout and validation settings point at checkpoints hosted in our dataset
+repos. Nothing in the repo notices when a config path and the uploaded data drift
+apart, so this test lists each dataset repo once and checks every configured path
+against that listing. It needs network access, so it is opt-in: run it with
+
+    pytest -m hf_data --run-hf-data
+
+or let the weekly check-teammate-paths workflow run it.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_DIR = REPO_ROOT / "evaluation/configs"
+
+# Local directory a path is relative to -> dataset repos that may hold it. Best
+# responses live in their own repo, except for BRDiv's, which are stored inside the
+# teammate run they respond to (via ckpt_key: final_params_br), so eval_teammates
+# paths have to be looked up in both.
+DIR_TO_REPOS = {
+    "eval_teammates": ("jaxaht/eval-teammates", "jaxaht/eval-teammates-br"),
+    "val_teammates": ("jaxaht/val-teammates",),
+}
+PATH_KEYS = ("path", "weight_file")
+
+
+def iter_configured_paths(config):
+    """Yield every checkpoint path in a loaded config, however deeply nested."""
+    if isinstance(config, dict):
+        for key, value in config.items():
+            if key in PATH_KEYS and isinstance(value, str) and value:
+                yield value
+            else:
+                yield from iter_configured_paths(value)
+    elif isinstance(config, list):
+        for item in config:
+            yield from iter_configured_paths(item)
+
+
+def collect_paths():
+    """Map each configured checkpoint path to the config files that reference it."""
+    paths = {}
+    for config_file in sorted(CONFIG_DIR.glob("global_*.yaml")):
+        config = yaml.safe_load(config_file.read_text())
+        for path in iter_configured_paths(config):
+            paths.setdefault(path, set()).add(config_file.name)
+    return paths
+
+
+@pytest.mark.hf_data
+def test_configured_teammate_paths_exist_on_hf(request):
+    if not request.config.getoption("--run-hf-data"):
+        pytest.skip("needs network access to Hugging Face; pass --run-hf-data to run")
+
+    from huggingface_hub import list_repo_files
+
+    paths = collect_paths()
+    assert paths, f"no checkpoint paths found in {CONFIG_DIR}/global_*.yaml"
+
+    # One listing per repo is far cheaper than an existence check per path.
+    repo_files = {
+        repo_id: set(list_repo_files(repo_id=repo_id, repo_type="dataset"))
+        for repo_id in sorted({r for repos in DIR_TO_REPOS.values() for r in repos})
+    }
+
+    missing = []
+    for path, config_files in sorted(paths.items()):
+        local_dir, _, remote_path = path.partition("/")
+        repo_ids = DIR_TO_REPOS.get(local_dir)
+        sources = ", ".join(sorted(config_files))
+
+        if repo_ids is None:
+            missing.append(
+                f"{path} ({sources}): unknown top-level directory {local_dir!r}"
+            )
+            continue
+
+        prefix = remote_path.rstrip("/")
+        found = any(
+            f == prefix or f.startswith(f"{prefix}/")
+            for repo_id in repo_ids
+            for f in repo_files[repo_id]
+        )
+        if not found:
+            missing.append(f"{path} ({sources}): not found in {' or '.join(repo_ids)}")
+
+    assert not missing, "\n".join(
+        [f"{len(missing)} of {len(paths)} configured paths are missing:", *missing]
+    )


### PR DESCRIPTION
The heldout and validation configs point at checkpoints in our Hugging Face dataset repos, and nothing notices when a config path and the uploaded data drift apart. This adds an opt-in test that lists each dataset repo once and checks every configured `path`/`weight_file` against it, plus a workflow that runs it Mondays at 12:00 UTC.

It is deliberately not part of PR CI: the failure mode is a stale config or a renamed dataset file, which can happen without anyone touching the repo, and coupling every PR to Hugging Face availability would block unrelated work. Currently 59 paths from `global_heldout_settings.yaml`, all of which resolve; it picks up `best_response_set` blocks and any new `global_*.yaml` automatically.