### PR TITLE
Add hanabi mini br configs

### DIFF
--- a/agents/initialize_agents.py
+++ b/agents/initialize_agents.py
@@ -8,6 +8,11 @@ from agents.s5_actor_critic_agent import S5ActorCriticPolicy, S5ActorWithDoubleC
 from agents.liam_agent import LIAMPolicy, initialize_liam_encoder_decoder
 from agents.meliba_agent import MeLIBAPolicy, initialize_meliba_encoder_decoder
 
+def _env_obs_dim(env):
+    # Hanabi/mini-hanabi expose observation_space().shape as an int, not a tuple.
+    shape = env.observation_space(env.agents[0]).shape
+    return shape[0] if isinstance(shape, (tuple, list)) else shape
+
 def initialize_s5_agent(config, env, rng, obs_dim_override=None):
     """Initialize an S5 agent with the given config.
 
@@ -25,7 +30,7 @@ def initialize_s5_agent(config, env, rng, obs_dim_override=None):
     policy = S5ActorCriticPolicy(
         action_dim=env.action_space(env.agents[0]).n,
         obs_dim=obs_dim_override if obs_dim_override is not None
-            else config.get("POLICY_INPUT_DIM", env.observation_space(env.agents[0]).shape[0]),
+            else config.get("POLICY_INPUT_DIM", _env_obs_dim(env)),
         d_model=config.get("S5_D_MODEL", 128),
         ssm_size=config.get("S5_SSM_SIZE", 128),
         # d_model=config.get("S5_D_MODEL", 16),
@@ -62,7 +67,7 @@ def initialize_rnn_agent(config, env, rng):
     # Create the RNN policy
     policy = RNNActorCriticPolicy(
         action_dim=env.action_space(env.agents[0]).n,
-        obs_dim=config.get("POLICY_INPUT_DIM", env.observation_space(env.agents[0]).shape[0]),
+        obs_dim=config.get("POLICY_INPUT_DIM", _env_obs_dim(env)),
         activation=config.get("ACTIVATION", "tanh"),
         fc_hidden_dim=config.get("FC_HIDDEN_DIM", 64),
         gru_hidden_dim=config.get("GRU_HIDDEN_DIM", 64),
@@ -80,7 +85,7 @@ def initialize_mlp_agent(config, env, rng, obs_dim_override=None):
     policy = MLPActorCriticPolicy(
         action_dim=env.action_space(env.agents[0]).n,
         obs_dim=obs_dim_override if obs_dim_override is not None
-            else config.get("POLICY_INPUT_DIM", env.observation_space(env.agents[0]).shape[0]),
+            else config.get("POLICY_INPUT_DIM", _env_obs_dim(env)),
         activation=config.get("ACTIVATION", "tanh"),
         fc_hidden_dim=config.get("FC_HIDDEN_DIM", 64),
     )
@@ -94,7 +99,7 @@ def initialize_actor_with_double_critic(config, env, rng, obs_dim_override=None)
     policy = ActorWithDoubleCriticPolicy(
         action_dim=env.action_space(env.agents[0]).n,
         obs_dim=obs_dim_override if obs_dim_override is not None
-            else config.get("POLICY_INPUT_DIM", env.observation_space(env.agents[0]).shape[0]),
+            else config.get("POLICY_INPUT_DIM", _env_obs_dim(env)),
         activation=config.get("ACTIVATION", "tanh"),
         fc_hidden_dim=config.get("FC_HIDDEN_DIM", 64),
     )
@@ -108,7 +113,7 @@ def initialize_s5_actor_with_double_critic(config, env, rng, obs_dim_override=No
     policy = S5ActorWithDoubleCriticPolicy(
         action_dim=env.action_space(env.agents[0]).n,
         obs_dim=obs_dim_override if obs_dim_override is not None
-            else config.get("POLICY_INPUT_DIM", env.observation_space(env.agents[0]).shape[0]),
+            else config.get("POLICY_INPUT_DIM", _env_obs_dim(env)),
         d_model=config.get("S5_D_MODEL", 128),
         ssm_size=config.get("S5_SSM_SIZE", 128),
         ssm_n_layers=config.get("S5_N_LAYERS", 2),
@@ -129,7 +134,7 @@ def initialize_pseudo_actor_with_double_critic(config, env, rng):
     """Initialize a pseudo actor with double critic with the given config."""
     policy = PseudoActorWithDoubleCriticPolicy(
         action_dim=env.action_space(env.agents[0]).n,
-        obs_dim=config.get("POLICY_INPUT_DIM", env.observation_space(env.agents[0]).shape[0]),
+        obs_dim=config.get("POLICY_INPUT_DIM", _env_obs_dim(env)),
         activation=config.get("ACTIVATION", "tanh"),
         fc_hidden_dim=config.get("FC_HIDDEN_DIM", 64),
     )
@@ -142,7 +147,7 @@ def initialize_actor_with_conditional_critic(config, env, rng):
     """Initialize an actor with conditional critic with the given config."""
     policy = ActorWithConditionalCriticPolicy(
         action_dim=env.action_space(env.agents[0]).n,
-        obs_dim=config.get("POLICY_INPUT_DIM", env.observation_space(env.agents[0]).shape[0]),
+        obs_dim=config.get("POLICY_INPUT_DIM", _env_obs_dim(env)),
         pop_size=config["POP_SIZE"],
         activation=config.get("ACTIVATION", "tanh"),
         fc_hidden_dim=config.get("FC_HIDDEN_DIM", 64),
@@ -156,7 +161,7 @@ def initialize_pseudo_actor_with_conditional_critic(config, env, rng):
     """Initialize a pseudo actor with conditional critic with the given config."""
     policy = PseudoActorWithConditionalCriticPolicy(
         action_dim=env.action_space(env.agents[0]).n,
-        obs_dim=config.get("POLICY_INPUT_DIM", env.observation_space(env.agents[0]).shape[0]),
+        obs_dim=config.get("POLICY_INPUT_DIM", _env_obs_dim(env)),
         pop_size=config["POP_SIZE"],
         activation=config.get("ACTIVATION", "tanh"),
         fc_hidden_dim=config.get("FC_HIDDEN_DIM", 64),

--- a/evaluation/configs/global_heldout_br.yaml
+++ b/evaluation/configs/global_heldout_br.yaml
@@ -788,3 +788,355 @@ best_response_set:
       ckpt_key: final_params
       idx_list: [0]
       test_mode: true
+
+  hanabi:
+    br_for_iggi:
+      path: "eval_teammates/full_hanabi/iggi/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_piers:
+      path: "eval_teammates/full_hanabi/piers/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_flawed:
+      path: "eval_teammates/full_hanabi/flawed/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_outer:
+      path: "eval_teammates/full_hanabi/outer/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_van_den_bergh:
+      path: "eval_teammates/full_hanabi/van_den_bergh/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_smartbot:
+      path: "eval_teammates/full_hanabi/smartbot/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_cautious:
+      path: "eval_teammates/full_hanabi/cautious/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_internal:
+      path: "eval_teammates/full_hanabi/internal/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_obl_r2d2_l1:
+      path: "eval_teammates/full_hanabi/obl_r2d2_l1/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_obl_r2d2_l4:
+      path: "eval_teammates/full_hanabi/obl_r2d2_l4/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_bc_lstm_human_proxy:
+      path: "eval_teammates/full_hanabi/bc_lstm_human_proxy/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_bc_lstm_v2:
+      path: "eval_teammates/full_hanabi/br_for_bc_lstm_v2/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_seed0:
+      path: "eval_teammates/full_hanabi/ippo_mlp_seed0/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_seed1:
+      path: "eval_teammates/full_hanabi/ippo_mlp_seed1/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_seed2:
+      path: "eval_teammates/full_hanabi/ippo_mlp_seed2/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_seed42:
+      path: "eval_teammates/full_hanabi/ippo_s5_seed42/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_seed123:
+      path: "eval_teammates/full_hanabi/ippo_s5_seed123/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_seed31415:
+      path: "eval_teammates/full_hanabi/ippo_s5_seed31415/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_op_seed42:
+      path: "eval_teammates/full_hanabi/ippo_s5_op_seed42/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_op_seed123:
+      path: "eval_teammates/full_hanabi/ippo_s5_op_seed123/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_op_seed31415:
+      path: "eval_teammates/full_hanabi/ippo_s5_op_seed31415/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_seed99999:
+      path: "eval_teammates/full_hanabi/ippo_s5_seed99999/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+  mini-hanabi:
+    br_for_ippo_mlp_seed0:
+      path: "eval_teammates/mini_hanabi/ippo_mlp_seed0/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_seed1:
+      path: "eval_teammates/mini_hanabi/ippo_mlp_seed1/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_iggi:
+      path: "eval_teammates/mini_hanabi/iggi/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_piers:
+      path: "eval_teammates/mini_hanabi/piers/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_flawed:
+      path: "eval_teammates/mini_hanabi/flawed/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_outer:
+      path: "eval_teammates/mini_hanabi/outer/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_van_den_bergh:
+      path: "eval_teammates/mini_hanabi/van_den_bergh/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_smartbot:
+      path: "eval_teammates/mini_hanabi/smartbot/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_cautious:
+      path: "eval_teammates/mini_hanabi/cautious/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_internal:
+      path: "eval_teammates/mini_hanabi/internal/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_mlp_seed2:
+      path: "eval_teammates/mini_hanabi/ippo_mlp_seed2/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf_0:
+      path: "eval_teammates/mini_hanabi/brdiv_conf_0/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf_1:
+      path: "eval_teammates/mini_hanabi/brdiv_conf_1/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_brdiv_conf_2:
+      path: "eval_teammates/mini_hanabi/brdiv_conf_2/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_0:
+      path: "eval_teammates/mini_hanabi/lbrdiv_conf_0/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_1:
+      path: "eval_teammates/mini_hanabi/lbrdiv_conf_1/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_lbrdiv_conf_2:
+      path: "eval_teammates/mini_hanabi/lbrdiv_conf_2/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_conf_0:
+      path: "eval_teammates/mini_hanabi/comedi_conf_0/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_conf_1:
+      path: "eval_teammates/mini_hanabi/comedi_conf_1/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_conf_2:
+      path: "eval_teammates/mini_hanabi/comedi_conf_2/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_conf_3:
+      path: "eval_teammates/mini_hanabi/comedi_conf_3/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_comedi_conf_4:
+      path: "eval_teammates/mini_hanabi/comedi_conf_4/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_seed42:
+      path: "eval_teammates/mini_hanabi/ippo_s5_seed42/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_seed123:
+      path: "eval_teammates/mini_hanabi/ippo_s5_seed123/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_seed31415:
+      path: "eval_teammates/mini_hanabi/ippo_s5_seed31415/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_op_seed42:
+      path: "eval_teammates/mini_hanabi/ippo_s5_op_seed42/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_op_seed123:
+      path: "eval_teammates/mini_hanabi/ippo_s5_op_seed123/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true
+
+    br_for_ippo_s5_op_seed31415:
+      path: "eval_teammates/mini_hanabi/ippo_s5_op_seed31415/saved_train_run"
+      actor_type: s5
+      ckpt_key: final_params
+      idx_list: [0]
+      test_mode: true


### PR DESCRIPTION
Adds the missing best_response_set blocks for hanabi (22) and mini-hanabi (28)
to global_heldout_br.yaml. 
Also fixes S5/MLP agent initialization for hanabi/mini-hanabi (because .shape[0] in initialize_agents.py raised IndexError for every hanabi/mini agent)